### PR TITLE
User edit panel remix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,9 @@ class ApplicationController < ActionController::Base
   # whitelists attributes in devise
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update) do |user|
+      user.permit :name, :current_password
+    end
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update) do |user|
-      user.permit :name, :current_password
+      user.permit :name, :current_password, :password, :password_confirmation
     end
   end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,21 +1,21 @@
 <div class="authform">
-  <h2>Edit <%= current_user.email %> (<%= current_user.name %>)</h2>
+  <h2>User panel for <%= current_user.email %> (<%= current_user.name %>)</h2>
 
   <%= bootstrap_form_for resource, as: resource_name, url: '/users', html: { method: :put } do |f| %>
     <%= devise_error_messages! %>
 
-    <h3>Change your account details</h3>
-    <p>Email</p>
-    <p><%= current_user.email %></p>
+    <%= f.static_control :email %>
+    <%= f.static_control :role %>
     <%= f.text_field :name, label: 'First and last name' %>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
-      <%= link_to "Forgot your password?", new_user_password_path %>
+    <%= f.password_field :current_password, autocomplete: 'off' %>
+
+    <%= f.submit "Update info", class: 'btn btn-primary' %>
   <% end %>
   <br>
-
   <%= link_to "Back", :back %>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -12,8 +12,6 @@
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
-    <%= link_to "Forgot your password?", new_user_password_path %>
-
     <%= f.password_field :current_password, autocomplete: 'off' %>
 
     <%= f.submit "Update info", class: 'btn btn-primary' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -12,6 +12,11 @@
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
+    <h3>Change your password</h3>
+    <%= f.password_field :password, autocomplete: 'off' %>
+    <%= f.password_field :password_confirmation, autocomplete: 'off' %>
+
+    <h3>Enter your current password to confirm any changes</h3>
     <%= f.password_field :current_password, autocomplete: 'off' %>
 
     <%= f.submit "Update info", class: 'btn btn-primary' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -12,6 +12,8 @@
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
+    <%= link_to "Forgot your password?", new_user_password_path %>
+
     <%= f.password_field :current_password, autocomplete: 'off' %>
 
     <%= f.submit "Update info", class: 'btn btn-primary' %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -204,7 +204,16 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  it 'should be the devise controller' do
-    assert :devise_controller?
+  describe 'devise controller customization' do
+    it 'should be the devise controller' do
+      assert :devise_controller?
+    end
+
+    it 'should not let you edit email' do
+      params = { email: 'nope@nope.com', current_password: @user.password }
+      put registration_path, params: { user: params }
+      @user.reload
+      refute_equal @user.email, 'nope@nope.com'
+    end
   end
 end

--- a/test/integration/call_list_test.rb
+++ b/test/integration/call_list_test.rb
@@ -67,6 +67,7 @@ class CallListTest < ActionDispatch::IntegrationTest
       end
       find('a', text: 'I left a voicemail for the patient').click
       wait_for_no_element "Call #{@patient.name} now:"
+      wait_for_ajax
       wait_for_element 'Your completed calls'
     end
 

--- a/test/integration/update_user_info_test.rb
+++ b/test/integration/update_user_info_test.rb
@@ -9,19 +9,16 @@ class UpdateUserInfoTest < ActionDispatch::IntegrationTest
   end
 
   describe 'alter user info' do
-    it 'should let you change name and email' do
+    it 'should let you change name' do
       fill_in 'First and last name', with: 'Thorny'
       fill_in 'Current password', with: @user.password
       click_button 'Update info'
       assert has_text? 'Thorny'
     end
 
-    it 'should let you change email' do
-      fill_in 'Email', with: 'different@email.com'
-      fill_in 'Current password', with: @user.password
-      click_button 'Update info'
-      visit edit_user_registration_path
-      assert_text 'different@email.com'
+    it 'should not let you change email' do
+      assert has_text? 'Email'
+      refute has_field? 'Email'
     end
 
     describe 'changing your password' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adapts @AlexandraCasser 's great work in #1050 , and works out an additional kink or two (the reset password link doesn't work if you are already logged in, whoops, sorry @AlexandraCasser !).

This pull request makes the following changes:
* email no longer an editable field (woo security)

![screen shot 2017-06-24 at 1 23 16 pm](https://user-images.githubusercontent.com/3866868/27510522-4da9f4c4-58e0-11e7-9226-843fb5a28a7f.png)

It relates to the following issue #s: 
* Fixes #951
