### PR TITLE
Fixes issue #1053 remove zip code field

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -61,7 +61,6 @@ class Patient
   field :age, type: Integer
   field :city, type: String
   field :state, type: String
-  field :zip, type: String
   field :county, type: String
   field :race_ethnicity, type: String
   field :employment_status, type: String

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -41,8 +41,6 @@
 
           <%= f.text_field :county, label: 'County', autocomplete: 'off' %>
 
-          <%= f.text_field :zip, label: 'ZIP', autocomplete: 'off' %>
-
           <h3>Other Contact</h3>
             <%= f.text_field :other_contact, autocomplete: 'off', label: 'Other contact name' %>
             <%= f.text_field :other_phone, value: patient.other_phone_display, autocomplete: 'off', label: 'Other phone' %>

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -110,7 +110,6 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       fill_in 'City', with: 'Washington'
       fill_in 'State', with: 'DC'
       fill_in 'County', with: 'Wash'
-      fill_in 'ZIP', with: '90210'
       select 'Voicemail OK', from: 'patient_voicemail_preference'
       check 'Spanish Only'
 
@@ -140,7 +139,6 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert has_field? 'City', with: 'Washington'
         assert has_field? 'State', with: 'DC'
         assert has_field? 'County', with: 'Wash'
-        assert has_field? 'ZIP', with: '90210'
         assert_equal 'yes', find('#patient_voicemail_preference').value
         assert has_checked_field? 'Spanish Only'
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fixes issue #1053 remove zip code field

This pull request makes the following changes:
* Remove the field from the model in `app/models/patient.rb!`

It relates to the following issue #s: 
* Fixes #1053

