### PR TITLE
More prominent Google SSO link ctd

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -198,18 +198,6 @@ h5 {
   margin: 0 auto;
 }
 
-.authform a:first-of-type {
-  font-size: 1.625rem;
-  padding: 4px;
-  color: #FFFAF8;
-  background-color: $daria-color;
-  border-radius: 4px;
-}
-
-.authform a:first-of-type:hover {
-  background-color: lighten($daria-color,15%);
-}
-
 .authform form {
   /*@extend .well;*/
   /*@extend .well-lg;*/

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,10 @@
 <div class="col-sm-6">
   <div class="authform">
-    <h3>Sign in</h3>
+    <h3>
+      <%= button_to "Sign in with Google (recommended)", user_google_oauth2_omniauth_authorize_path, class: 'btn btn-primary' %>
+    </h3>
 
-    <%= link_to "Sign in with Google (recommended)", user_google_oauth2_omniauth_authorize_path %>
+    <p>Or, sign in with a password:</p>
 
     <%= bootstrap_form_for resource, as: resource_name, url: session_path(resource_name) do |f| %>
       <%= devise_error_messages! %>
@@ -21,7 +23,7 @@
         <%= f.check_box :remember_me %>
       <% end -%>
 
-      <%= f.submit 'Sign in', :class => 'btn btn-primary' %>
+      <%= f.submit 'Sign in with password', class: 'btn btn-default' %>
     <% end %>
 
     <%= render "devise/shared/links" %>

--- a/test/integration/google_sso_test.rb
+++ b/test/integration/google_sso_test.rb
@@ -10,17 +10,17 @@ class GoogleSSOTest < ActionDispatch::IntegrationTest
       @user = create :user, email: 'test@gmail.com'
       visit root_path
       wait_for_element 'Sign in with Google'
-      click_link 'Sign in with Google'
+      click_button 'Sign in with Google'
 
       assert has_content? @user.name
     end
 
     it 'will reject sign ins if email is not associated with a user' do
       visit root_path
-      assert has_content? 'Sign in'
-      click_link 'Sign in with Google'
+      assert has_content? 'Forgot your password?'
+      click_button 'Sign in with Google'
 
-      assert has_content? 'Sign in'
+      assert has_content? 'Forgot your password?'
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,7 +68,7 @@ class ActionDispatch::IntegrationTest
     visit root_path
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
-    click_button 'Sign in'
+    click_button 'Sign in with password'
   end
 
   def select_line(line = 'DC')
@@ -98,7 +98,7 @@ class ActionDispatch::IntegrationTest
   def _finished_all_ajax_requests?
     page.evaluate_script('jQuery.active').zero?
   end
-  
+
   def go_to_dashboard
     click_link "DARIA - #{(ENV['FUND'] ? ENV['FUND'] : Rails.env)}"
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Some very slight adjustments to @rudietuesdays excellent and thoughtful work in #1149 to point people more toward google sign in.

This pull request makes the following changes:
* favor inline bootstrap classes over css
* some adjustments for my own neuroses
* follow 'one primary button per page' rule that @mebates has instilled unto me

@mebates does this look okay? We're trying to push people toward google sign in, primarily. The main diff is that `Sign in with Google` is now the button primary, and sign in with password is just a blank white button.

<img width="1133" alt="screen shot 2017-08-05 at 12 49 47 am" src="https://user-images.githubusercontent.com/3866868/28992943-ff505670-7977-11e7-9d2a-faeba59e6d69.png">

It relates to the following issue #s: 
* Fixes #811 