### PR TITLE
Add skylight monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,5 @@ end
 group :production do
   gem 'puma'
   gem 'letsencrypt-rails-heroku'
+  gem 'skylight'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    skylight (1.3.1)
+      activesupport (>= 3.0.0)
     slop (3.6.0)
     source_finder (3.2.1)
     spring (2.0.1)
@@ -498,6 +500,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-context
   simplecov
+  skylight
   spring
   timecop
   turbolinks (= 2.5.3)

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,3 @@
+---
+# The authentication token for the application.
+authentication: <%= ENV['SKYLIGHT_AUTH_TOKEN'] %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds the skylight gem and config file, so we have more rails specific monitoring! I think this will help us identify where the pain points are, where loads are slow, and what keeps triggering logentries alerts.

I also added the appropriate api keys to the prod environment(s). This is free up until 100,000 requests so it's rolled out to just dcaf and baf, but not the sandbox env.

This pull request makes the following changes:
* Sets up skylight for accessible monitoring

@DarthHater I added you (and @lwaldsc and @lomky) as a collaborator to this. Can you approve these changes? I don't plan on rolling them out until this Sunday during out deployment window either way. 

It relates to the following issue #s: 
* Fixes #1017 (brick squad)
