### PR TITLE
Make integration tests more integration test-y

### DIFF
--- a/test/integration/change_log_test.rb
+++ b/test/integration/change_log_test.rb
@@ -4,14 +4,13 @@ class ChangeLogTest < ActionDispatch::IntegrationTest
   before do
     Capybara.current_driver = :poltergeist
     @user = create :user, email: 'first_user@email.com'
-    @user2 = create :user, email: 'second_user@email.com'
-    log_in_as @user
     @patient = create :patient, name: 'tester',
                                 primary_phone: '1231231234',
-                                created_by: @user2
+                                created_by: @user,
+                                city: 'Washington'
 
+    log_in_as @user
     visit edit_patient_path(@patient)
-    fill_in 'City', with: 'Washington'
   end
 
   after do
@@ -20,8 +19,9 @@ class ChangeLogTest < ActionDispatch::IntegrationTest
 
   describe 'viewing the changelog' do
     it 'should log patient accessibly' do
-      fill_in 'City', with: 'Washington'
-      visit edit_patient_path(@patient)
+      fill_in 'City', with: 'Canada'
+      click_away_from_field
+
       wait_for_element 'Change Log'
       click_link 'Change Log'
       wait_for_element 'Patient history'
@@ -29,7 +29,7 @@ class ChangeLogTest < ActionDispatch::IntegrationTest
       within :css, '#change_log' do
         assert has_text? Time.zone.now.display_date
         assert has_text? 'City'
-        assert has_text? 'Washington'
+        assert has_text? 'Canada'
         assert has_text? @user.name
       end
     end

--- a/test/integration/create_new_external_pledge_test.rb
+++ b/test/integration/create_new_external_pledge_test.rb
@@ -18,10 +18,6 @@ class CreateNewExternalPledgeTest < ActionDispatch::IntegrationTest
       select 'Clinic discount', from: 'Source'
       fill_in 'Amount', with: '30000'
       click_button 'Create External pledge'
-      wait_for_element 'Patient Information'
-      click_link 'Abortion Information'
-      wait_for_element 'Abortion information'
-
       assert has_field? 'Clinic discount pledge', with: '30000'
     end
   end

--- a/test/integration/create_user_test.rb
+++ b/test/integration/create_user_test.rb
@@ -38,8 +38,8 @@ class CreateUserTest < ActionDispatch::IntegrationTest
       assert has_field? 'Name'
       fill_in 'Name', with: 'Test User'
 
-      click_link 'Test User'
-      assert has_content? 'Status: Active'
+      click_button 'Add'
+      assert has_content? 'Active', count: 2
     end
 
     it 'should validate form correctly' do

--- a/test/integration/create_user_test.rb
+++ b/test/integration/create_user_test.rb
@@ -26,29 +26,20 @@ class CreateUserTest < ActionDispatch::IntegrationTest
     end
 
     it 'should be able to create user' do
-      assert_difference('User.count', 1) do
-        click_link 'Admin'
-        assert_text 'User Management'
-        click_link 'User Management'
-        wait_for_element 'User Account Management'
-        click_link 'Add New User'
+      click_link 'Admin'
+      assert_text 'User Management'
+      click_link 'User Management'
+      wait_for_element 'User Account Management'
+      click_link 'Add New User'
 
-        assert has_field? 'Email'
-        fill_in 'Email', with: 'test@test.com'
+      assert has_field? 'Email'
+      fill_in 'Email', with: 'test@test.com'
 
-        assert has_field? 'Name'
-        fill_in 'Name', with: 'Test User'
+      assert has_field? 'Name'
+      fill_in 'Name', with: 'Test User'
 
-        UserMailer.stub(:account_created, @mail_mock) do
-          click_button 'Add'
-          wait_for_element 'User created!'
-        end
-        assert @mail_mock.verify
-      end
-
-      user = User.find_by(email: 'test@test.com')
-      assert_not_nil user
-      assert_equal user.name, 'Test User'
+      click_link 'Test User'
+      assert has_content? 'Status: Active'
     end
 
     it 'should validate form correctly' do

--- a/test/integration/filter_naf_clinics_test.rb
+++ b/test/integration/filter_naf_clinics_test.rb
@@ -23,8 +23,8 @@ class FilterNafClinicsTest < ActionDispatch::IntegrationTest
       options_with_filter = find('#patient_clinic_id').all('option')
                                                       .map { |opt| { name: opt.text, disabled: opt['disabled'] } }
 
-      assert options_with_filter.find { |x| x[:name] == @nonnaf_clinic.name }[:disabled] == true
-      assert options_with_filter.find { |x| x[:name] == @naf_clinic.name }[:disabled] == false
+      assert options_with_filter.find { |x| x[:name] == @nonnaf_clinic.name }[:disabled] == 'true'
+      assert options_with_filter.find { |x| x[:name] == @naf_clinic.name }[:disabled] == nil
 
       # try to select and watch it not work
       select @nonnaf_clinic.name, from: 'patient_clinic_id'

--- a/test/integration/filter_naf_clinics_test.rb
+++ b/test/integration/filter_naf_clinics_test.rb
@@ -23,8 +23,8 @@ class FilterNafClinicsTest < ActionDispatch::IntegrationTest
       options_with_filter = find('#patient_clinic_id').all('option')
                                                       .map { |opt| { name: opt.text, disabled: opt['disabled'] } }
 
-      assert options_with_filter.find { |x| x[:name] == @nonnaf_clinic.name }[:disabled] == 'true'
-      assert options_with_filter.find { |x| x[:name] == @naf_clinic.name }[:disabled] == nil
+      assert options_with_filter.find { |x| x[:name] == @nonnaf_clinic.name }[:disabled] == true
+      assert options_with_filter.find { |x| x[:name] == @naf_clinic.name }[:disabled] == false
 
       # try to select and watch it not work
       select @nonnaf_clinic.name, from: 'patient_clinic_id'

--- a/test/integration/new_patient_creation_test.rb
+++ b/test/integration/new_patient_creation_test.rb
@@ -19,7 +19,7 @@ class NewPatientCreationTest < ActionDispatch::IntegrationTest
       fill_in 'Name', with: 'Susan Everyteen 2'
       fill_in 'Initial Call Date', with: '03/04/2016'
       select 'MD', from: 'Line'
-      find('button', text: /Add new patient/).trigger('click')
+      click_button 'Add new patient'
       sleep 1
     end
 
@@ -58,6 +58,7 @@ class NewPatientCreationTest < ActionDispatch::IntegrationTest
         fill_in 'search', with: 'Susan Everyteen 2'
         click_button 'Search'
         refute has_text? '555-666-7777'
+        assert has_text? 'Your search produced no results'
       end
     end
   end

--- a/test/integration/pledge_fulfillment_test.rb
+++ b/test/integration/pledge_fulfillment_test.rb
@@ -96,6 +96,7 @@ class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
 
     it 'should autocheck on field change' do
       fill_in 'patient_fulfillment_procedure_cost', with: '10'
+      click_away_from_field
       assert has_checked_field? 'Pledge fulfilled'
     end
 
@@ -113,8 +114,6 @@ class PledgeFulfillmentTest < ActionDispatch::IntegrationTest
       fill_in 'patient_fulfillment_procedure_date', with: ''
       select '', from: "patient_fulfillment_gestation_at_procedure"
       assert has_no_checked_field? 'Pledge fulfilled'
-
     end
-
   end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -256,10 +256,4 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
     visit edit_patient_path @patient
     click_link link_text
   end
-
-  def click_away_from_field
-    find("body").click
-    fill_in 'First and last name', with: nil
-    wait_for_ajax
-  end
 end

--- a/test/integration/update_patient_info_test.rb
+++ b/test/integration/update_patient_info_test.rb
@@ -15,7 +15,6 @@ class UpdatePatientInfoTest < ActionDispatch::IntegrationTest
     log_in_as @user
     visit edit_patient_path @patient
     has_text? 'First and last name' # wait until page loads
-    page.driver.resize(2000, 2000)
   end
 
   after { Capybara.use_default_driver }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,6 +112,12 @@ class ActionDispatch::IntegrationTest
   def go_to_dashboard
     click_link "DARIA - #{(ENV['FUND'] ? ENV['FUND'] : Rails.env)}"
   end
+
+  def click_away_from_field
+    find('body').click
+    fill_in 'First and last name', with: nil
+    wait_for_ajax
+  end
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Rails 5.1 may be a real mess of a conversion but I'm not going to let it be a complete bust. Here are some improvements to the integration tests to make them more integration test-y.

This pull request makes the following changes:
* Makes integration tests marginally better

It relates to the following issue #s: 
* Bumps #1167 , in a sense
