### PR TITLE
Removed 12factor, no longer needed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,5 @@ end
 
 group :production do
   gem 'puma'
-  gem 'rails_12factor'
   gem 'letsencrypt-rails-heroku'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,9 +324,6 @@ GEM
       nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_best_practices (1.18.0)
       activesupport
       code_analyzer (>= 0.4.3)
@@ -335,8 +332,6 @@ GEM
       json
       require_all
       ruby-progressbar
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.2)
       actionpack (= 5.0.2)
       activesupport (= 5.0.2)
@@ -478,7 +473,6 @@ DEPENDENCIES
   rack-attack (~> 5.0.1)
   rack-test (~> 0.6.3)
   rails (>= 5.0.0, < 5.1)
-  rails_12factor
   rubocop
   ruby_audit
   sass-rails (~> 5.0)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Removes 12factor, no longer needed in Rails 5.

This pull request makes the following changes:
* Removes 12 factor gem

Testing for this needs to mainly be on Heroku, since it relies on ENV variables that Heroku provides. Code changes are minimal. 12 Monkeys is a good Terry Gilliam movie.

It relates to the following issue #s: 
* Fixes #988 
