### PR TITLE
downgrade omniauth-google-oauth2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'bootstrap-sass', '~> 3.3', '>= 3.3.6'
 gem 'bootstrap_form'
 gem 'bootstrap_form-datetimepicker'
 gem 'devise', '~> 4.2.1'
-gem 'omniauth-google-oauth2'
+gem 'omniauth-google-oauth2', '0.2.1' # TODO upgrade
 gem 'mongoid', '6.1.0'
 gem 'mongoid-history', '0.6.1'
 gem 'mongoid_userstamp', git: 'https://github.com/DCAFEngineering/mongoid_userstamp.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,11 +210,9 @@ GEM
     omniauth (1.6.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
-    omniauth-google-oauth2 (0.5.1)
-      jwt (~> 1.5)
-      multi_json (~> 1.3)
-      omniauth (>= 1.1.1)
-      omniauth-oauth2 (>= 1.3.1)
+    omniauth-google-oauth2 (0.2.1)
+      omniauth (~> 1.0)
+      omniauth-oauth2
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -397,7 +395,7 @@ DEPENDENCIES
   mongoid-history (= 0.6.1)
   mongoid_userstamp!
   nokogiri (>= 1.7.2)
-  omniauth-google-oauth2
+  omniauth-google-oauth2 (= 0.2.1)
   pdf-inspector
   poltergeist
   prawn


### PR DESCRIPTION
Looks like this particular gem upgrade, despite being a point release, contains a breaking change of some sort. 