### PR TITLE
add shas for gon and popover

### DIFF
--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -1,8 +1,11 @@
+gon_gem_sha = "'sha256-+PC+Kf6qxwFk9MeuRMDmsALBNWNX473zplWkiVYhJgY='"
+popover_sha = "'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc='"
+
 SecureHeaders::Configuration.default do |config|
   config.csp = {
     preserve_schemes: true, # default: false.
     default_src: %w('self'),
-    script_src: %w('self' 'unsafe-eval'),
+    script_src: ["'self'", "'unsafe-eval'", gon_gem_sha, popover_sha],
     font_src: %w('self' fonts.gstatic.com),
     connect_src: %w('self'),
     style_src: %w('self' 'unsafe-inline'),


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This adds standard shas for our common JS, a popover and the cruft the gon gem dumps in, into our CSP script-src whitelist. The main effect is that the javascript console will now not dump errors all the time.

This pull request makes the following changes:
* Adds shas for popover and gon to the CSP whitelist

It relates to the following issue #s: 
* Loosely relates to #1144 #1140 

@tingaloo for approval please!