### PR TITLE
Pledge reload ajax

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
     redirect_to root_url unless current_user.admin?
   end
 
-  def confirm_user_has_data_access
-    redirect_to root_url unless (current_user.admin? || current_user.data_volunteer?)
+  def redirect_unless_has_data_access
+    redirect_to root_url unless current_user.allowed_data_access?
   end
 end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -63,6 +63,7 @@ class PatientsController < ApplicationController
 
   def update
     if @patient.update_attributes patient_params
+      @patient.reload
       respond_to { |format| format.js }
     else
       head :internal_server_error

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,6 +1,6 @@
 # Create, edit, and update patients. The main patient view is edit.
 class PatientsController < ApplicationController
-  before_action :confirm_user_has_data_access, only: [:index]
+  before_action :redirect_unless_has_data_access, only: [:index]
   before_action :find_patient, only: [:edit, :update, :download]
   rescue_from Mongoid::Errors::DocumentNotFound,
               with: -> { redirect_to root_path }
@@ -63,15 +63,15 @@ class PatientsController < ApplicationController
 
   def update
     if @patient.update_attributes patient_params
-      if @patient.previous_changes.key?("pledge_sent")
+      puts @patient.previous_changes
+      # if @patient.previous_changes.key?("pledge_sent")
         respond_to { |format| format.js }
-      else
-        head :ok
-      end
+      # else
+        # head :ok
+      # end
     else
       head :internal_server_error
     end
-
   end
 
   def data_entry

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -63,12 +63,7 @@ class PatientsController < ApplicationController
 
   def update
     if @patient.update_attributes patient_params
-      puts @patient.previous_changes
-      # if @patient.previous_changes.key?("pledge_sent")
-        respond_to { |format| format.js }
-      # else
-        # head :ok
-      # end
+      respond_to { |format| format.js }
     else
       head :internal_server_error
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,6 +156,10 @@ class User
     role == :admin
   end
 
+  def allowed_data_access?
+    admin? || data_volunteer?
+  end
+
   private
 
   def verify_password_complexity

--- a/app/views/patients/_change_log.html.erb
+++ b/app/views/patients/_change_log.html.erb
@@ -1,4 +1,4 @@
-<section id="patient_change_log" class="abortion-info tab-pane">
+<section id="change_log" class="abortion-info tab-pane">
   <div class="col-sm-12">
     <h2>Patient history</h2>
     <table class="table border-side">

--- a/app/views/patients/_change_log.html.erb
+++ b/app/views/patients/_change_log.html.erb
@@ -1,4 +1,4 @@
-<section id="change_log" class="abortion-info tab-pane">
+<section id="patient_change_log" class="abortion-info tab-pane">
   <div class="col-sm-12">
     <h2>Patient history</h2>
     <table class="table border-side">

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -11,11 +11,11 @@
       </div>
       <div class="col-sm-6 hide-label">
         <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{patient.initial_call_date}" %>
-      </div>
+      </div><%=  %>
     </div>
     <div class="row">
       <div class="col-sm-12">
-        <p><strong>Status:</strong> <%= patient.status %></p>
+        <p><strong>Status:</strong> <span id='patient_status'><%= patient.status %></span></p>
       </div>
     </div>
   </div>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div class="col-sm-6 hide-label">
         <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{patient.initial_call_date}" %>
-      </div><%=  %>
+      </div>
     </div>
     <div class="row">
       <div class="col-sm-12">

--- a/app/views/patients/pledge.js.erb
+++ b/app/views/patients/pledge.js.erb
@@ -8,7 +8,6 @@ $('.modal').modal('toggle');
 $('.js-title-step span').slice(1).remove();
 var el = $(".js-title-step").contents()
 
-
 if (el.length > 2) {
   el.slice(2,el.length).remove();
 }

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -5,7 +5,7 @@ $('#patient_dashboard').html(
 );
 
 // $('#change_log').remove();
-$('#patient_change_log').html(
+$('#change_log').html(
   '<%= escape_javascript(render partial: "patients/change_log", locals: { patient: @patient })%>'
 );
 
@@ -20,4 +20,6 @@ $('#patient_change_log').html(
   $('#menu').html(
     '<%= escape_javascript(render partial: "patients/menu", locals: { patient: @patient })%>'
   );
+<% else %>
+  $('#fulfillment').empty();
 <% end %>

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -1,25 +1,37 @@
-// $('a[href$="#patient_information"]').click();
+// rerack approx gestation
+$('#patient_appointment_date')
+  .parent()
+  .find('span.help-block')
+  .text('Approx gestation at appt: <%= @patient.last_menstrual_period_at_appt %>')
 
-$('#patient_dashboard').html(
-  '<%= escape_javascript(render partial: "patients/patient_dashboard", locals: { patient: @patient })%>'
-);
+// rerack status
+$('#patient_status').text('<%= @patient.status %>');
 
-// $('#change_log').remove();
+// rerack current LMP
+$('#patient_last_menstrual_period_weeks')
+  .parent()
+  .find('span.help-block')
+  .text('Currently: <%= @patient.last_menstrual_period_display_short %>');
+
+// refresh entire changelog
 $('#change_log').html(
   '<%= escape_javascript(render partial: "patients/change_log", locals: { patient: @patient })%>'
 );
 
-// $('#fulfillment').remove();
+// if pledge is sent, re-rack fulfillment info
 <% if @patient.previous_changes.key?('pledge_sent') && current_user.allowed_data_access? %>
+  // properly set the button and make fulfillment show up, if it should
+  $('#menu').html(
+    '<%= escape_javascript(render partial: "patients/menu", locals: { patient: @patient })%>'
+  );
+
+  // populate the fulfillment form if it's supposed to be there
   <% if @patient.pledge_sent? %>
     $('#fulfillment').html(
       '<%= escape_javascript(render partial: "patients/fulfillment", locals: { patient: @patient })%>'
     );
   <% end %>
-
-  $('#menu').html(
-    '<%= escape_javascript(render partial: "patients/menu", locals: { patient: @patient })%>'
-  );
 <% else %>
+  // clear out fulfillment form
   $('#fulfillment').empty();
 <% end %>

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -2,7 +2,7 @@
 $('#patient_appointment_date')
   .parent()
   .find('span.help-block')
-  .text('Approx gestation at appt: <%= @patient.last_menstrual_period_at_appt %>')
+  .text('Approx gestation at appt: <%= @patient.last_menstrual_period_at_appt %>');
 
 // rerack status
 $('#patient_status').text('<%= @patient.status %>');

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -1,19 +1,23 @@
-$('a[href$="#patient_information"]').click();
-
-$('#menu').html(
-  '<%= escape_javascript(render partial: "patients/menu", locals: { patient: @patient })%>'
-);
+// $('a[href$="#patient_information"]').click();
 
 $('#patient_dashboard').html(
   '<%= escape_javascript(render partial: "patients/patient_dashboard", locals: { patient: @patient })%>'
 );
 
-$('#fulfillment').remove();
-$('#sections').append(
-  '<%= escape_javascript(render partial: "patients/fulfillment", locals: { patient: @patient })%>'
-);
-
-$('#change_log').remove();
-$('#sections').append(
+// $('#change_log').remove();
+$('#patient_change_log').html(
   '<%= escape_javascript(render partial: "patients/change_log", locals: { patient: @patient })%>'
 );
+
+// $('#fulfillment').remove();
+<% if @patient.previous_changes.key?('pledge_sent') && current_user.allowed_data_access? %>
+  <% if @patient.pledge_sent? %>
+    $('#fulfillment').html(
+      '<%= escape_javascript(render partial: "patients/fulfillment", locals: { patient: @patient })%>'
+    );
+  <% end %>
+
+  $('#menu').html(
+    '<%= escape_javascript(render partial: "patients/menu", locals: { patient: @patient })%>'
+  );
+<% end %>

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -20,18 +20,18 @@ $('#change_log').html(
 
 // if pledge is sent, re-rack fulfillment info
 <% if @patient.previous_changes.key?('pledge_sent') && current_user.allowed_data_access? %>
-  // properly set the button and make fulfillment show up, if it should
-  $('#menu').html(
-    '<%= escape_javascript(render partial: "patients/menu", locals: { patient: @patient })%>'
-  );
-
   // populate the fulfillment form if it's supposed to be there
   <% if @patient.pledge_sent? %>
     $('#fulfillment').html(
       '<%= escape_javascript(render partial: "patients/fulfillment", locals: { patient: @patient })%>'
     );
   <% end %>
-<% else %>
+
+  // properly set the button and make fulfillment show up, if it should
+  $('#menu').html(
+    '<%= escape_javascript(render partial: "patients/menu", locals: { patient: @patient })%>'
+  );
+<% elsif !@patient.pledge_sent %>
   // clear out fulfillment form
   $('#fulfillment').empty();
 <% end %>

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -145,10 +145,7 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
     it 'should respond success on completion' do
       patch patient_path(@patient), params: { patient: @payload }, xhr: true
       assert_response :success
-      patch patient_path(@patient), params: { patient: @payload }
-      assert_response :success
     end
-
 
     it 'should respond internal server error on failure' do
       @payload[:primary_phone] = nil
@@ -173,7 +170,7 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  #confirm get :data_entry returns a success code
+  # confirm get :data_entry returns a success code
   describe 'data_entry method' do
     it 'should respond success on completion' do
       get data_entry_path

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -170,7 +170,6 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # confirm get :data_entry returns a success code
   describe 'data_entry method' do
     it 'should respond success on completion' do
       get data_entry_path

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -16,6 +16,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
 
   after { Capybara.use_default_driver }
 
+  # this is a test for a persistent turbolinks bug
   it 'should load properly without other page touches' do
     visit dashboard_path
     click_link @patient.name
@@ -43,8 +44,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       find('#pledge-next').click
       wait_for_no_element 'Awesome, you generated a DCAF'
 
-      go_to_dashboard
-      visit edit_patient_path @patient
+      wait_for_ajax
       wait_for_element 'Patient information'
 
       assert has_text? Patient::STATUSES[:pledge_sent]
@@ -75,7 +75,6 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       @fulfillment = create :fulfillment, patient: @patient
       visit edit_patient_path @patient
       wait_for_element 'Patient information'
-
     end
 
     it 'should render after opening call modal' do
@@ -105,7 +104,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
       find('#pledge-next').click
 
-      visit edit_patient_path @patient
+      wait_for_ajax
       wait_for_element 'Patient information'
 
       assert has_link? 'Cancel pledge'
@@ -123,42 +122,12 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_no_element 'Cancel pledge:'
       assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
       find('#patient_pledge_sent').click
+      wait_for_ajax
       sleep 1 # out of ideas
       wait_for_ajax
 
       find('#pledge-next').click
-
-      visit edit_patient_path @patient
-      wait_for_element 'Patient information'
-
       assert has_link? 'Submit pledge'
-    end
-
-    it 'should dynamically update page' do
-      assert has_link? 'Cancel pledge'
-
-      find('#cancel-pledge-button').click
-
-      wait_for_element 'If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page'
-      assert has_text? 'Cancel pledge:'
-      find('#pledge-next').click
-
-      wait_for_no_element 'Cancel pledge:'
-      assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
-      find('#patient_pledge_sent').click
-
-      find('#pledge-next').click
-
-      wait_for_ajax
-      wait_for_no_element 'Cancel pledge:'
-      sleep 2
-
-      assert has_link? 'Submit pledge'
-
-      click_link 'Change Log'
-      wait_for_element 'Record new call'
-
-      assert has_text? 'Pledge sent', count: 2
     end
   end
 end

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -128,6 +128,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
 
       find('#pledge-next').click
       assert has_link? 'Submit pledge'
+      assert has_content? Patient::STATUSES[:no_contact]
     end
   end
 end

--- a/test/integration/submit_pledge_test.rb
+++ b/test/integration/submit_pledge_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class SubmitPledgeTest < ActionDispatch::IntegrationTest
   before do
     Capybara.current_driver = :poltergeist
-    @user = create :user
+    @user = create :user, role: :data_volunteer
     @clinic = create :clinic
     @patient = create :patient, clinic: @clinic,
                                 appointment_date: Time.zone.now + 14,
@@ -48,6 +48,8 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_element 'Patient information'
 
       assert has_text? Patient::STATUSES[:pledge_sent]
+      assert has_link? 'Fulfillment'
+      assert has_link? 'Cancel pledge'
     end
 
     it 'should render after opening call modal' do
@@ -83,10 +85,12 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_element "Call #{@patient.name} now:"
 
       find('#cancel-pledge-button').click
+      wait_for_ajax
 
       wait_for_element 'If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page'
       assert has_text? 'Cancel pledge:'
       find('#pledge-next').click
+      wait_for_ajax
 
       wait_for_no_element 'Cancel pledge:'
       assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
@@ -129,6 +133,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       find('#pledge-next').click
       assert has_link? 'Submit pledge'
       assert has_content? Patient::STATUSES[:no_contact]
+      refute has_link? 'Fulfillment'
     end
   end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -43,6 +43,9 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
         assert_equal '2', lmp_days.value
         assert has_field?('Appointment date', with: @date)
         assert has_field? 'Phone number', with: '123-666-8888'
+
+        assert has_content? 'Currently: 5w 4d'
+        assert has_content? 'Approx gestation at appt: 6 weeks, 2 days'
       end
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -184,4 +184,18 @@ class UserTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'data access' do
+    it 'should allow for admins' do
+      assert create(:user, role: :admin).allowed_data_access?
+    end
+
+    it 'should allow for data volunteers' do
+      assert create(:user, role: :data_volunteer).allowed_data_access?
+    end
+
+    it 'should not allow for CMs' do
+      refute create(:user, role: :cm).allowed_data_access?
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

@tingaloo has solved a long running problem of this app in #1064 , which is that the patient edit page is not particularly responsive. I've added a little bit of business logic surrounding this. This now makes the following fields bump on a patient edit:

* status
* current LMP
* approx gestation at appt
* the change log
* cancel pledge / submit pledge button status
* whether or not the fulfillment partial shows up


There's a thing that my js skills are a little weak that I'd like to sort out -- refreshing the page makes you lose focus, so if you're tabbing from field to field on the dashboard, you lose whatever you're editing. @tingaloo do you know of a good way to stop that from happening? (Maybe by just re-racking particular pieces of text in specific IDs, rather than blowing away the entire dashboard partial? That's probably the most straightforward way, but I'd like your opinion.)

This pull request makes the following changes:
* update js action fires now and refreshes certain partials we want to be dynamic
* tidies up in a couple other places

It relates to the following issue #s: 
* Fixes #490 !!!!!! ahhhhhhh
