### PR TITLE
Add a test for date of check

### DIFF
--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -216,6 +216,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       select '12 weeks', from: 'Weeks along at procedure'
       fill_in 'Abortion care $', with: '100'
       fill_in 'Check #', with: '444-22'
+      fill_in 'Date of check', with: 2.weeks.from_now.strftime('%Y-%m-%d')
 
       click_away_from_field
       wait_for_ajax
@@ -233,6 +234,8 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
                      find('#patient_fulfillment_gestation_at_procedure').value
         assert has_field? 'Abortion care $', with: 100
         assert has_field? 'Check #', with: '444-22'
+        assert has_field? 'Date of check',
+                          with: 2.weeks.from_now.strftime('%Y-%m-%d')
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Tests shoulda caught the bug fix in #1206 so I'm adding a test.

This pull request makes the following changes:
* Adds a test for #1206 

It relates to the following issue #s: 
* Fixes #1199 ... FOREVER

@tingaloo can you review? I'll hold on merging this until the MM/DD/YYYY PR is in so as to not making that even more of a moving target.
