### PR TITLE
Abstract DCAF out of the mailers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "no-reply@#{ENV['FUND_DOMAIN']}.org"
+  default from: "no-reply@#{FUND_DOMAIN}.org"
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@dcaf.org'
+  default from: "no-reply@#{ENV['FUND_DOMAIN']}.org"
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,6 @@
 # app/mailers/user_mailer.rb
 class UserMailer < Devise::Mailer
-  default from: "no-reply@#{ENV['FUND_DOMAIN']}.org"
+  default from: "no-reply@#{FUND_DOMAIN}.org"
 
   def password_changed(id)
     @user = User.find(id)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,14 +1,14 @@
 # app/mailers/user_mailer.rb
 class UserMailer < Devise::Mailer
-  default from: 'no-reply@dcabortionfund.org'
+  default from: "no-reply@#{ENV['FUND_DOMAIN']}.org"
 
   def password_changed(id)
     @user = User.find(id)
-    mail to: @user.email, subject: 'Your password has changed'
+    mail to: @user.email, subject: 'Your DARIA password has changed'
   end
 
   def account_created(id)
     @user = User.find(id)
-    mail to: @user.email, subject: 'Your DCAF account has been created'
+    mail to: @user.email, subject: 'Your DARIA account has been created'
   end
 end

--- a/app/views/user_mailer/account_created.html.erb
+++ b/app/views/user_mailer/account_created.html.erb
@@ -1,6 +1,6 @@
 <p>Hi <%= @user.name %> --</p>
-<p>A CMAPP account has been created for you!</p>
+<p>A DARIA account has been created for you!</p>
 <p>Please start by heading to the system and resetting your password.</p>
 <p>Email the CM Directors if you experience any difficulties.</p>
 <p>Thanks for your service!</p>
-<p>- Team DCAF</p>
+<p>- Team <%= FUND %></p>

--- a/app/views/user_mailer/account_created.text.erb
+++ b/app/views/user_mailer/account_created.text.erb
@@ -1,4 +1,4 @@
-Hi <%= @user.name %> -- A CMAPP account has been created for you!
+Hi <%= @user.name %> -- A DARIA account has been created for you!
 
 Please unlock it by heading to the system and resetting your password.
 
@@ -6,4 +6,4 @@ Email the CM Directors if you experience any difficulties.
 
 Thanks for your service!
 
-- Team DCAF
+- Team <%= FUND %>

--- a/app/views/user_mailer/password_changed.html.erb
+++ b/app/views/user_mailer/password_changed.html.erb
@@ -1,5 +1,5 @@
 <p>Hi <%= @user.name %> (<%= @user.email %>),</p>
-<p>We wanted to let you know that your password was changed. If you changed it, you can ignore this email.</p>
+<p>We wanted to let you know that your DARIA password was changed. If you changed it, you can ignore this email.</p>
 <p>If you did not make this change, please let the CM Directors know immediately!</p>
 <p>Thanks for your hustlin'!</p>
-<p>- Team DCAF</p>
+<p>- Team <%= FUND %></p>

--- a/app/views/user_mailer/password_changed.text.erb
+++ b/app/views/user_mailer/password_changed.text.erb
@@ -1,9 +1,9 @@
 Hi <%= @user.name %> (<%= @user.email %>),
 
-We wanted to let you know that your password was changed. If you changed it, you can ignore this email.
+We wanted to let you know that your DARIA password was changed. If you changed it, you can ignore this email.
 
 If you did not change it, please let the CM Directors know immediately!
 
 Thanks for your hustlin'!
 
-- Team DCAF
+- Team <%= FUND %>

--- a/config/initializers/env_var_constants.rb
+++ b/config/initializers/env_var_constants.rb
@@ -10,4 +10,5 @@ LINES = if ENV['DARIA_LINES'].present?
 
 # Definition of fund
 FUND_FULL = ENV['DARIA_FUND_FULL'] || 'DC Abortion Fund'
+FUND_DOMAIN = FUND_FULL.gsub(' ', '').downcase
 FUND = ENV['DARIA_FUND'] || 'DCAF'

--- a/test/integration/update_user_info_test.rb
+++ b/test/integration/update_user_info_test.rb
@@ -43,7 +43,7 @@ class UpdateUserInfoTest < ActionDispatch::IntegrationTest
 
       it 'should send an email notifying' do
         email_content = ActionMailer::Base.deliveries.last.to_s
-        assert_match /Your password has changed/, email_content
+        assert_match /Your DARIA password has changed/, email_content
         assert_match @user.email, email_content
       end
     end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -4,7 +4,7 @@ class UserMailerTest < ActionMailer::TestCase
   test 'should send an email' do
     @user = create :user
     mail = UserMailer.password_changed(@user.id)
-    assert_equal 'Your password has changed', mail.subject
+    assert_equal 'Your DARIA password has changed', mail.subject
     assert_equal [@user.email], mail.to
     assert_equal ['no-reply@dcabortionfund.org'], mail.from
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Removes a couple DCAF specific mentions (domain of email from, SL of emails) in favor of either the fund in particular or DARIA, whichever is more appropriate.

This pull request makes the following changes:
* Adds an app constant, `FUND_DOMAIN`
* Changes 'DCAF' to 'DARIA' in mailer subject lines

No view changes.

@tingaloo can you review? 

It relates to the following issue #s: 
* Bumps #999
