### PR TITLE
Change intro markdown to link to security practices

### DIFF
--- a/.github/CONTRIBUTING
+++ b/.github/CONTRIBUTING
@@ -10,3 +10,7 @@
 * Check the `beginner friendly` tag for issues that don't require deep familiarity with the codebase.
 * Check out the README! We do a pretty good job of documenting our processes. 
 * Come hang out with us at a Code for DC meeting!
+
+### Security Practices
+
+* Please see [this document]() for good security practices

--- a/.github/CONTRIBUTING
+++ b/.github/CONTRIBUTING
@@ -13,4 +13,4 @@
 
 ### Security Practices
 
-* Please see [this document]() for good security practices
+* Please see [this document](https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) for good security practices

--- a/docs/SECURITY_INTRO.md
+++ b/docs/SECURITY_INTRO.md
@@ -1,0 +1,52 @@
+## Security
+
+Please read the following resources to get an overview of Ruby and Rails security before opening PRs.
+
+[Ruby on Rails Security Cheatsheet](https://www.owasp.org/index.php/Ruby_on_Rails_Cheatsheet)
+
+Get familiar with Brakeman and run it often. It runs as part of the build but it is easier to run it before opening your PR and fixing it there.
+
+[Brakeman Scanner](http://brakemanscanner.org/)
+
+### Cryptography
+If you need to encrypt, sign or hash something here are the recommended libraries. Do not roll your own library and use only libraries that have been reviewed by the community.
+
+#### Hashing
+Ruby has built in hash function that can be used. MD5 and SHA1 are considered broken and should not be used. SHA2 is still considered secure.
+
+Example:
+```
+> require 'digest'
+> Digest::SHA2.hexdigest 'abc'
+> "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+```
+
+#### Password hashing
+Bcrypt or Scrypt are the preferred methods for hashing passwords. More details are here:
+
+[Bcrypt](https://github.com/codahale/bcrypt-ruby)
+
+#### Encryption
+RbNaCl is a great library that makes encryption in Ruby relatively easy. Be cautious when deciding to use encryption, there are a million ways to make a mistake and they're often overlooked.
+
+[RbNaCl](https://github.com/cryptosphere/rbnacl)
+
+#### Signing
+Rails has a built in method to sign messages.
+
+[Message Verifier](http://api.rubyonrails.org/classes/ActiveSupport/MessageVerifier.html)
+
+#### Random Token
+If you need to generate a random token, for a reset password email for example, use SecureRandom that is built into Ruby.
+
+[SecureRandom](https://ruby-doc.org/stdlib-2.3.0/libdoc/securerandom/rdoc/SecureRandom.html)
+
+#### More reading:
+
+Checkout [this document]( https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) on basic Ruby on Rails security.
+
+[Ruby on Rails Security Guide](http://guides.rubyonrails.org/security.html)
+
+[An Overview of Cryptography](http://www.garykessler.net/library/crypto.html)
+
+[Password Hashing](https://crackstation.net/hashing-security.htm)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -81,3 +81,8 @@ If you don't currently have Rails installed (or are on Windows), Cloud9 makes th
 * Pop back to the previous tab and run `rake db:seed` to populate your database with test data
 * Hit the `Run Project` button up top. (If the button is unresponsive, you may need select **Run -> Run With -> Rails Default** from the dropdown.)
 * Check out the URL it's running on! You're all set!
+
+
+## Security
+
+Checkout [this document]( https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) on Ruby on Rails security.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,9 +2,9 @@
 
 The directions below get you to a point where you can run the app with a test-seeded database.
 
-* **First things first**: Make a copy of your own to wrench on by forking! Go to https://github.com/colinxfleming/dcaf_case_management and hit the `fork` button up in the top right.
+* **First things first**: Make a copy of your own to wrench on by forking! Go to https://github.com/DCAFEngineering/dcaf_case_management and hit the `fork` button up in the top right.
 * **Second things second**: `git clone https://github.com/{YOUR GITHUB USERNAME}/dcaf_case_management` to pull it down to your local system
-* **Third things third**: Add the source repo as the upstream with the command `git remote add upstream https://github.com/colinxfleming/dcaf_case_management`. This will let you update when the source repo changes by running the command `git pull upstream master`.
+* **Third things third**: Add the source repo as the upstream with the command `git remote add upstream https://github.com/DCAFEngineering/dcaf_case_management`. This will let you update when the source repo changes by running the command `git pull upstream master`.
 * **Fourth things fourth**: Make the source repo fetch-only by unsetting the URL: `git remote set-url --push upstream no-pushing-to-upstream`. This will prevent mistakenly pushing to upstream if you get push access down the road.
 
 For the rest of the setup, you have three options: Docker, installing everything locally, or Cloud9. We recommend Docker if you're comfortable with its ecosystem.
@@ -85,4 +85,4 @@ If you don't currently have Rails installed (or are on Windows), Cloud9 makes th
 
 ## Security
 
-Checkout [this document]( https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) on Ruby on Rails security.
+Checkout [this document](https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) on Ruby on Rails security.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

 Created an intro security document for new contributors to read.

This pull request makes the following changes:
* Creates docs/SECURITY_INTRO.md
* Adds links to the security document in .github/CONTRIBUTING and docs/SETUP.md

It relates to the following issue #s: 
* Fixes #994
