### PR TITLE
Email is no longer an edited field; added link to new_user_password_path

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,20 +5,15 @@
     <%= devise_error_messages! %>
 
     <h3>Change your account details</h3>
-    <%= f.email_field :email, autofocus: true %>
+    <p>Email</p>
+    <p><%= current_user.email %></p>
     <%= f.text_field :name, label: 'First and last name' %>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
-    <h3>Change your password</h3>
-    <%= f.password_field :password, autocomplete: 'off' %>
-    <%= f.password_field :password_confirmation, autocomplete: 'off' %>
-
-    <h3>Enter your current password to save any changes</h3>
-    <%= f.password_field :current_password, autocomplete: 'off' %>
-    <%= f.submit "Update info", class: 'btn btn-primary' %>
+      <%= link_to "Forgot your password?", new_user_password_path %>
   <% end %>
   <br>
 


### PR DESCRIPTION
I've updated the user edit page to make the following changes: 

Email is no longer an editable field
Removed 'enter password to confirm'
Included link to `new_user_password_path'

It relates to the following issue #s: 
[Issue #951](https://github.com/DCAFEngineering/dcaf_case_management/issues/951)

