### PR TITLE
Remove language from patient factory

### DIFF
--- a/test/factories/patient.rb
+++ b/test/factories/patient.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
     name 'New Patient'
     sequence(:primary_phone, 100) { |n| "127-#{n}-1111" }
     line 'DC'
-    language 'English'
     created_by { FactoryGirl.create(:user) }
     initial_call_date { 2.days.ago }
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Super small cleanup, removes language from the patient test factory.

This pull request makes the following changes:
* Removes language from the patient test factory, since nil == english

No view changes. 

No issues.