### PR TITLE
change patients fulfillment partial to not autocomplete any forms

### DIFF
--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -16,7 +16,7 @@
         <div class="col-sm-12">
           <%= f.fields_for patient.fulfillment do |pt| %>
             <%= pt.form_group :fulfilled do %>
-              <%= pt.check_box :fulfilled, label: 'Pledge fulfilled' %>
+              <%= pt.check_box :fulfilled, label: 'Pledge fulfilled', autocomplete: 'off' %>
             <% end %>
           <% end %>
         </div>  
@@ -36,7 +36,7 @@
         <div class="info-form-right col-sm-6">
           <%= f.fields_for patient.fulfillment do |pt| %>
             <%= pt.text_field :check_number, label: 'Check #', autocomplete: 'off'%>
-            <%= pt.date_field :date_of_check, label: 'Date of check' %>
+            <%= pt.date_field :date_of_check, label: 'Date of check', autocomplete: 'off' %>
           <% end %>
         </div>  
       </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Change form fields in patients/_fulfillment partial to not autocomplete

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #838
