### PR TITLE
fix modal load

### DIFF
--- a/app/assets/javascripts/external_pledges.coffee
+++ b/app/assets/javascripts/external_pledges.coffee
@@ -4,6 +4,6 @@
 
 jQuery ->
   # use event that works with rails turbolinks
-  $(document).on 'ready page:load', ->
+  $(document).on 'turbolinks:load', ->
     # select all elements with id ending with "modal"
     $('[id$=modal]').modalSteps()

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -7,13 +7,22 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
     @clinic = create :clinic
     @patient = create :patient, clinic: @clinic,
                                 appointment_date: Time.zone.now + 14,
-                                fund_pledge: 500
+                                fund_pledge: 500,
+                                urgent_flag: true
     log_in_as @user
     visit edit_patient_path @patient
     has_text? 'First and last name'
   end
 
   after { Capybara.use_default_driver }
+
+  it 'should load properly without other page touches' do
+    visit dashboard_path
+    click_link @patient.name
+    find('#submit-pledge-button').click
+    sleep 2
+    assert has_text? 'Confirm the following information is correct'
+  end
 
   describe 'submitting a pledge' do
     it 'should let you mark a pledge submitted' do
@@ -109,6 +118,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_element 'If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page'
       assert has_text? 'Cancel pledge:'
       find('#pledge-next').click
+      wait_for_ajax
 
       wait_for_no_element 'Cancel pledge:'
       assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -90,12 +90,13 @@ class ActionDispatch::IntegrationTest
   end
 
   def wait_for_ajax
-    counter = 0
-    while page.execute_script('return $.active').to_i > 0
-      counter += 1
-      sleep(0.1)
-      raise 'Ajax request took longer than 5 seconds, failing' if counter >= 50
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until _finished_all_ajax_requests?
     end
+  end
+
+  def _finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
   end
   
   def go_to_dashboard


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fix submit pledge modal, this was pushed before the turbolinks merge so that'd explain the failure of modal steps populating.

This pull request makes the following changes:
* Added turbolinks loader

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1089 
