### PR TITLE
Fix dashboard n+1 queries

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,6 @@ class User
   validate :secure_password
 
   TIME_BEFORE_INACTIVE = 2.weeks
-  RECENT_TIMEFRAME = 8.hours.ago..Time.zone.now
 
   def secure_password
     return true if password.nil?

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -35,7 +35,7 @@
           <% if table_type == 'completed_calls' || table_type == 'urgent_patients' %>
             <td class="blank-td"></td>
           <% else %>
-            <% if current_user.patients.include?(patient) %>
+            <% if current_user.patient_ids.include?(patient.id) %>
               <td><%= link_to remove_from_call_list_glyphicon, remove_patient_path(current_user, patient), method: :patch, data: { confirm: "Are you sure you want to remove #{patient.name} from your call list?" },  remote: true %></td>
             <% else %>
               <td><%= link_to "Add", add_patient_path(current_user, patient), method: :patch, remote: true %></td>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Jumps off @tingaloo 's sharp work in #1081 to eliminate an n+1 query.

Turns out we were both wrong! This wound up being a check in the view, which was way, way under. It was not my first, third, or fifth inclination, but I eventually traced it down to that, and it turns out that single check using the full `patients` set instead of `patient_ids` was causing our n+1 by re-getting `patients` over and over and over, instead of just checking the reference numbers.

looking back, could have probably guessed this -- this is the same thing that @rivers (hi! hope all is well back west 👋 ) fixed in #914 on a different model. But this was nested a little deeper, unfortunately, so it was pretty difficult to dig up. 

The more you know / the peril of rails magic, etc.

This pull request makes the following changes:
* Removes a reference that was causing an n+1 query

wooooo
<img width="1258" alt="screen shot 2017-08-12 at 8 33 42 pm" src="https://user-images.githubusercontent.com/3866868/29245130-9261a380-7f9d-11e7-9d3a-79414a74019d.png">

It relates to the following issue #s: 
* Fixes #1054 
