### PR TITLE
Enable setting user role on account creation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email)
+    params.require(:user).permit(:name, :email, :_role)
   end
 
   def retrieve_patients

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,9 @@
+module UsersHelper
+  def user_role_options
+    [
+      ['Case manager', 'cm'],
+      ['Data volunteer', 'data_volunteer'],
+      ['Admin', 'admin']
+    ]
+  end
+end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,6 +3,7 @@
     <%= bootstrap_form_for @user do |f| %>
         <%= f.email_field :email %>
         <%= f.text_field :name %>
+        <%= f.select :_role, options_for_select(user_role_options) %>
         <%= f.submit "Add", class: 'btn btn-primary' %>
       </div>
     <% end %>

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UsersHelperTest < ActionView::TestCase
+  describe 'user role options' do
+    it 'should return a span tag' do
+      assert user_role_options.is_a? Array
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Long overdue, this adds the ability to set another user as an admin.

This pull request makes the following changes:
* Allows an admin to set another user's role on create

Nice and simple:

![screen shot 2017-05-20 at 1 44 52 am](https://cloud.githubusercontent.com/assets/3866868/26273417/f473f8da-3cfd-11e7-99d0-038cdb326fba.png)

No issue.

@lomky and/or @DarthHater would appreciate a review, since this has a security implication!
