### PR TITLE
decrease puma workers to see if it fixes those r14 errors

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ port        ENV.fetch("PORT") { 3000 }
 # the concurrency of the application would be max `threads` * `workers`.
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
-workers ENV.fetch("WEB_CONCURRENCY") { 3 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Reducing puma workers to 2 to see what effect it has on heroku R14 errors we're getting. See #998 

This pull request makes the following changes:
* Reduces puma workers from 3 to 2

It relates to the following issue #s: 
* Bumps #998
