### PR TITLE
Correct line handler in patients to take a correct env var

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -50,7 +50,7 @@ class Patient
 
   # Contact-related info
   enum :voicemail_preference, [:not_specified, :no, :yes]
-  enum :line, [:DC, :MD, :VA] # See config/initializers/lines.rb. TODO: Env var.
+  enum :line, LINES # See config/initializers/env_vars.rb
   field :spanish, type: Boolean
   field :initial_call_date, type: Date
   field :urgent_flag, type: Boolean

--- a/config/initializers/env_var_constants.rb
+++ b/config/initializers/env_var_constants.rb
@@ -1,6 +1,6 @@
 # Definition of line constants
-LINES = if ENV['LINES'].present?
-          ENV['LINES'].split(',')
+LINES = if ENV['DARIA_LINES'].present?
+          ENV['DARIA_LINES'].split(',')
                       .map(&:strip)
                       .map(&:to_sym)
                       .freeze


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

It turns out that `LINES` is a reserved env var in heroku, so this moves the line setter to `DARIA_LINES`, which is thankfully NOT a reserved env var.

Requires a heroku env var change after merge.

This pull request makes the following changes:
* Changes `LINES` variable to draw from the env var `DARIA_LINES`
* Alters patient model to use `LINES` instead of hardset option

Bumps #999 