### PR TITLE
Plop Notifications as Absolute

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -116,6 +116,12 @@ $font-size: 17px;
   padding: 15px 30px;
 }
 
+#flash {
+  position: absolute;
+  width: 100%;
+  z-index: 999;
+}
+
 // General styling artifacts
 // make all images responsive by default
 img {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -120,6 +120,10 @@ $font-size: 17px;
   position: absolute;
   width: 100%;
   z-index: 999;
+  transition-duration: .5s;
+  &:hover {
+    opacity: .5;
+  }
 }
 
 // General styling artifacts

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,4 +1,5 @@
 <div id='flash'>
+  <div class="col-sm-10">
   <% flash.each do |name, msg| %>
     <% if name != 'timedout' && msg.length > 0 %>
       <div class="alert alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">
@@ -6,5 +7,6 @@
         <%= content_tag :div, msg, :id => "flash_#{name}" %>
       </div>
     <% end %>
-  <% end %>  
+  <% end %>
+  </div>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Notifications no longer bump form up and down yeah? Also added opacity effect when hovered.

This pull request makes the following changes:
* Notifications boop


![screen shot 2017-08-19 at 4 08 15 pm](https://user-images.githubusercontent.com/8662824/29489871-a33a56a6-84f8-11e7-9d28-67bc8b460797.jpg)

It relates to the following issue #s: 
* Fixes #1210 
