### PR TITLE
View dupe bug

### DIFF
--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -1,4 +1,4 @@
-<section id="abortion_information" class="abortion-info tab-pane">
+<section id="abortion_information_content">
   <div id="patient_fields" class="col-sm-12">
     <div class="row">
       <div class="col-sm-12">

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -1,4 +1,4 @@
-<section id="call_log" class="call-info tab-pane">
+<section id="call_log_content">
   <div class="margin-bottom col-sm-12">
     <h2>
       Call Log

--- a/app/views/patients/_change_log.html.erb
+++ b/app/views/patients/_change_log.html.erb
@@ -1,4 +1,4 @@
-<section id="change_log" class="abortion-info tab-pane">
+<section id="change_log_content">
   <div class="col-sm-12">
     <h2>Patient history</h2>
     <table class="table border-side">

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -1,4 +1,4 @@
-<section id="fulfillment" class="abortion-info tab-pane">
+<section id="fulfillment_content">
   <%= bootstrap_form_for patient, html: { id: 'fulfillment_form' }, remote: true do |f| %>
   <%# bootstrap_form_for @fulfillment, html: { id: 'fulfillment_form' }, remote: true do |f| %>
     <div class="col-sm-12">

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -1,4 +1,4 @@
-<section id="notes" class="notes tab-pane">
+<section id="notes_content">
   <div class="col-sm-12 margin-bottom-sm">
     <div class="row">
 			<%= bootstrap_form_for [patient, note], html: { id: 'notes-form' }, remote: true do |f| %>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -1,28 +1,30 @@
-<%= bootstrap_form_for patient, html: { id: 'patient_dashboard_form' }, remote: true do |f| %>
-  <div class="col-sm-4" >
-    <%= f.text_field :name, label: 'First and last name', autocomplete: 'off' %>
-    <%= f.text_field :primary_phone, value: patient.primary_phone_display, label: 'Phone number', autocomplete: 'off' %>
-  </div>
+<div id="patient_dashboard_content">
+  <%= bootstrap_form_for patient, html: { id: 'patient_dashboard_form' }, remote: true do |f| %>
+    <div class="col-sm-4" >
+      <%= f.text_field :name, label: 'First and last name', autocomplete: 'off' %>
+      <%= f.text_field :primary_phone, value: patient.primary_phone_display, label: 'Phone number', autocomplete: 'off' %>
+    </div>
 
-  <div class="col-sm-4">
-    <div class="row">
-      <div class="col-sm-6">
-        <%= f.select :last_menstrual_period_weeks, options_for_select(weeks_options, patient.last_menstrual_period_weeks ), label: 'LMP at intake', autocomplete: 'off', help: "Currently: #{patient.last_menstrual_period_display_short}" %>
+    <div class="col-sm-4">
+      <div class="row">
+        <div class="col-sm-6">
+          <%= f.select :last_menstrual_period_weeks, options_for_select(weeks_options, patient.last_menstrual_period_weeks ), label: 'LMP at intake', autocomplete: 'off', help: "Currently: #{patient.last_menstrual_period_display_short}" %>
+        </div>
+        <div class="col-sm-6 hide-label">
+          <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{patient.initial_call_date.strftime("%m/%d/%Y")}" %>
+        </div>
       </div>
-      <div class="col-sm-6 hide-label">
-        <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), label: '.', autocomplete: 'off', help: "Called on: #{patient.initial_call_date.strftime("%m/%d/%Y")}" %>
+      <div class="row">
+        <div class="col-sm-12">
+          <p><strong>Status:</strong> <span id='patient_status'><%= patient.status %></span></p>
+        </div>
       </div>
     </div>
-    <div class="row">
-      <div class="col-sm-12">
-        <p><strong>Status:</strong> <span id='patient_status'><%= patient.status %></span></p>
-      </div>
-    </div>
-  </div>
 
-  <div class="col-sm-4">
-    <div class="row">
-      <%= f.date_field :appointment_date, label: 'Appointment date', autocomplete: 'off', help: "Approx gestation at appt: #{patient.last_menstrual_period_at_appt}" %>
+    <div class="col-sm-4">
+      <div class="row">
+        <%= f.date_field :appointment_date, label: 'Appointment date', autocomplete: 'off', help: "Approx gestation at appt: #{patient.last_menstrual_period_at_appt}" %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -1,4 +1,4 @@
-<section id="patient_information" class="abortion-info tab-pane active">
+<section id="patient_information_content">
   <%= bootstrap_form_for patient, html: { id: 'patient_information_form' }, remote: true do |f| %>
     <div class="col-sm-12">
       <div class="row">

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -1,7 +1,4 @@
-<!-- Patient Info -->
-
 <%= render partial: "patients/modal" %>
-
 
 <div id="patient_dashboard" class="row">
   <%= render 'patients/patient_dashboard', patient: @patient %>
@@ -15,13 +12,30 @@
   </div>
 
   <div id="sections" class="col-sm-9 tab-content">
-    <%= render 'patients/abortion_information', patient: @patient, new_external_pledge: @external_pledge %>
-    <%= render 'patients/patient_information', patient: @patient %>
-    <%= render 'patients/change_log', patient: @patient %>
-    <%= render 'patients/call_log', patient: @patient %>
-    <%= render 'patients/notes', patient: @patient, note: @note %>
+    <div id="abortion_information" class="abortion-info tab-pane">
+      <%= render 'patients/abortion_information', patient: @patient, new_external_pledge: @external_pledge %>      
+    </div>
+
+    <div id="patient_information" class="patient-info tab-pane active">
+      <%= render 'patients/patient_information', patient: @patient %>    
+    </div>
+
+    <div id="change_log" class="change-log tab-pane">
+      <%= render 'patients/change_log', patient: @patient %>      
+    </div>
+
+    <div id="call_log" class="call-info tab-pane">
+      <%= render 'patients/call_log', patient: @patient %>    
+    </div>
+
+    <div id="notes" class="notes tab-pane">
+      <%= render 'patients/notes', patient: @patient, note: @note %>    
+    </div>
+
     <% if ( current_user.admin? || current_user.data_volunteer? ) && @patient.pledge_sent == true %>
-      <%= render 'patients/fulfillment', patient: @patient %>
+      <div id="fulfillment" class="fulfillment-info tab-pane">
+        <%= render 'patients/fulfillment', patient: @patient %>      
+      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Patient update was emptying out divs with particular ids and then repopulating, causing all sorts of mess to happen. This fixes that.

This pull request makes the following changes:
* patient partials now populate inner content instead of emptying out the div and then putting in another div with the same id

No real changes to the view, just some rearranging ids. 

@tingaloo for review

It relates to the following issue #s: 
* Bumps #1141 ... kinda.
