### PR TITLE
move checkboxes to same line as label

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -229,6 +229,11 @@ h5 {
    margin-top:25px;
 }
 
+.info-form .checkbox label {
+  font-weight: bold;
+}
+
+
 // Search result
 // shell styling
 .form-group input {

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -7,25 +7,28 @@
     </div>
 
     <div class="row">
-      <div class="col-sm-12">
+      <div class="col-sm-12 info-form">
         <h3> Clinic details </h3>
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form' }, remote: true do |f| %>
           <div class="col-sm-6">
             <div class="info-form-left">
               <%= f.select :clinic_id, options_for_select(clinic_options, patient.clinic.try(:id)) %>
+              <div class="checkbox">
+                <%= label_tag 'naf_filter' do %>
+                  <%= check_box_tag 'naf_filter' %>
+                  Enable only NAF clinics
+                <% end %>
+              </div>
             </div>
-            <%= label_tag 'Enable only NAF clinics' %>
-            <br>
-            <%= check_box_tag 'naf_filter' %>
           </div>
 
           <div class="col-sm-6">
             <div class="info-form-right">
-              <%= f.form_group :resolved_without_fund, label: { text: "Resolved without assistance from #{FUND}" } do %>
-                <%= f.check_box :resolved_without_fund, label: '' %>
+              <%= f.form_group :resolved_without_fund do %>
+                <%= f.check_box :resolved_without_fund, label: "Resolved without assistance from #{FUND}" %>
               <% end %>
-              <%= f.form_group :referred_to_clinic, label: { text: 'Referred to clinic' } do %>
-                <%= f.check_box :referred_to_clinic, label: '' %>
+              <%= f.form_group :referred_to_clinic do %>
+                <%= f.check_box :referred_to_clinic, label: 'Referred to clinic' %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

In the **Abortion InformationI** section, I managed to move the checkboxes to the same lines as their labels.

This pull request makes the following changes:
* label checkboxes instead of form groups
* alter the formatting for the `naf_filter` checkbox to match the other two
* add a css rule to keep the checkbox label fonts bold

![image](https://user-images.githubusercontent.com/20198354/28395990-6650431c-6cc6-11e7-9fb6-dab0d63d2e39.png)

It relates to the following issue #s: 
* Fixes #1135 
