### PR TITLE
Switch back to ROOOOOT (beer)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,6 @@ RUN ln -s `which nodejs` /usr/bin/node
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-RUN addgroup dcaf && adduser -s /bin/bash -D -G dcaf dcaf
-RUN chown -R dcaf:dcaf ${DCAF_DIR}
-
-USER dcaf
-
 WORKDIR ${DCAF_DIR}
 
 COPY . ${DCAF_DIR}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Switches the Docker image back to using root. We don't have plans to use Docker in production, switching user is kinda cool but causing too much pain at the moment.

This pull request makes the following changes:
* DOCKERRRRRRR
