### PR TITLE
only one patient retriever

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -6,13 +6,11 @@ class PatientsController < ApplicationController
               with: -> { redirect_to root_path }
 
   def index
-    patients = Patient.all
-
     respond_to do |format|
       format.csv do
         now = Time.zone.now.strftime('%Y%m%d')
         csv_filename = "patient_data_export_#{now}.csv"
-        send_data patients.to_csv, filename: csv_filename, format: 'text/csv'
+        send_data Patient.to_csv, filename: csv_filename, format: 'text/csv'
       end
     end
   end

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -143,7 +143,7 @@ module Exportable
         csv << CSV_EXPORT_FIELDS.keys # Header line
         all.each do |patient|
           csv << CSV_EXPORT_FIELDS.values.map do |field|
-             patient.get_field_value_for_serialization(field)
+            patient.get_field_value_for_serialization(field)
           end
         end
       end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We're regularly getting timeout errors when trying to export files. I think this might help -- it invokes `Patient.all` once instead of twice when hitting the CSV export endpoint now.

@lomky for review please!

This pull request makes the following changes:
* just one multi thousand record query please

No view changes.

No issues.