### PR TITLE
Alter CSP to allow for script tags to be executed

### DIFF
--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -8,6 +8,6 @@
   <div class="progress-bar progress-bar-striped"</div>
 </div>
  -->
-<%= render_async patients_report_path(timeframe: 'weekly'), nonce: content_security_policy_script_nonce %>
-<%= render_async patients_report_path(timeframe: 'monthly'), nonce: content_security_policy_script_nonce %>
-<%= render_async patients_report_path(timeframe: 'yearly'), nonce: content_security_policy_script_nonce %>
+<%= render_async patients_report_path(timeframe: 'weekly') %>
+<%= render_async patients_report_path(timeframe: 'monthly') %>
+<%= render_async patients_report_path(timeframe: 'yearly') %>

--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -1,12 +1,9 @@
-gon_gem_sha = "'sha256-+PC+Kf6qxwFk9MeuRMDmsALBNWNX473zplWkiVYhJgY='"
-popover_sha = "'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc='"
-
 SecureHeaders::Configuration.default do |config|
   config.csp = {
     preserve_schemes: true, # default: false.
     default_src: %w('self'),
-    script_src: ["'self'", "'unsafe-eval'", gon_gem_sha, popover_sha],
-    font_src: %w('self' fonts.gstatic.com),
+    script_src: %w('self' 'unsafe-eval' 'unsafe-inline'),
+    font_src: %w('self' fonts.gstatic.com ),
     connect_src: %w('self'),
     style_src: %w('self' 'unsafe-inline'),
     report_uri: ["https://#{ENV['CSP_VIOLATION_URI']}/csp/reportOnly"]


### PR DESCRIPTION
Note that 'unsafe-inline' is ignored if either a hash or nonce value
is present in the source list. 

I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* csp script_src line should be: script_src: %w('self' 'unsafe-eval' 'unsafe-inline'),
* removal of nonce from render_async

It relates to the following issue #s: 
* Fixes #1095
