### PR TITLE
Slight test adjustment, no more role editing for now

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -106,7 +106,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :_role)
+    params.require(:user).permit(:name, :email)
   end
 
   def retrieve_patients

--- a/test/integration/user_management_test.rb
+++ b/test/integration/user_management_test.rb
@@ -24,14 +24,10 @@ class UserManagementTest < ActionDispatch::IntegrationTest
       log_in_as @user
     end
 
-    it 'should not be able to access Admin links' do
-      visit users_path
-      assert has_no_link? 'Admin'
-    end
-
     it 'should redirect to main dashboard' do
       visit users_path
       assert_text 'Build your call list'
+      assert_no_text 'User Account Management'
     end
   end
 
@@ -42,7 +38,7 @@ class UserManagementTest < ActionDispatch::IntegrationTest
 
     it 'should not be able to access user management' do
       click_link 'Admin'
-      assert_no_text 'User Management'
+      assert_no_text 'User Account Management'
     end
   end
 
@@ -144,6 +140,8 @@ class UserManagementTest < ActionDispatch::IntegrationTest
     end
 
     # TODO figure out a way to show error
+    # Right now this is failing because role is not in user params.
+    # Alter this test when there's a good story around that
     it 'disallows role editing' do
       select 'Admin', from: 'Role'
       click_button 'Save'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Temporarily turns off role changing until we can build some precise rules around it; adjusts the user mgmt integration test so that #1106 will fly.

This pull request makes the following changes:
* Removes `_role` from `user_params`
* Makes some precision adjustments to the user management integration tests

No view changes

It relates to the following issue #s: 
* No issue, but is here so we can get #1106 to fly
