### PR TITLE
Add Link to export, add data entry admin tools

### DIFF
--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -13,14 +13,17 @@
   <% if !user_signed_in? %>
     <li><%= link_to 'Sign in', new_user_session_path %></li>
   <% else %>
-    <% if current_user.admin? %>
+    <% if current_user.admin? || current_user.data_volunteer? %>
       <li class="dropdown">
-        <a href="#" data-toggle="dropdown" class="dropdown-toggle">Admin<b class="caret"></b></a>
+        <a href="#" data-toggle="dropdown" class="dropdown-toggle">Admin tools<b class="caret"></b></a>
         <ul class="dropdown-menu">
-          <li><%= link_to 'User Management', new_user_path %></li>
-          <li><%= link_to 'Clinic Management', clinics_path %></li>
+          <% if current_user.admin? %>
+            <li><%= link_to 'User Management', new_user_path %></li>
+            <li><%= link_to 'Clinic Management', clinics_path %></li>
+          <% end %>
           <li><%= link_to 'Accounting', accountants_path %></li>
           <li><%= link_to 'Reporting', reports_path %></li>
+          <li><%= link_to 'Export anonymized CSV', patients_path(format: :csv) %></li>
         </ul>
       </li>
     <% end %>

--- a/test/integration/navbar_links_test.rb
+++ b/test/integration/navbar_links_test.rb
@@ -28,7 +28,7 @@ class NavbarLinksTest < ActionDispatch::IntegrationTest
   end
 
   describe 'admin dropdown' do
-    describe 'admin view'
+    describe 'admin view' do
       before { click_link 'Admin' }
 
       it 'should display the new user link' do
@@ -54,9 +54,11 @@ class NavbarLinksTest < ActionDispatch::IntegrationTest
 
     describe 'data volunteer view' do
       before do
+        sign_out
         @user2 = create :user, role: :data_volunteer
+        log_in_as @user2
         visit authenticated_root_path
-        click_link 'Admin'
+        click_link 'Admin tools'
       end
 
       it 'should not display the new user link' do
@@ -82,17 +84,15 @@ class NavbarLinksTest < ActionDispatch::IntegrationTest
 
     describe 'case manager view' do
       before do
-        @user2 = create :user, role: :cm
+        sign_out
+        @user3 = create :user, role: :cm
+        log_in_as @user3
         visit authenticated_root_path
       end
 
       it 'should not display an admin link' do
-        refute has_link? 'Admin'
+        refute has_link? 'Admin tools'
       end
     end
-  end
-
-  describe 'data volunteer dropdown' do
-    before { @user.update role: :data_volunteer }
   end
 end

--- a/test/integration/navbar_links_test.rb
+++ b/test/integration/navbar_links_test.rb
@@ -28,21 +28,71 @@ class NavbarLinksTest < ActionDispatch::IntegrationTest
   end
 
   describe 'admin dropdown' do
-    before { click_link 'Admin' }
-    it 'should display the Clinic Management link' do
-      assert has_link? 'Clinic Management', href: clinics_path
+    describe 'admin view'
+      before { click_link 'Admin' }
+
+      it 'should display the new user link' do
+        assert has_link? 'User Management', href: new_user_path
+      end
+
+      it 'should display the Clinic Management link' do
+        assert has_link? 'Clinic Management', href: clinics_path
+      end
+
+      it 'should display the Accounting link' do
+        assert has_link? 'Accounting', href: accountants_path
+      end
+
+      it 'should display the Reporting link' do
+        assert has_link? 'Reporting', href: reports_path
+      end
+
+      it 'should display the export link' do
+        assert has_link? 'Export anonymized CSV', href: patients_path(format: :csv)
+      end
     end
 
-    it 'should display the Accounting link' do
-      assert has_link? 'Accounting', href: accountants_path
+    describe 'data volunteer view' do
+      before do
+        @user2 = create :user, role: :data_volunteer
+        visit authenticated_root_path
+        click_link 'Admin'
+      end
+
+      it 'should not display the new user link' do
+        refute has_link? 'User Management'
+      end
+
+      it 'should not display the Clinic Management link' do
+        refute has_link? 'Clinic Management'
+      end
+
+      it 'should display the Accounting link' do
+        assert has_link? 'Accounting', href: accountants_path
+      end
+
+      it 'should display the Reporting link' do
+        assert has_link? 'Reporting', href: reports_path
+      end
+
+      it 'should display the export link' do
+        assert has_link? 'Export anonymized CSV', href: patients_path(format: :csv)
+      end
     end
 
-    it 'should display the Reporting link' do
-      assert has_link? 'Reporting', href: reports_path
-    end
+    describe 'case manager view' do
+      before do
+        @user2 = create :user, role: :cm
+        visit authenticated_root_path
+      end
 
-    it 'should display the export link' do
-      assert has_link? 'Export anonymized CSV', href: patients_path(format: :csv)
+      it 'should not display an admin link' do
+        refute has_link? 'Admin'
+      end
     end
+  end
+
+  describe 'data volunteer dropdown' do
+    before { @user.update role: :data_volunteer }
   end
 end

--- a/test/integration/navbar_links_test.rb
+++ b/test/integration/navbar_links_test.rb
@@ -19,26 +19,30 @@ class NavbarLinksTest < ActionDispatch::IntegrationTest
       refute has_link? 'CM Resources'
     end
   end
-  
+
   describe 'user dropdown' do
     before { click_link @user.name }
     it 'should display the profile link' do
-      assert has_link? 'My Profile', edit_user_registration_path
+      assert has_link? 'My Profile', href: edit_user_registration_path
     end
   end
-  
+
   describe 'admin dropdown' do
     before { click_link 'Admin' }
     it 'should display the Clinic Management link' do
-      assert has_link? 'Clinic Management', clinics_path
+      assert has_link? 'Clinic Management', href: clinics_path
     end
-    
+
     it 'should display the Accounting link' do
-      assert has_link? 'Accounting', accountants_path
+      assert has_link? 'Accounting', href: accountants_path
     end
-    
+
     it 'should display the Reporting link' do
-      assert has_link? 'Reporting', reports_path
+      assert has_link? 'Reporting', href: reports_path
+    end
+
+    it 'should display the export link' do
+      assert has_link? 'Export anonymized CSV', href: patients_path(format: :csv)
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Adds a link to the patient CSV exoprt
* Splits the admin dropdown into two blocks, `admin` and `data_volunteer`, and gives data volunteers access to reports/accounting/csv export
* adds some integration tests

It relates to the following issue #s: 
* Bumps #965 
