### PR TITLE
dcaf-color -> daria-color in scss

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -9,7 +9,7 @@
 @import "bootstrap";
 @charset "utf-8";
 
-$dcaf-color: #5D3E8D;
+$daria-color: #5D3E8D;
 $grey-color: #828282;
 $font-size: 17px;
 
@@ -18,9 +18,9 @@ $font-size: 17px;
   background-color: #f5f5f5;
   border: none;
   .navbar-header > a, .navbar-nav > li > a, .navbar-link{
-    color: $dcaf-color;
+    color: $daria-color;
     &:hover{
-      color: lighten($dcaf-color, 20%);
+      color: lighten($daria-color, 20%);
       text-decoration: underline;
     }
     &:visited{

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -29,7 +29,7 @@ $font-size: 17px;
   }
 
   .navbar-text{
-    color: $dcaf-color;
+    color: $daria-color;
     padding:15px;
     margin:0px;
     line-height:20px;
@@ -57,7 +57,7 @@ $font-size: 17px;
 
 .btn-primary {
   @extend .btn-primary;
-  background-color: $dcaf-color;
+  background-color: $daria-color;
   border: none;
   margin-bottom: 2px;
   font-size: $font-size;
@@ -65,7 +65,7 @@ $font-size: 17px;
 
 .btn-primary:hover {
   @extend .btn-primary:hover;
-  background-color: lighten($dcaf-color,15%);
+  background-color: lighten($daria-color,15%);
 }
 
 .border-bottom {
@@ -238,25 +238,25 @@ h5 {
 
 }
 
-$dcaf-color-lt : #825fb9;
+$daria-color-lt : #825fb9;
 
 // Modal partial styling
 .btn-success {
 
-  background-color: $dcaf-color;
-  border-color: $dcaf-color;
+  background-color: $daria-color;
+  border-color: $daria-color;
 
   &:hover {
-    background-color: $dcaf-color-lt;
-    border-color: $dcaf-color;
+    background-color: $daria-color-lt;
+    border-color: $daria-color;
   }
   &:active {
     background-color: #286090 !important;
   }
   &:focus {
-    background-color: $dcaf-color;
+    background-color: $daria-color;
     &:hover {
-    background-color: $dcaf-color-lt;
+    background-color: $daria-color-lt;
     }
   }
 
@@ -267,19 +267,19 @@ $dcaf-color-lt : #825fb9;
 
 .btn-warning {
   color: black;
-  border-color: $dcaf-color;
+  border-color: $daria-color;
   background-color: white;
   &:hover {
-    background-color: $dcaf-color-lt;
-    border-color: $dcaf-color;
+    background-color: $daria-color-lt;
+    border-color: $daria-color;
   }
   &:active {
     background-color: #286090 !important;
   }
   &:focus {
-    background-color: $dcaf-color;
+    background-color: $daria-color;
     &:hover {
-    background-color: $dcaf-color-lt;
+    background-color: $daria-color-lt;
     }
   }
   
@@ -288,17 +288,17 @@ $dcaf-color-lt : #825fb9;
 .btn-success[disabled] {
   color: white;
   background-color: gray;
-  border-color: $dcaf-color;
+  border-color: $daria-color;
   &:hover {
     background-color: gray;
-    border-color: $dcaf-color;
+    border-color: $daria-color;
   }
   &:focus {
     background-color: gray;
-    border-color: $dcaf-color;
+    border-color: $daria-color;
     &:hover {
       background-color: gray;
-      border-color: $dcaf-color;
+      border-color: $daria-color;
     }
   }
   
@@ -309,7 +309,7 @@ $dcaf-color-lt : #825fb9;
 }
 
 .label-success {
-  background-color: $dcaf-color;
+  background-color: $daria-color;
 }
 
 .btn[data-orientation='cancel'] {

--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -2,7 +2,7 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-$dcaf-color: #5D3E8D;
+$daria-color: #5D3E8D;
 $font-size: 17px;
 
 #patient_dashboard {

--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -2,13 +2,13 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-$dcaf-color: #5D3E8D;
+$daria-color: #5D3E8D;
 
 .report-section{
   margin-bottom: 50px;
 }
 
 .line-header, .line-header:hover{
-  color: $dcaf-color;
+  color: $daria-color;
 }
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

In keeping with getting dcaf-specific references out of the app as much as possible, this renames the stock color code from `dcaf-color` to `daria-color`.

This pull request makes the following changes:
* renames `dcaf-color` to `daria-color` in a few scss files

@ashlynnpai can you review and approve these changes? Want to get another set of eyes on it to confirm I didn't accidentally misspell anything or do anything goofy by accident. Thank you!

It relates to the following issue #s: 
* Bumps #999 
