### PR TITLE
Autoselect when 1 line

### DIFF
--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,6 +1,11 @@
 # Single-serving controller for setting current line for a user.
 class LinesController < ApplicationController
-  def new; end
+  def new
+    if LINES.count == 1
+      session[:line] = LINES[0]
+      redirect_to authenticated_root_path
+    end
+  end
 
   def create
     session[:line] = params[:line]

--- a/test/integration/select_line_test.rb
+++ b/test/integration/select_line_test.rb
@@ -24,6 +24,21 @@ class SelectLineTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # TODO
+  describe 'line redirect on single line' do
+    before do
+      # TODO setup line array like so ['dc']
+      @user.line='DC'
+      # LINES=%w(DC).map(&:to_sym).freeze
+      puts @user.inspect
+      # how to change env var constants in this block?
+    end
+
+    it 'should redirect to the dashboard' do
+      assert_equal current_path, authenticated_root_path
+    end
+  end
+
   describe 'redirection conditions' do
     before { @patient = create :patient }
     it 'should redirect from dashboard if no line is set' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Automatically selects and redirects to line if only 1 line count. Not sure how to test but it should be working.

This pull request makes the following changes:
Redirects to line if only 1 line.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1151 
