### PR TITLE
updated Google SSO login link to be more prominent

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -197,6 +197,19 @@ h5 {
   /*max-width: 320px;*/
   margin: 0 auto;
 }
+
+.authform a:first-of-type {
+  font-size: 1.625rem;
+  padding: 4px;
+  color: #FFFAF8;
+  background-color: $daria-color;
+  border-radius: 4px;
+}
+
+.authform a:first-of-type:hover {
+  background-color: lighten($daria-color,15%);
+}
+
 .authform form {
   /*@extend .well;*/
   /*@extend .well-lg;*/

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <div class="authform">
     <h3>Sign in</h3>
 
-    <%= link_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path %>
+    <%= link_to "Sign in with Google (recommended)", user_google_oauth2_omniauth_authorize_path %>
 
     <%= bootstrap_form_for resource, as: resource_name, url: session_path(resource_name) do |f| %>
       <%= devise_error_messages! %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* update Google SSO login link to make it more prominent and visible on the page

Screenshot:
<img width="571" alt="case_manager_google_sso_update" src="https://user-images.githubusercontent.com/10843135/28397084-60317d3c-6ccd-11e7-908c-9564c3492d16.png">

It relates to the following issue #s: 
* Fixes #811 
