### PR TITLE
Changes to_csv to enumerable, streams CSV generation

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -8,9 +8,7 @@ class PatientsController < ApplicationController
   def index
     respond_to do |format|
       format.csv do
-        now = Time.zone.now.strftime('%Y%m%d')
-        csv_filename = "patient_data_export_#{now}.csv"
-        send_data Patient.to_csv, filename: csv_filename, format: 'text/csv'
+        render_csv
       end
     end
   end
@@ -123,5 +121,23 @@ class PatientsController < ApplicationController
       [].concat(PATIENT_DASHBOARD_PARAMS, PATIENT_INFORMATION_PARAMS,
                 ABORTION_INFORMATION_PARAMS, OTHER_PARAMS, FULFILLMENT_PARAMS)
     )
+  end
+
+  def render_csv
+    now = Time.zone.now.strftime('%Y%m%d')
+    csv_filename = "patient_data_export_#{now}.csv"
+    set_headers(csv_filename)
+
+    response.status = 200
+
+    self.response_body = Patient.to_csv
+  end
+
+  def set_headers(filename)
+    headers["Content-Type"] = "text/csv"
+    headers["Content-disposition"] = "attachment; filename=\"#{filename}\""
+    headers['X-Accel-Buffering'] = 'no'
+    headers["Cache-Control"] = "no-cache"
+    headers.delete("Content-Length")
   end
 end

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -146,12 +146,11 @@ module Exportable
 
   class_methods do
     def to_csv
-      CSV.generate(encoding: 'utf-8') do |csv|
-        csv << CSV_EXPORT_FIELDS.keys # Header line
-        all.each do |patient|
-          csv << CSV_EXPORT_FIELDS.values.map do |field|
-            patient.get_field_value_for_serialization(field)
-          end
+      Enumerator.new do |y|
+        y << CSV.generate_line(CSV_EXPORT_FIELDS.keys, encoding: 'utf-8')
+        each do |patient|
+          row = CSV_EXPORT_FIELDS.values.map{ |field| patient.get_field_value_for_serialization(field) }
+          y << CSV.generate_line(row, encoding: 'utf-8')
         end
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns CSV generation into streaming request to avoid timeouts.

This pull request makes the following changes:
* Changes `to_csv` return enumerable (it only seemed to be called in one place)
* Turns patient csv generation into stream. Heroku won't time out on streaming requests unless it goes 55 seconds or more between packets, so this should allow for arbitrarily long CSVs (https://devcenter.heroku.com/articles/request-timeout)

It relates to the following issue #s: 
* Fixes #1224
