### PR TITLE
Shape frontend for events stream

### DIFF
--- a/app/assets/javascripts/events.coffee
+++ b/app/assets/javascripts/events.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -12,3 +12,8 @@ $daria-color: #5D3E8D;
   border-radius: 50%;
   font-size: 12px;
 }
+
+#event-data {
+  height: 300px;
+  overflow: auto;
+}

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,3 +1,14 @@
 // Place all the styles related to the events controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+$daria-color: #5D3E8D;
+
+.event-item {
+  color: white;
+  background-color: $daria-color;
+  vertical-align: top;
+  padding: 5px;
+  border-radius: 50%;
+  font-size: 12px;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,2 @@
+class EventsController < ApplicationController
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,12 @@
+# For render
 class EventsController < ApplicationController
+  def index
+    @events = Event.all.order_by(created_at: :desc)
+                   # .where(line: current_user.line)
+                   
+                   # .includes(:user, :patient)
+
+    render partial: 'events/events'
+    # respond_to { |format| format.js }
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,11 +3,9 @@ class EventsController < ApplicationController
   include LinesHelper
 
   def index
-    puts current_line
     @events = Event.where(line: current_line)
                    .order_by(created_at: :desc)
 
     render partial: 'events/events'
-    # respond_to { |format| format.js }
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,10 +1,11 @@
 # For render
 class EventsController < ApplicationController
+  include LinesHelper
+
   def index
-    @events = Event.all.order_by(created_at: :desc)
-                   # .where(line: current_user.line)
-                   
-                   # .includes(:user, :patient)
+    puts current_line
+    @events = Event.where(line: current_line)
+                   .order_by(created_at: :desc)
 
     render partial: 'events/events'
     # respond_to { |format| format.js }

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,7 +1,16 @@
 module EventsHelper
   def display_event(event)
-    # glyphicon = content_tag :span, class: "glyphicon glyphicon-#{event.glyphicon}"
-    # safe_join [glyphicon, event.to_log_entry], ' '
-    event.to_log_entry
+    safe_join [
+      # TODO style this so it isn't the same as he regular call buttons
+      tag(:span, class: ['glyphicon', "glyphicon-#{event.glyphicon}"]),
+      log_entry(event)
+    ], ' '
+  end
+
+  def log_entry(event)
+    time = "#{event.created_at.display_date} #{event.created_at.display_time}"
+    str = "-- #{event.cm_name} #{event.event_text}"
+    link = link_to event.patient_name, edit_patient_path(event.patient_id)
+    safe_join [time, str, link], ' '
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,7 +1,6 @@
 module EventsHelper
   def display_event(event)
     safe_join [
-      # TODO style this so it isn't the same as he regular call buttons
       tag(:span, class: ['glyphicon', "glyphicon-#{event.glyphicon}", 'event-item']),
       log_entry(event)
     ], ' '

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,2 +1,7 @@
 module EventsHelper
+  def display_event(event)
+    # glyphicon = content_tag :span, class: "glyphicon glyphicon-#{event.glyphicon}"
+    # safe_join [glyphicon, event.to_log_entry], ' '
+    event.to_log_entry
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -7,7 +7,7 @@ module EventsHelper
   end
 
   def log_entry(event)
-    time = "#{event.created_at.display_date} #{event.created_at.display_time}"
+    time = "#{event.created_at.display_time}"
     str = "-- #{event.cm_name} #{event.event_text}"
     pt_link = link_to "#{event.patient_name}.", edit_patient_path(event.patient_id)
     add_link = link_to '(Add to call list)', add_patient_path(current_user, event.patient_id), method: :patch, remote: true

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -9,7 +9,9 @@ module EventsHelper
   def log_entry(event)
     time = "#{event.created_at.display_date} #{event.created_at.display_time}"
     str = "-- #{event.cm_name} #{event.event_text}"
-    link = link_to event.patient_name, edit_patient_path(event.patient_id)
-    safe_join [time, str, link], ' '
+    pt_link = link_to "#{event.patient_name}.", edit_patient_path(event.patient_id)
+    add_link = link_to '(Add to call list)', add_patient_path(current_user, event.patient_id), method: :patch, remote: true
+
+    safe_join [time, str, pt_link, add_link], ' '
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -2,7 +2,7 @@ module EventsHelper
   def display_event(event)
     safe_join [
       # TODO style this so it isn't the same as he regular call buttons
-      tag(:span, class: ['glyphicon', "glyphicon-#{event.glyphicon}"]),
+      tag(:span, class: ['glyphicon', "glyphicon-#{event.glyphicon}", 'event-item']),
       log_entry(event)
     ], ' '
   end

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -39,7 +39,7 @@ class Call
   def event_params
     {
       event_type:   status,
-      cm_name:      created_by.name,
+      cm_name:      created_by&.name || 'System',
       patient_name: patient.name,
       patient_id:   patient.id,
       line:         patient.line

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -39,9 +39,10 @@ class Call
   def event_params
     {
       event_type:   status,
-      cm_name:      created_by_id,
+      cm_name:      created_by.name,
       patient_name: patient.name,
-      patient_id:   patient.id
+      patient_id:   patient.id,
+      line:         patient.line
     }
   end
 end

--- a/app/models/concerns/event_loggable.rb
+++ b/app/models/concerns/event_loggable.rb
@@ -18,7 +18,7 @@ module EventLoggable
     is_a? Call
   end
 
-  def pledge_was_sent
-    is_a?(Patient) && previous_changes[:pledge_sent].second == true
+  def pledge_was_sent?
+    is_a?(Patient) && pledge_sent_changed? && pledge_sent
   end
 end

--- a/app/models/concerns/event_loggable.rb
+++ b/app/models/concerns/event_loggable.rb
@@ -19,6 +19,6 @@ module EventLoggable
   end
 
   def pledge_was_sent?
-    is_a?(Patient) && pledge_sent_changed? && pledge_sent
+    is_a?(Patient) && pledge_sent_changed? && pledge_sent?
   end
 end

--- a/app/models/concerns/event_loggable.rb
+++ b/app/models/concerns/event_loggable.rb
@@ -3,10 +3,22 @@ module EventLoggable
   extend ActiveSupport::Concern
 
   included do
-    after_create -> { log_event(event_params) }
+    after_create -> { log_event(event_params) }, if: :call?
+
+    after_save -> { log_event(event_params) }, if: :pledge_was_sent?
   end
 
   def log_event(params = {})
     Event.create!(params)
+  end
+
+  private
+
+  def call?
+    is_a? Call
+  end
+
+  def pledge_was_sent
+    is_a?(Patient) && previous_changes[:pledge_sent].second == true
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -46,6 +46,12 @@ class Event
     end
   end
 
+  # Clean events older than three weeks
+  def self.destroy_old_events
+    Event.where(:created_at.lte => 3.weeks.ago)
+         .destroy_all
+  end
+
   private
 
   def pledged_type?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,6 +21,7 @@ class Event
   enumerize :line, in: LINES, default: LINES[0]
   field :patient_name, type: String
   field :patient_id, type: String
+  field :pledge_amount, type: Integer
 
   # Validations
   validates :event_type, inclusion: { in: EVENT_TYPES }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,7 +25,8 @@ class Event
 
   # Validations
   validates :event_type, inclusion: { in: EVENT_TYPES }
-  validates :cm_name, :patient_name, :patient_id, presence: true
+  validates :cm_name, :patient_name, :patient_id, :line, presence: true
+  validates :pledge_amount, presence: true, if: :pledged_type?
 
   def glyphicon
     return 'usd' if event_type == 'Pledged'
@@ -43,5 +44,11 @@ class Event
     when 'Reached patient'
       'called and reached'
     end
+  end
+
+  private
+
+  def pledged_type?
+    event_type == 'Pledged'
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -29,8 +29,14 @@ class Event
   validates :pledge_amount, presence: true, if: :pledged_type?
 
   def glyphicon
-    return 'thumbs-up' if event_type == 'Pledged'
-    'earphone'
+    case event_type
+    when 'Pledged'
+      'thumbs-up'
+    when 'Reached patient'
+      'comment'
+    else
+      'earphone'
+    end
   end
 
   def event_text

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -26,16 +26,10 @@ class Event
   validates :event_type, inclusion: { in: EVENT_TYPES }
   validates :cm_name, :patient_name, :patient_id, presence: true
 
-  def to_log_entry
-    "#{created_at.display_date} #{created_at.display_time} - #{cm_name} #{event_text} #{patient_name}"
-  end
-
   def glyphicon
     'usd' if event_type == 'Pledged'
-    'earpiece'
+    'earphone'
   end
-
-  private
 
   def event_text
     case event_type

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,14 +28,14 @@ class Event
   validates :cm_name, :patient_name, :patient_id, presence: true
 
   def glyphicon
-    'usd' if event_type == 'Pledged'
+    return 'usd' if event_type == 'Pledged'
     'earphone'
   end
 
   def event_text
     case event_type
     when 'Pledged'
-      'sent a pledge to'
+      "sent a $#{pledge_amount} pledge for"
     when 'Left voicemail'
       'left a voicemail for'
     when "Couldn't reach patient"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,4 +25,28 @@ class Event
   # Validations
   validates :event_type, inclusion: { in: EVENT_TYPES }
   validates :cm_name, :patient_name, :patient_id, presence: true
+
+  def to_log_entry
+    "#{created_at.display_date} #{created_at.display_time} - #{cm_name} #{event_text} #{patient_name}"
+  end
+
+  private
+
+  def event_text
+    case event_type
+    when 'Pledged'
+      'sent a pledge to'
+    when 'Left voicemail'
+      'left a voicemail for'
+    when "Couldn't reach patient"
+      "called, but couldn't reach"
+    when 'Reached patient'
+      'called and reached'
+    end
+  end
+
+  def glyphicon
+    'usd' if event_type == 'Pledged'
+    'earpiece'
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,6 +30,11 @@ class Event
     "#{created_at.display_date} #{created_at.display_time} - #{cm_name} #{event_text} #{patient_name}"
   end
 
+  def glyphicon
+    'usd' if event_type == 'Pledged'
+    'earpiece'
+  end
+
   private
 
   def event_text
@@ -43,10 +48,5 @@ class Event
     when 'Reached patient'
       'called and reached'
     end
-  end
-
-  def glyphicon
-    'usd' if event_type == 'Pledged'
-    'earpiece'
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -29,7 +29,7 @@ class Event
   validates :pledge_amount, presence: true, if: :pledged_type?
 
   def glyphicon
-    return 'usd' if event_type == 'Pledged'
+    return 'thumbs-up' if event_type == 'Pledged'
     'earphone'
   end
 
@@ -42,7 +42,7 @@ class Event
     when "Couldn't reach patient"
       "called, but couldn't reach"
     when 'Reached patient'
-      'called and reached'
+      'reached'
     end
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -17,6 +17,7 @@ class Patient
   include HistoryTrackable
   include Statusable
   include Exportable
+  include EventLoggable
   extend Enumerize
 
   LINES.each do |line|
@@ -146,6 +147,17 @@ class Patient
     self.identifier = "#{line[0]}#{primary_phone[-5]}-#{primary_phone[-4..-1]}"
   end
 
+  def event_params
+    {
+      event_type:    'Pledged',
+      cm_name:       updated_by.name,
+      patient_name:  name,
+      patient_id:    id,
+      line:          line,
+      pledge_amount: fund_pledge
+    }
+  end
+
   private
 
   def confirm_appointment_after_initial_call
@@ -164,5 +176,5 @@ class Patient
 
   def initialize_fulfillment
     build_fulfillment(created_by_id: created_by_id).save
-  end
+  end  
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -176,5 +176,5 @@ class Patient
 
   def initialize_fulfillment
     build_fulfillment(created_by_id: created_by_id).save
-  end  
+  end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -150,7 +150,7 @@ class Patient
   def event_params
     {
       event_type:    'Pledged',
-      cm_name:       updated_by.name,
+      cm_name:       updated_by&.name || 'System',
       patient_name:  name,
       patient_id:    id,
       line:          line,

--- a/app/views/dashboards/_activity_feed.html.erb
+++ b/app/views/dashboards/_activity_feed.html.erb
@@ -1,8 +1,9 @@
 <div id='activity_feed' class='margin-bottom'>
-  <h1 class='border-bottom title'>Activity Feed</h1>
+  <h1 class='border-bottom title'>Activity on this line</h1>
   <ul>
-  <% Event.order_by(created_at: :desc).limit(10).each do |event| %>
-    <%= content_tag :li, "#{event.cm_name} #{event.event_type} #{event.patient_name} #{event.patient_id} #{event.created_at}" %>
-  <% end %>
+
+    <% Event.order_by(created_at: :desc).limit(10).each do |event| %>
+      <%= content_tag :li, event.to_log_entry %>
+    <% end %>
   </ul>
 </div>

--- a/app/views/dashboards/_activity_feed.html.erb
+++ b/app/views/dashboards/_activity_feed.html.erb
@@ -1,9 +1,9 @@
-<div id='activity_feed' class='margin-bottom'>
+<div id='activity_feed_content' class='margin-bottom'>
   <h1 class='border-bottom title'>Activity on this line</h1>
-  <ul>
+  <ul class='well well-lg'>
 
     <% Event.order_by(created_at: :desc).limit(10).each do |event| %>
-      <%= content_tag :li, event.to_log_entry %>
+      <%= content_tag :li, event.to_log_entry %><br />
     <% end %>
   </ul>
 </div>

--- a/app/views/dashboards/_activity_feed.html.erb
+++ b/app/views/dashboards/_activity_feed.html.erb
@@ -1,9 +1,7 @@
-<div id='activity_feed_content' class='margin-bottom'>
+<div id='activity_feed' class='margin-bottom'>
   <h1 class='border-bottom title'>Activity on this line</h1>
-  <ul class='well well-lg'>
 
-    <% Event.order_by(created_at: :desc).limit(10).each do |event| %>
-      <%= content_tag :li, event.to_log_entry %><br />
-    <% end %>
-  </ul>
+  <div id="activity_feed_content">
+    <%= render_async events_path, nonce: content_security_policy_script_nonce %>
+  </div>
 </div>

--- a/app/views/dashboards/_activity_log.html.erb
+++ b/app/views/dashboards/_activity_log.html.erb
@@ -1,7 +1,7 @@
-<div id='activity_feed' class='margin-bottom'>
+<div id='activity_log' class='margin-bottom'>
   <h1 class='border-bottom title'>Activity on this line</h1>
 
-  <div id="activity_feed_content">
+  <div id="activity_log_content">
     <%= render_async events_path, nonce: content_security_policy_script_nonce %>
   </div>
 </div>

--- a/app/views/dashboards/_activity_log.html.erb
+++ b/app/views/dashboards/_activity_log.html.erb
@@ -1,5 +1,5 @@
 <div id='activity_log' class='margin-bottom'>
-  <h1 class='border-bottom title'>Activity on this line</h1>
+  <h1 class='border-bottom title'><%= current_line %> Call Line Activity Log</h1>
 
   <div id="activity_log_content">
     <%= render_async events_path, nonce: content_security_policy_script_nonce %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -12,6 +12,6 @@
     <%= render partial: 'dashboards/table_content', locals: { title: 'Your completed calls', table_type: 'completed_calls', patients: current_user.recently_called_patients(current_line), autosortable: true } %>
     <%= render partial: 'dashboards/table_content', locals: { title: 'Urgent cases', table_type: 'urgent_patients', patients: @urgent_patients, autosortable: true } %>
     <%= render partial: 'dashboards/modal' %>
-    <%= render partial: 'dashboards/activity_feed' %>
+    <%= render partial: 'dashboards/activity_log' %>
   </div>
 </div>

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -1,0 +1,5 @@
+<ul class='well well-lg'>
+  <% @events.each do |event| %>
+    <%= content_tag :p, display_event(event) %><br />
+  <% end %>
+</ul>

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -1,5 +1,7 @@
-<ul class='well well-lg'>
-  <% @events.each do |event| %>
-    <%= content_tag :p, display_event(event) %>
-  <% end %>
-</ul>
+<div class='well well-lg' id='event-data'>
+  <ul id='event-list'>
+    <% @events.each do |event| %>
+      <%= content_tag :p, display_event(event) %>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -1,7 +1,10 @@
 <div class='well well-lg' id='event-data'>
   <ul id='event-list'>
-    <% @events.each do |event| %>
-      <%= content_tag :p, display_event(event) %>
+    <% @events.map { |event| event.created_at.display_date }.uniq.each do |date| %>
+      <h3><%= date %></h3>
+      <% @events.select { |event| event.created_at.display_date == date }.each do |event| %>
+        <%= content_tag :p, display_event(event) %>
+      <% end %>
     <% end %>
   </ul>
 </div>

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -1,5 +1,5 @@
 <ul class='well well-lg'>
   <% @events.each do |event| %>
-    <%= content_tag :p, display_event(event) %><br />
+    <%= content_tag :p, display_event(event) %>
   <% end %>
 </ul>

--- a/app/views/events/index.js.erb
+++ b/app/views/events/index.js.erb
@@ -1,0 +1,1 @@
+$('activity_feed').empty().append('<%= escape_javascript(render partial: "events/events", locals: { events: @events }) %>');

--- a/app/views/events/index.js.erb
+++ b/app/views/events/index.js.erb
@@ -1,1 +1,1 @@
-$('activity_feed').empty().append('<%= escape_javascript(render partial: "events/events", locals: { events: @events }) %>');
+$('activity_log').empty().append('<%= escape_javascript(render partial: "events/events", locals: { events: @events }) %>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     post 'clinicfinder', to: 'clinicfinders#search', defaults: { format: :js } #, as: 'clinicfinder'
     resources :clinics, only: [:index, :create, :update, :new, :destroy, :edit]
     resources :configs, only: [:index, :create, :update]
+    resources :events, only: [:index]
   end
 
   # Auth routes

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -1,4 +1,4 @@
-desc 'Clean up call lists and urgent patients'
+desc 'Clean up call lists, unmark urgent patients, destroy old events'
 task nightly_cleanup: :environment do
   User.all.each { |user| user.clear_call_list }
   puts "#{Time.now} -- cleared all recently reached patients from call lists"

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -2,6 +2,10 @@ desc 'Clean up call lists and urgent patients'
 task nightly_cleanup: :environment do
   User.all.each { |user| user.clear_call_list }
   puts "#{Time.now} -- cleared all recently reached patients from call lists"
+
   Patient.trim_urgent_patients
   puts "#{Time.now} -- trimmed urgent patients"
+
+  Event.destroy_old_events
+  puts "#{Time.now} -- destroyed old events"
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,7 +1,19 @@
 require 'test_helper'
 
 class EventsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  before do
+    @user = create :user
+    sign_in @user
+    choose_line 'dc'
+  end
+
+  describe 'index method' do
+    before do
+      get events_path
+    end
+
+    it 'should return success' do
+      assert_response :success
+    end
+  end
 end

--- a/test/factories/event.rb
+++ b/test/factories/event.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :event do
+    event_type 'Reached patient'
+    cm_name 'Yolorita'
+    patient_name 'Susan Everyteen'
+    patient_id 'sdfghjk'
+    line :DC
+  end
+end

--- a/test/factories/event.rb
+++ b/test/factories/event.rb
@@ -4,6 +4,5 @@ FactoryGirl.define do
     cm_name 'Yolorita'
     patient_name 'Susan Everyteen'
     patient_id 'sdfghjk'
-    line :DC
   end
 end

--- a/test/integration/activity_log_test.rb
+++ b/test/integration/activity_log_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+# Confirm that calls and pledges are showing up in activity log
+class ActivityLogTest < ActionDispatch::IntegrationTest
+  before do
+    Capybara.current_driver = :poltergeist
+    @user = create :user
+    @clinic = create :clinic
+    @patient = create :patient,
+                      fund_pledge: 100,
+                      clinic: @clinic,
+                      appointment_date: 3.days.from_now
+
+    log_in_as @user
+    choose_line 'dc'
+    visit edit_patient_path @patient
+  end
+
+  after { Capybara.use_default_driver }
+
+  describe 'logging phone calls' do
+    it 'should log a phone call into the activity log' do
+      wait_for_element 'Call Log'
+      click_link 'Call Log'
+      click_link 'Record new call'
+      click_link 'I left a voicemail for the patient'
+
+      visit authenticated_root_path
+      within :css, '#activity_log_content' do
+        assert has_content? "#{@user.name} left a voicemail for " \
+                            "#{@patient.name}"
+      end
+    end
+  end
+
+  describe 'logging a pledge' do
+    it 'should log a pledge into the activity log' do
+      find('#submit-pledge-button').click
+      wait_for_element 'Patient name'
+      assert has_text? 'Confirm the following information is correct'
+      click_button 'Next'
+      wait_for_element 'Generate your pledge form'
+      click_button 'Next'
+      check 'I sent the pledge'
+      wait_for_ajax
+
+      visit authenticated_root_path
+      within :css, '#activity_log_content' do
+        assert has_content? "#{@user.name} sent a $#{@patient.fund_pledge} " \
+                            "pledge for #{@patient.name}"
+      end
+    end
+  end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -49,4 +49,25 @@ class EventTest < ActiveSupport::TestCase
       assert @event.event_text
     end
   end
+
+  describe 'cleaning old events' do
+    before do
+      # Here are the destroyers
+      create :event, created_at: 4.weeks.ago
+      create :event, created_at: 22.days.ago
+      create :event, created_at: 3.weeks.ago
+
+      # Here are the keepers
+      # In addition to the other event...
+      create :event, created_at: 20.days.ago
+      create :event, created_at: 2.weeks.ago
+    end
+
+    it 'should be able to clean old events' do
+      assert_equal 6, Event.count
+      Event.destroy_old_events
+
+      assert_equal 3, Event.count
+    end
+  end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class EventTest < ActiveSupport::TestCase
+  before { @event = create :event }
+
+  describe 'basic validations' do
+    it 'should build' do
+      assert @event.valid?
+    end
+
+    it 'should only allow certain statuses' do
+      [nil, 'not a status'].each do |bad_status|
+        @event.event_type = bad_status
+        refute @event.valid?
+      end
+
+      valid_types = ['Reached patient', "Couldn't reach patient",
+                     'Left voicemail', 'Pledged']
+      valid_types.each do |status|
+        @event.event_type = status
+        assert @event.valid?
+      end
+    end
+
+    [:patient_name, :patient_id, :cm_name].each do |req_field|
+      it "requires #{req_field}" do
+        @event[req_field] = nil
+        refute @event.valid?
+      end
+    end
+
+    it 'requires a pledge amount if pledged type' do
+      @event.event_type = 'Pledged'
+      refute @event.valid?
+      @event.pledge_amount = 100
+      assert @event.valid?
+    end
+  end
+
+  describe 'rendering methods' do
+    it 'should render the correct glyphicon' do
+      assert_equal 'earphone', @event.glyphicon
+
+      @event.event_type = 'Pledged'
+      assert_equal 'usd', @event.glyphicon
+    end
+
+    it 'should do something on event text' do
+      assert @event.event_text
+    end
+  end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -15,7 +15,7 @@ class EventTest < ActiveSupport::TestCase
       end
 
       valid_types = ['Reached patient', "Couldn't reach patient",
-                     'Left voicemail', 'Pledged']
+                     'Left voicemail']
       valid_types.each do |status|
         @event.event_type = status
         assert @event.valid?

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -42,7 +42,7 @@ class EventTest < ActiveSupport::TestCase
       assert_equal 'earphone', @event.glyphicon
 
       @event.event_type = 'Pledged'
-      assert_equal 'usd', @event.glyphicon
+      assert_equal 'thumbs-up', @event.glyphicon
     end
 
     it 'should do something on event text' do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -39,10 +39,17 @@ class EventTest < ActiveSupport::TestCase
 
   describe 'rendering methods' do
     it 'should render the correct glyphicon' do
+      @event.event_type = "Couldn't reach patient"
       assert_equal 'earphone', @event.glyphicon
+
+      @event.event_type = 'Reached patient'
+      assert_equal 'comment', @event.glyphicon
 
       @event.event_type = 'Pledged'
       assert_equal 'thumbs-up', @event.glyphicon
+
+      @event.event_type = 'Left voicemail'
+      assert_equal 'earphone', @event.glyphicon
     end
 
     it 'should do something on event text' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Jumps off the structural work in #1136 to add a clean render stream for events as follows:

* Single serve events endpoint that renders a partial of events for that line
* Renders the activity feed async

This pull request makes the following changes:
* Refines some frontend stuff around #1136 

Screenshots coming when I get it to blend right

It relates to the following issue #s: 
* Fixes #654 
