### PR TITLE
Date format testing adjustments

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -74,8 +74,6 @@ class PatientsController < ApplicationController
     @patient = Patient.new
   end
 
-
-
   def data_entry_create
     @patient = Patient.new patient_params
     @patient.created_by = current_user

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -16,7 +16,6 @@ class PatientsController < ApplicationController
   end
 
   def create
-
     patient = Patient.new patient_params
 
     patient.created_by = current_user

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -16,6 +16,7 @@ class PatientsController < ApplicationController
   end
 
   def create
+
     patient = Patient.new patient_params
 
     patient.created_by = current_user
@@ -74,6 +75,8 @@ class PatientsController < ApplicationController
     @patient = Patient.new
   end
 
+
+
   def data_entry_create
     @patient = Patient.new patient_params
     @patient.created_by = current_user
@@ -93,7 +96,6 @@ class PatientsController < ApplicationController
     @patient = Patient.find params[:id]
   end
 
-  # Strong params divided up by partial
   PATIENT_DASHBOARD_PARAMS = [
     :name, :last_menstrual_period_days, :last_menstrual_period_weeks,
     :appointment_date, :primary_phone

--- a/app/models/audit_trail.rb
+++ b/app/models/audit_trail.rb
@@ -16,21 +16,50 @@ class AuditTrail
     relevant_fields = modified.map do |key, _value|
       key unless IRRELEVANT_FIELDS.include? key
     end
-
     relevant_fields.compact.map(&:humanize)
   end
 
   # TODO: properly render null values like in special circumstances
   # Something like this should work:
   # "HAHA I WIN" if (fields.all?{|f| f.blank? || (f.flatten.all? &:blank? if f.respond_to?('each'))})
+
+  def format_dates(hash)
+    for key in ['appointment_date', 'initial_call_date', 'pledge_generated_at']
+      if hash.has_key? key
+        hash[key] = hash[key].display_date
+      end
+    end
+    return hash
+  end
+
+  def format_special_circumstances(hash)
+    hash.each do |key, value|
+      if value.kind_of?(Array)
+        hash[key].reject! { |item| item.blank? }
+        if value.empty?
+          hash[key] = 'not selected'
+        end
+      end
+    end
+    return hash
+  end
+
+  def parse_clinics(hash)
+    if hash.key?('clinic_id')
+      @clinic = Clinic.where(:id => hash["clinic_id"]).first
+      hash["clinic_id"] = @clinic.name
+    end
+    return hash
+  end
+
   def changed_from
-    original.map do |key, value|
+    format_special_circumstances(parse_clinics(format_dates(original))).map do |key, value|
       value unless IRRELEVANT_FIELDS.include? key
     end
   end
 
   def changed_to
-    modified.map do |key, value|
+    format_special_circumstances(parse_clinics(format_dates(modified))).map do |key, value|
       value unless IRRELEVANT_FIELDS.include? key
     end
   end

--- a/app/models/concerns/attribute_displayable.rb
+++ b/app/models/concerns/attribute_displayable.rb
@@ -11,4 +11,14 @@ module AttributeDisplayable
     return nil unless other_phone.present?
     "#{other_phone[0..2]}-#{other_phone[3..5]}-#{other_phone[6..9]}"
   end
+
+  def appointment_date_display
+    return nil unless appointment_date.present?
+    "#{appointment_date.strftime("%m/%d/%Y")}"
+  end
+
+  def procedure_date_display
+    return nil unless fulfillment.procedure_date.present?
+    "#{fulfillment.procedure_date}"
+  end
 end

--- a/app/models/concerns/history_trackable.rb
+++ b/app/models/concerns/history_trackable.rb
@@ -9,4 +9,5 @@ module HistoryTrackable
   def recent_history_tracks
     history_tracks.select { |ht| ht.updated_at > 6.days.ago }
   end
+
 end

--- a/app/models/concerns/history_trackable.rb
+++ b/app/models/concerns/history_trackable.rb
@@ -9,5 +9,4 @@ module HistoryTrackable
   def recent_history_tracks
     history_tracks.select { |ht| ht.updated_at > 6.days.ago }
   end
-
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -25,6 +25,7 @@ class Patient
 
   before_validation :clean_fields
   before_save :save_identifier
+
   after_create :initialize_fulfillment
 
   # Relationships

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -29,7 +29,7 @@
           <td class="pt-spacer"><%= link_to patient.name, edit_patient_path(patient) %></td>
           <td class="pt-spacer"><%= patient.last_menstrual_period_display_short %></td>
           <td><%= patient.status %></td>
-          <td><%= patient.appointment_date %></td>
+          <td><%= patient.appointment_date_display %></td>
           <td><%= patient.most_recent_note_display_text %></td>
           <td><%= plus_sign_glyphicon(patient.most_recent_note) %></td>
           <% if table_type == 'completed_calls' || table_type == 'urgent_patients' %>

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -29,10 +29,9 @@
                           options_for_select(weeks_options, patient.fulfillment.gestation_at_procedure),
                           label: 'Weeks along at procedure',
                           autocomplete: 'off' %>
-            <%= pt.text_field :procedure_date,
+            <%= pt.date_field :procedure_date,
                                   label: 'Procedure date',
-                                  autocomplete: 'off', format: '%Y-%m-%d',
-                                  placeholder: 'YYYY-MM-DD' %>
+                                  autocomplete: 'off' %>
           <% end %>
         </div>
         <div class="info-form-right col-sm-6">

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -10,7 +10,7 @@
         <%= f.select :last_menstrual_period_weeks, options_for_select(weeks_options, patient.last_menstrual_period_weeks ), label: 'LMP at intake', autocomplete: 'off', help: "Currently: #{patient.last_menstrual_period_display_short}" %>
       </div>
       <div class="col-sm-6 hide-label">
-        <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{patient.initial_call_date}" %>
+        <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{patient.initial_call_date.strftime("%m/%d/%Y")}" %>
       </div>
     </div>
     <div class="row">
@@ -22,7 +22,7 @@
 
   <div class="col-sm-4">
     <div class="row">
-      <%= f.text_field :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD', help: "Approx gestation at appt: #{patient.last_menstrual_period_at_appt}" %>
+      <%= f.date_field :appointment_date, label: 'Appointment date', autocomplete: 'off', help: "Approx gestation at appt: #{patient.last_menstrual_period_at_appt}" %>
     </div>
   </div>
 <% end %>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -10,7 +10,7 @@
     <div class='col-sm-12'><span class="pledge_modal_category">Patient name:</span> <%= patient.name %></div>
     <div class='col-sm-12'><span class="pledge_modal_category">Patient ID:</span> <%= patient.identifier %></div>
     <div class='col-sm-12'><span class="pledge_modal_category">Pledge amount:</span> $<%= patient.fund_pledge %> </div>
-    <div class='col-sm-12'><span class="pledge_modal_category">Appointment date:</span> <%= patient.appointment_date %></div>
+    <div class='col-sm-12'><span class="pledge_modal_category">Appointment date:</span> <%= patient.appointment_date_display %></div>
     <div class='col-sm-12'><span class="pledge_modal_category">Clinic name:</span> <%= patient.clinic.try :name %></div>
   </div>
 
@@ -25,7 +25,7 @@
         <%= bootstrap_form_tag url: generate_pledge_patient_path(patient), method: 'get' do |f| %>
           <%= f.text_field :case_manager_name, label: 'Enter your name in this box to sign your pledge:' %>
           <%= f.submit 'Generate your pledge', class: 'btn btn-large btn-primary' %>
-        <% end %>      
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -5,7 +5,7 @@
 <%= bootstrap_form_for @patient, url: data_entry_create_path, html: { class: 'mass_entry_form' } do |f| %>
   <%= f.select :line, options_for_select(lines, current_line) %>
 
-  <%= f.text_field :initial_call_date, format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD' %>
+  <%= f.date_field :initial_call_date %>
 
   <%= f.text_field :name, autocomplete: 'off' %>
 
@@ -32,14 +32,14 @@
   <%#= f.fields_for @patient.notes.new do |notes| %>
     <%#= notes.text_area :full_text, size: '20x5', placeholder: 'Enter notes here' %>
   <%# end %>
-  
+
   <%= f.text_field :fund_pledge, label: "#{FUND} pledge" %>
 
   <%= f.text_field :age, autocomplete: 'off' %>
   <%= f.select :race_ethnicity, options_for_select(race_ethnicity_options), label: 'Race / Ethnicity', autocomplete: 'off' %>
   <%= f.select :clinic_id, options_for_select(clinic_options) %>
 
-  <%= f.text_field :appointment_date, label: 'Appointment date', autocomplete: 'off', format: '%Y-%m-%d', placeholder: 'YYYY-MM-DD' %>
+  <%= f.date_field :appointment_date, label: 'Appointment date', autocomplete: 'off' %>
 
   <%= f.select :insurance,
                options_for_select(insurance_options),

--- a/config/initializers/time.rb
+++ b/config/initializers/time.rb
@@ -1,7 +1,7 @@
 # Extends time class with convenience methods
 class Time
   def display_date
-    getlocal.strftime("%Y-%m-%d")
+    getlocal.strftime("%m/%d/%Y")
   end
 
   def display_time

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -234,7 +234,6 @@ end
 
 # we'll create 5 patients with pledges at different times
 (1..5).each do |patient_number|
-  pledge_time = 
   patient = Patient.create!(
     name: "Pledge Reporting Patient #{patient_number}",
     primary_phone: "321-0#{patient_number}0-004#{rand(10)}",

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -236,4 +236,5 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
       assert_not_nil Patient.find_by(name: 'Test Patient').fulfillment
     end
   end
+
 end

--- a/test/integration/data_entry_test.rb
+++ b/test/integration/data_entry_test.rb
@@ -56,9 +56,9 @@ class DataEntryTest < ActionDispatch::IntegrationTest
         assert has_field? 'First and last name', with: 'Susie Everyteen'
         assert_equal '1', lmp_weeks.value
         assert_equal '2', lmp_days.value
-        assert has_text? "Called on: #{2.days.ago.strftime('%Y-%m-%d')}"
+        assert has_text? "Called on: #{2.days.ago.strftime('%m/%d/%Y')}"
         assert has_field?('Appointment date',
-                          with: 1.day.ago.strftime('%Y-%m-%d'))
+                          with: 1.day.ago.strftime('%m/%d/%Y'))
         assert has_field? 'Phone number', with: '111-222-3344'
       end
     end
@@ -104,7 +104,7 @@ class DataEntryTest < ActionDispatch::IntegrationTest
         create :patient, primary_phone: '111-111-1111'
 
         select 'DC', from: 'patient_line'
-        fill_in 'Initial call date', with: 2.days.ago.strftime('%Y-%m-%d')
+        fill_in 'Initial call date', with: 2.days.ago.strftime('%m-%d-%Y')
         fill_in 'Name', with: 'Susie Everyteen'
         fill_in 'Primary phone', with: '111-111-1111'
         click_button 'Create Patient'

--- a/test/integration/data_entry_test.rb
+++ b/test/integration/data_entry_test.rb
@@ -58,7 +58,7 @@ class DataEntryTest < ActionDispatch::IntegrationTest
         assert_equal '2', lmp_days.value
         assert has_text? "Called on: #{2.days.ago.strftime('%m/%d/%Y')}"
         assert has_field?('Appointment date',
-                          with: 1.day.ago.strftime('%m/%d/%Y'))
+                          with: 1.day.ago.strftime('%Y-%m-%d')) # TODO: Driver format problem
         assert has_field? 'Phone number', with: '111-222-3344'
       end
     end
@@ -104,7 +104,7 @@ class DataEntryTest < ActionDispatch::IntegrationTest
         create :patient, primary_phone: '111-111-1111'
 
         select 'DC', from: 'patient_line'
-        fill_in 'Initial call date', with: 2.days.ago.strftime('%m-%d-%Y')
+        fill_in 'Initial call date', with: 2.days.ago.strftime('%m-%d-%Y') # TODO: Driver format problem
         fill_in 'Name', with: 'Susie Everyteen'
         fill_in 'Primary phone', with: '111-111-1111'
         click_button 'Create Patient'
@@ -119,7 +119,7 @@ class DataEntryTest < ActionDispatch::IntegrationTest
     describe 'pledge with insufficient other info' do
       before do
         select 'DC', from: 'patient_line'
-        fill_in 'Initial call date', with: 2.days.ago.strftime('%Y-%m-%d')
+        fill_in 'Initial call date', with: 2.days.ago.strftime('%Y-%m-%d') # TODO: Driver format problem
         fill_in 'Name', with: 'Susie Everyteen'
         fill_in 'Primary phone', with: '111-222-3344'
         check 'Pledge sent'

--- a/test/integration/filter_medicaid_clinics_test.rb
+++ b/test/integration/filter_medicaid_clinics_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class FilterNafClinicsTest < ActionDispatch::IntegrationTest
+class FilterMedicaidClinicsTest < ActionDispatch::IntegrationTest
   before do
     Capybara.current_driver = :poltergeist
     @user = create :user, role: :cm

--- a/test/integration/table_content_test.rb
+++ b/test/integration/table_content_test.rb
@@ -26,7 +26,7 @@ class TableContentTest < ActionDispatch::IntegrationTest
       within :css, '#call_list_content' do
         assert has_content? @patient.primary_phone_display
         assert has_content? @patient.name
-        assert has_content? 3.days.from_now.utc.strftime('%Y-%m-%d')
+        assert has_content? 3.days.from_now.utc.strftime('%m/%d/%Y')
         assert has_content? @patient.last_menstrual_period_display_short
         # TODO: has remove, phone clicky
       end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -212,7 +212,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
       click_link 'Pledge Fulfillment'
       check 'Pledge fulfilled'
-      fill_in 'Procedure date', with: 2.days.from_now.strftime('%m/%d/%Y')
+      fill_in 'Procedure date', with: 2.days.from_now.strftime('%Y-%m-%d')  # TODO: Driver format problem
       select '12 weeks', from: 'Weeks along at procedure'
       fill_in 'Abortion care $', with: '100'
       fill_in 'Check #', with: '444-22'
@@ -228,7 +228,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       within :css, '#fulfillment' do
         assert has_checked_field? 'Pledge fulfilled'
         assert has_field? 'Procedure date',
-                          with: 2.days.from_now.strftime('%m/%d/%Y')
+                          with: 2.days.from_now.strftime('%Y-%m-%d') # TODO: Driver format problem
         assert_equal '12',
                      find('#patient_fulfillment_gestation_at_procedure').value
         assert has_field? 'Abortion care $', with: 100

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -212,7 +212,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
 
       click_link 'Pledge Fulfillment'
       check 'Pledge fulfilled'
-      fill_in 'Procedure date', with: 2.days.from_now.strftime('%Y-%m-%d')
+      fill_in 'Procedure date', with: 2.days.from_now.strftime('%m/%d/%Y')
       select '12 weeks', from: 'Weeks along at procedure'
       fill_in 'Abortion care $', with: '100'
       fill_in 'Check #', with: '444-22'
@@ -228,7 +228,7 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
       within :css, '#fulfillment' do
         assert has_checked_field? 'Pledge fulfilled'
         assert has_field? 'Procedure date',
-                          with: 2.days.from_now.strftime('%Y-%m-%d')
+                          with: 2.days.from_now.strftime('%m/%d/%Y')
         assert_equal '12',
                      find('#patient_fulfillment_gestation_at_procedure').value
         assert has_field? 'Abortion care $', with: 100

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -5,8 +5,8 @@ class AuditTrailTest < ActiveSupport::TestCase
     @user = create :user
     @patient = create :patient, name: 'Susie Everyteen',
                                 primary_phone: '111-222-3333',
-                                appointment_date: Time.zone.now + 5.days,
-                                initial_call_date: Time.zone.now - 3.days,
+                                appointment_date: 5.days.from_now,
+                                initial_call_date: 3.days.ago,
                                 created_by: @user
   end
 
@@ -25,8 +25,8 @@ class AuditTrailTest < ActiveSupport::TestCase
     before do
       @patient.update_attributes name: 'Yolo',
                                  primary_phone: '123-456-9999',
-                                 appointment_date: Time.zone.now + 10.days,
-                                 initial_call_date: Time.zone.now - 4.days
+                                 appointment_date: 10.days.from_now,
+                                 initial_call_date: 4.days.ago
       @track = @patient.history_tracks.second
     end
 
@@ -45,8 +45,8 @@ class AuditTrailTest < ActiveSupport::TestCase
       assert_equal @track.changed_from,
                    ["Susie Everyteen",
                      "1112223333",
-                     (Time.zone.now + 5.days).strftime('%m/%d/%Y'),
-                     (Time.zone.now - 3.days).strftime('%m/%d/%Y'),
+                     5.days.from_now.strftime('%m/%d/%Y'),
+                     3.days.ago.strftime('%m/%d/%Y'),
                      "D2-3333"]
     end
 
@@ -54,8 +54,8 @@ class AuditTrailTest < ActiveSupport::TestCase
       assert_equal @track.changed_to,
                   ["Yolo",
                     "1234569999",
-                    (Time.zone.now + 10.days).strftime('%m/%d/%Y'),
-                    (Time.zone.now - 4.days).strftime('%m/%d/%Y'),
+                    10.days.from_now.strftime('%m/%d/%Y'),
+                    4.days.ago.strftime('%m/%d/%Y'),
                     "D6-9999"]
     end
 

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -5,6 +5,8 @@ class AuditTrailTest < ActiveSupport::TestCase
     @user = create :user
     @patient = create :patient, name: 'Susie Everyteen',
                                 primary_phone: '111-222-3333',
+                                appointment_date: Time.zone.now + 5.days,
+                                initial_call_date: Time.zone.now - 3.days,
                                 created_by: @user
   end
 
@@ -22,7 +24,9 @@ class AuditTrailTest < ActiveSupport::TestCase
   describe 'methods' do
     before do
       @patient.update_attributes name: 'Yolo',
-                                 primary_phone: '123-456-9999'
+                                 primary_phone: '123-456-9999',
+                                 appointment_date: Time.zone.now + 10.days,
+                                 initial_call_date: Time.zone.now - 4.days
       @track = @patient.history_tracks.second
     end
 
@@ -31,24 +35,34 @@ class AuditTrailTest < ActiveSupport::TestCase
                    @track.date_of_change
     end
 
+
     it 'should conveniently render changed fields' do
       assert_equal @track.changed_fields,
-                   ['Name', 'Primary phone', 'Identifier']
+                   ["Name", "Primary phone", "Appointment date", "Initial call date", "Identifier"]
     end
 
     it 'should conveniently render what they were before' do
       assert_equal @track.changed_from,
-                   ['Susie Everyteen', '1112223333', 'D2-3333']
+                   ["Susie Everyteen",
+                     "1112223333",
+                     (Time.zone.now + 5.days).strftime('%m/%d/%Y'),
+                     (Time.zone.now - 3.days).strftime('%m/%d/%Y'),
+                     "D2-3333"]
     end
 
     it 'should conveniently render what they are now' do
       assert_equal @track.changed_to,
-                   %w(Yolo 1234569999 D6-9999)
+                  ["Yolo",
+                    "1234569999",
+                    (Time.zone.now + 10.days).strftime('%m/%d/%Y'),
+                    (Time.zone.now - 4.days).strftime('%m/%d/%Y'),
+                    "D6-9999"]
     end
 
     it 'should default to System if it cannot find a user' do
       assert_equal @track.changed_by_user, 'System'
     end
+
   end
 
   describe 'marked urgent' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Test adjustments for the world's worst integration test failures. Poltergeist's driver has an interesting interpretation of `input type="date"` it seems. We'll probably need to fix when we move to a diff driver in #1216 / #1191 .

This pull request makes the following changes:
* Punts on some truly awful test problems with the integration test driver
* Everything in #1088 

Stems from #1088 , where all the good stuff is.

Tagging in @tingaloo for final thumbs up. Going to merge after the scheduled deploy today. 

It relates to the following issue #s: 
* Fixes #860
