### PR TITLE
Bump rubocop to address gemnasium warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,8 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     rdoc (4.3.0)
     reek (4.5.6)
@@ -363,7 +364,8 @@ GEM
     require_all (1.4.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    rubocop (0.47.1)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -419,7 +421,7 @@ GEM
       tzinfo (>= 1.0.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.2.1)
     url (0.3.2)
     virtus (1.0.5)
       axiom-types (~> 0.1)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bumps rubocop to 0.49 to address a gemnasium flag.

This pull request makes the following changes:
* that thing I said

No issue #.