### PR TITLE
Links Issue #1001

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ group :development do
   gem 'ruby_audit', require: false
   gem 'bundler-audit', require: false
   gem 'quality', '20.1.0', require: false
+  gem 'derailed_benchmarks'
+  gem 'stackprof'
   # gem 'dawnscanner', require: false # disable until dawnscanner fixes CD prob
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
+    benchmark-ips (2.7.2)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -141,6 +142,14 @@ GEM
     concurrent-ruby (1.0.5)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
+    derailed_benchmarks (1.3.2)
+      benchmark-ips (~> 2)
+      get_process_mem (~> 0)
+      heapy (~> 0)
+      memory_profiler (~> 0)
+      rack (>= 1)
+      rake (> 10, < 13)
+      thor (~> 0.19)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.2.1)
@@ -176,6 +185,7 @@ GEM
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
     geokit (1.11.0)
+    get_process_mem (0.2.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     gon (6.1.0)
@@ -184,6 +194,7 @@ GEM
       multi_json
       request_store (>= 1.0)
     hashie (3.5.5)
+    heapy (0.1.2)
     heroics (0.0.21)
       erubis (~> 2.0)
       excon
@@ -213,6 +224,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    memory_profiler (0.9.8)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -395,6 +407,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.10)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -446,6 +459,7 @@ DEPENDENCIES
   codecov
   coffee-rails (~> 4.1.0)
   database_cleaner
+  derailed_benchmarks
   devise (~> 4.2.1)
   factory_girl_rails
   faker
@@ -486,6 +500,7 @@ DEPENDENCIES
   shoulda-context
   simplecov
   spring
+  stackprof
   timecop
   turbolinks (= 2.5.3)
   tzinfo-data

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,6 +10,7 @@
 @charset "utf-8";
 
 $dcaf-color: #5D3E8D;
+$grey-color: #828282;
 $font-size: 17px;
 
 /* NAVBAR */
@@ -34,6 +35,12 @@ $font-size: 17px;
     line-height:20px;
   }
 
+  .navbar-text-alt{
+    color: $grey-color;
+    padding:15px;
+    margin:0px;
+    line-height:20px;
+  }
 }
 
 

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -1,23 +1,38 @@
-<% if session[:line] %>
-  <ul class="nav navbar-nav navbar-left">
-    <li class="navbar-text"><%= current_line_display %></li>
-    <% if ENV['CM_RESOURCES_URL'] %>
-      <li><%= link_to 'CM Resources', ENV['CM_RESOURCES_URL'], target: '_blank' %></li>
-    <% end %>
-  </ul>
-<% end %>
+<ul class="nav navbar-nav navbar-left">
+  <% if current_user && session[:line] %>
+    <li class="navbar-text-alt"><%= current_line_display %></li>
+  <% end %>
+</ul>    
 
 <ul class="nav navbar-nav navbar-right">
   <% if !user_signed_in? %>
     <li><%= link_to 'Sign in', new_user_session_path %></li>
   <% else %>
-    <% unless current_page?(authenticated_root_url) %>
-      <li><%= link_to 'Dashboard', authenticated_root_path %></li>
+    <li><%= link_to 'Reports', '#' %></li>
+    <% if ENV['CM_RESOURCES_URL'] %>
+      <li><%= link_to 'CM Resources', ENV['CM_RESOURCES_URL'], target: '_blank' %></li>
     <% end %>
     <% if current_user.admin? %>
-      <li> <%= link_to 'Create User', new_user_path %></li>
+      <li class="dropdown">
+        <a href="#" data-toggle="dropdown" class="dropdown-toggle">Admin<b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><%= link_to 'User Management', new_user_path %></li>
+          <li><%= link_to 'Clinic Management', '#' %></li>
+          <li><%= link_to 'Accounting', '#' %></li>
+          <li><%= link_to 'Reporting', '#' %></li>
+        </ul>
+      </li>
     <% end %>
-    <li><%= link_to current_user.name, edit_user_registration_path %></li>
-    <li><%= link_to 'Sign out', destroy_user_session_path, method: 'delete' %></li>
+
+    <li class="dropdown">
+    <a href="#" data-toggle="dropdown" class="dropdown-toggle"><%= current_user.name %><b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><%= link_to 'My Profile', edit_user_registration_path %></li>
+        <li><%= link_to 'Sign out', destroy_user_session_path, method: 'delete' %></li>
+      </ul>
+    </li>
   <% end %>
 </ul>
+
+
+


### PR DESCRIPTION
This pull request makes the following changes:

* Follows the mockup in #1001 
* Removes Dashboard link. The brand link Daria was already linking to the dashboard (root), so that was not changed.
* Call line text changed to grey.
* 4 menu items at the top level (CM Resources and Admin only appear if conditions are fulfilled)
* Admin and Username links become dropdowns. User Management, My Profile and Sign Out have active links, the rest have placeholder links.
*"Create User" becomes "User Management."

![navlinks](https://cloud.githubusercontent.com/assets/7366046/25604771/305a3554-2ed4-11e7-96ca-0f45b60f4b8c.png)

Big question: Do you want the tests that depend on the old navlinks rewritten at this time?



