### PR TITLE
Cancel pledge checkbox

### DIFF
--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -1,6 +1,8 @@
-<%= render '/shared/multi_modal', disable_next: disable_continue?(patient), :captured => capture { %>
+
 
 <% if not patient.pledge_sent %>
+
+  <%= render '/shared/multi_modal', disable_next: disable_continue?(patient), :captured => capture { %>
   <div class="row hide" data-step="1" data-title="Confirm the following information is correct:">
     <% if patient.pledge_info_present? %>
       <% patient.pledge_info_errors.each do |error| %>
@@ -25,13 +27,13 @@
         <%= bootstrap_form_tag url: generate_pledge_patient_path(patient), method: 'get' do |f| %>
           <%= f.text_field :case_manager_name, label: 'Enter your name in this box to sign your pledge:' %>
           <%= f.submit 'Generate your pledge', class: 'btn btn-large btn-primary' %>
-        <% end %>      
+        <% end %>
       </div>
     <% end %>
   </div>
 
   <div class="row hide" data-step="3" data-title="Submit and send your pledge:">
-    <p class="col-sm-12">Awesome, you generated a DCAF Pledge! Thanks!</p>
+    <p class="col-sm-12">Awesome, you generated a <%= FUND %> Pledge! Thanks!</p>
     <p class="col-sm-12">Your pledge should appear in your computer's downloads. Find the document and go to <a href="http://www.onlinefaxes.com" target="_blank">onlinefaxes.com</a> to submit the pledge for your client.</p>
     <p class="col-sm-12"><strong>Once you've completed the online fax process, please use the check box below to indicate your pledge has been sent.</strong></p>
     <div class="col-sm-12">
@@ -40,19 +42,21 @@
       <% end %>
     </div>
   </div>
+  <% } %>
 <% else %>
-  <div class="row hide" data-step="1" data-title="Cancel pledge:">
-    <p class="col-sm-12">If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page.</p>
+  <div class="modal-header">
+    <h4 class="modal-title">Cancel Pledge</h4>
   </div>
-
-  <div class="row hide" data-step="2" data-title="Cancel pledge:">
-    <p class="col-sm-12">To confirm you want to cancel this pledge, please uncheck the check box below.</p>
-    <div class="col-sm-12">
-      <%= bootstrap_form_for patient, id: 'pledge-create-modal-form', remote: true do |f| %>
-        <%= f.check_box :pledge_sent, label: 'Uncheck this box to rescind the pledge' %>
-      <% end %>
+  <div class="modal-body">
+    <div class="row">
+      <div class="col-sm-12">
+        <p>Are you sure you want to cancel this pledge?</p>
+      </div>
     </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">No</button>
+    <button type="button" class="btn btn-default btn-lg" data-dismiss="modal" style="margin-bottom: 15px;">Yes</button>
   </div>
 <% end %>
 
-<% } %>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -55,11 +55,11 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">No</button>
+    <button type="button" class="btn btn-default js-btn-step pull-left" style="color:red;" data-dismiss="modal">No</button>
 
-    <%= form_for @patient, html:{style:'display:inline-block;', id:'cancel-pledge-form'}, remote: true do |f|%>    
+    <%= form_for @patient, html:{id:'cancel-pledge-form'}, remote: true do |f|%>    
       <%= f.hidden_field :pledge_sent, :value=> false %>
-      <%= f.submit 'Yes', class:"btn btn-default btn-lg", id: 'cancel-pledge-submit', style: "margin-bottom: 15px;"%>
+      <%= f.submit 'Yes', class:"btn btn-success js-btn-step", id: 'cancel-pledge-submit'%>
     <% end %>
   </div>
 <% end %>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -56,7 +56,11 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">No</button>
-    <button type="button" class="btn btn-default btn-lg" data-dismiss="modal" style="margin-bottom: 15px;">Yes</button>
+
+    <%= form_for @patient, html:{style:'display:inline-block;', id:'cancel-pledge-form'}, remote: true do |f|%>    
+      <%= f.hidden_field :pledge_sent, :value=> false %>
+      <%= f.submit 'Yes', class:"btn btn-default btn-lg", id: 'cancel-pledge-submit', style: "margin-bottom: 15px;"%>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/patients/pledge.js.erb
+++ b/app/views/patients/pledge.js.erb
@@ -5,11 +5,16 @@ $('.modal-content').append(
 );
 
 $('.modal').modal('toggle');
-$('.js-title-step span').slice(1).remove();
-var el = $(".js-title-step").contents()
 
-if (el.length > 2) {
-  el.slice(2,el.length).remove();
-}
+<% if (!@patient.pledge_sent) %>
 
-$('#pledge-modal').modalSteps();
+  $('.js-title-step span').slice(1).remove();
+  var el = $(".js-title-step").contents()
+
+  if (el.length > 2) {
+    el.slice(2,el.length).remove();
+  }
+
+  $('#pledge-modal').modalSteps();
+
+<% end %>

--- a/app/views/patients/pledge.js.erb
+++ b/app/views/patients/pledge.js.erb
@@ -17,4 +17,8 @@ $('.modal').modal('toggle');
 
   $('#pledge-modal').modalSteps();
 
+<% else %>
+  $('#cancel-pledge-form').on('submit', function() {
+    $('.modal').modal('hide');
+  })
 <% end %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* removes checkbox from the cancel pledge modal
* changes _pledge.html.erb to only call views/shared/multi-modal for submitting a pledge, not cancelling. Cancelling a pledge is only one step.

(If there are changes to the views, please include a screenshot so we know what to look for!)

Cancel pledge modal before:

![image](https://user-images.githubusercontent.com/22413614/29884411-68b8f122-8d81-11e7-85c6-e1630ff68bc5.png)

Cancel pledge modal after:

![image](https://user-images.githubusercontent.com/22413614/29884430-7c6dae6a-8d81-11e7-9f1a-c1a0cb988d8d.png)


It relates to the following issue #s: 
* Fixes #1046
