### PR TITLE
Add nonce to js to display reports... for real

### DIFF
--- a/app/views/reports/_patient_report.html.erb
+++ b/app/views/reports/_patient_report.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_tag do %>
+<%= javascript_tag nonce: content_security_policy_script_nonce do %>
   $(function() {
     var report = <%= report.to_json.html_safe %>
     var lines = (<%= lines.to_json.html_safe %>)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

facepalm.gif. SORRY EVERYONE this massive dumb odyssey is my screwup.

This pull request makes the following changes:
* Adds a nonce to the js
* Literally nothing else

It works in sandbox!

<img width="783" alt="screen shot 2017-08-12 at 1 42 39 am" src="https://user-images.githubusercontent.com/3866868/29238325-32c66380-7f01-11e7-8f3e-9fdcaa023723.png">

Tagging in @tingaloo and @lapolonio for approval.

It relates to the following issue #s: 
* Fixes #1009 
