### PR TITLE
Back out Lets Encrypt stuffz

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem 'js-routes'
 gem "omniauth-google-oauth2", "~> 0.2.1"
 gem 'rack-attack', '~> 5.0.1'
 gem 'rack-test', '~> 0.6.3', require: 'rack/test'
-gem 'platform-api', git: 'https://github.com/jalada/platform-api', branch: 'master'
 gem 'clinic_finder', '~> 0.0.1'
 gem 'geokit'
 
@@ -74,5 +73,4 @@ end
 group :production do
   gem 'puma'
   gem 'rails_12factor'
-  gem 'letsencrypt-rails-heroku'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,6 @@
-GIT
-  remote: https://github.com/jalada/platform-api
-  revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
-  branch: master
-  specs:
-    platform-api (0.8.0)
-      heroics (~> 0.0.17)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    acme-client (0.4.1)
-      faraday (~> 0.9, >= 0.9.1)
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
       actionview (= 4.2.7.1)
@@ -127,7 +117,6 @@ GEM
     easy_diff (1.0.0)
     equalizer (0.0.11)
     erubis (2.7.0)
-    excon (0.54.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -158,12 +147,6 @@ GEM
       multi_json
       request_store (>= 1.0)
     hashie (3.4.6)
-    heroics (0.0.17)
-      erubis (~> 2.0)
-      excon
-      moneta
-      multi_json (>= 1.9.2)
-      netrc
     i18n (0.7.0)
     ice_nine (0.11.2)
     jbuilder (2.5.0)
@@ -182,9 +165,6 @@ GEM
     jwt (1.5.6)
     launchy (2.4.3)
       addressable (~> 2.3)
-    letsencrypt-rails-heroku (0.3.0)
-      acme-client (~> 0.4.0)
-      platform-api
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -208,7 +188,6 @@ GEM
     minitest-spec-rails (5.4.0)
       minitest (~> 5.0)
       rails (>= 4.1)
-    moneta (0.8.1)
     mongo (2.2.5)
       bson (~> 4.0)
     mongo_session_store-rails4 (6.0.0)
@@ -233,7 +212,6 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    netrc (0.11.0)
     newrelic_rpm (3.15.2.317)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -447,7 +425,6 @@ DEPENDENCIES
   jquery-ui-rails
   js-routes
   launchy
-  letsencrypt-rails-heroku
   mini_backtrace
   minitest-ci
   minitest-reporters
@@ -460,7 +437,6 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri (>= 1.6.8)
   omniauth-google-oauth2 (~> 0.2.1)
-  platform-api!
   poltergeist
   pry
   puma

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,9 +41,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Do this before forcing SSL, see https://github.com/pixielabs/letsencrypt-rails-heroku/blob/master/README.md#installation for more info
-  config.middleware.insert_before ActionDispatch::SSL, Letsencrypt::Middleware
-
   # Do this AFTER the world hasn't imploded (see previous line)
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
@@ -84,7 +81,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
-
-  # Use Let's Encrypt for SSL
-  config.middleware.use Letsencrypt::Middleware
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Do this AFTER the world hasn't imploded (see previous line)
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This allows for moving to just using Heroku's SSL stuff now that it is released

This pull request makes the following changes:
* Removes platform api dependency
* Removes letsencrypt middleware (not needed)

It relates to the following issue #s: 
* Fixes #957 
