### PR TITLE
Enable enhanced CSRF protections provided by Rails 5

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -7,10 +7,10 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+Rails.application.config.action_controller.forgery_protection_origin_check = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This makes the configuration changes described in #989.
The basic manual functional tests described in the #989 continue to work fine, and all automated tests pass except a few Capybara ones which I think are related to #903. 

This pull request makes the following changes:
* Enable `per_form_csrf_tokens`
* Enable `forgery_protection_origin_check`

It relates to the following issue #s: 
* Implements #989 
