### PR TITLE
Sub in Fund env var for DCAF in calls helper

### DIFF
--- a/app/helpers/calls_helper.rb
+++ b/app/helpers/calls_helper.rb
@@ -64,13 +64,13 @@ module CallsHelper
 
   def voicemail_ok_notifier
     content_tag :p, class: 'text-success' do
-      content_tag :strong, 'Voicemail OK; Okay to identify as DCAF'
+      content_tag :strong, "Voicemail OK; Okay to identify as #{FUND}"
     end
   end
 
   def voicemail_not_specified_notifier
     content_tag :p, class: 'text-warning' do
-      content_tag :strong, 'Voicemail OK; Do not identify as DCAF'
+      content_tag :strong, "Voicemail OK; Do not identify as #{FUND}"
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Sub in `FUND` for DCAF in the voicemail preference part of the calls helper.

This pull request makes the following changes:
* What it says on the label

@KatSDC could I get you to approve these changes?

It relates to the following issue #s: 
* Bumps #999 
