### PR TITLE
Patient no longer added to call list in data entry mode

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -78,7 +78,6 @@ class PatientsController < ApplicationController
 
     if @patient.save
       flash[:notice] = "#{@patient.name} has been successfully saved! Add notes and external pledges, confirm the hard pledge and the soft pledge amounts are the same, and you're set."
-      current_user.add_patient @patient
       redirect_to edit_patient_path @patient
     else
       flash[:alert] = "Errors prevented this patient from being saved: #{@patient.errors.full_messages.to_sentence}"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Patient is no longer added to call list in data entry mode.

This pull request makes the following changes:
* removed line in PatientsController#data_entry_create that automatically added patient to current user's 
  call list.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1076
