### PR TITLE
Update nokogiri to 1.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
     multipart-post (2.0.0)
     newrelic_rpm (4.0.0.332)
     nio4r (2.0.0)
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     oauth2 (1.3.1)
       faraday (>= 0.8, < 0.12)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

An upstream lib of nokogiri has a vulnerability, and they've patched to fix it as a part of 1.7.2
https://github.com/sparklemotion/nokogiri/issues/1634

This pull request makes the following changes:
* Bundle update nokogiri (puts us at 1.7.2)
