### PR TITLE
Remove DCAF references from a few places

### DIFF
--- a/app/views/lines/new.html.erb
+++ b/app/views/lines/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="col-sm-12">
-    <h1 class="border-bottom title">Welcome to DCAF Case Manager!</h1>
+    <h1 class="border-bottom title">Welcome to <%= FUND %> Case Manager!</h1>
     <h4>What line are you working tonight?</h4>
 
     <%= bootstrap_form_tag url: lines_path do |f| %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h1><strong>DCAF Data Center</strong></h1>
+<h1><strong><%= FUND %> Data Center</strong></h1>
 <div class="row">
   <h4 class="col-sm-8"><strong>Budget bar, design TK</strong></h4>
 </div>

--- a/civic.json
+++ b/civic.json
@@ -1,6 +1,6 @@
 {
     "name": "DCAF Case Manager", 
-    "description": "A Rails-based case management system for ", 
+    "description": "A Rails-based case management system for abortion funds",
     "license": "MIT", 
     "status": "Production", 
     "homepage": "https://sandbox.dcabortionfnd.org", 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Incremental bump toward abstracting DCAF out of the business part of the app -- removes DCAF from a few headers in favor of the `FUND` variable.

This pull request makes the following changes:
* changes a few DCAFs to `FUND`s
* completes a sentence in civic.json

No view changes.

It relates to the following issue #s: 
* Bump to #999 

@ashlynnpai  for sign off please!