### PR TITLE
Frontend improvements for call line selections

### DIFF
--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -2,20 +2,24 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-input[type="radio"] {
-    -ms-transform: scale(2); /* IE 9 */
-    -webkit-transform: scale(2); /* Chrome, Safari, Opera */
-    transform: scale(2);
-}
+.lines-form {
+    input[type="radio"] {
+        -ms-transform: scale(2); /* IE 9 */
+        -webkit-transform: scale(2); /* Chrome, Safari, Opera */
+        transform: scale(2);
+        margin-top: 10px;
+    }
 
-label {
-    margin: 10px;
-}
+    label {
+        margin: 10px;
+        font-size: 24px;
+    }
 
-.radio label {
-    float: left;
-}
+    .radio label {
+        float: left;
+    }
 
-.btn-primary {
-    display: block;
+    .btn-primary {
+        display: block;
+    }
 }

--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -1,3 +1,21 @@
 // Place all the styles related to the lines controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+input[type="radio"] {
+    -ms-transform: scale(2); /* IE 9 */
+    -webkit-transform: scale(2); /* Chrome, Safari, Opera */
+    transform: scale(2);
+}
+
+label {
+    margin: 10px;
+}
+
+.radio label {
+    float: left;
+}
+
+.btn-primary {
+    display: block;
+}

--- a/app/views/lines/new.html.erb
+++ b/app/views/lines/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="col-sm-12">
+  <div class="col-sm-12 lines-form">
     <h1 class="border-bottom title">Welcome to <%= FUND %> Case Manager!</h1>
     <h4>What line are you working tonight?</h4>
 

--- a/app/views/lines/new.html.erb
+++ b/app/views/lines/new.html.erb
@@ -5,9 +5,10 @@
 
     <%= bootstrap_form_tag url: lines_path do |f| %>
       <% lines.each do |line| %>
-        <%= f.radio_button :line, line, label: line %>
+        <%= f.radio_button :line, line %>
+        <%= f.label :line, line, :value => line %>
       <% end %>
-      <%= f.submit 'Select your line for this session', class: 'btn-lg btn-primary' %>
+      <%= f.submit 'Start', class: 'btn-lg btn-primary' %>
     <% end %>
 
   </div>

--- a/test/integration/select_line_test.rb
+++ b/test/integration/select_line_test.rb
@@ -13,12 +13,12 @@ class SelectLineTest < ActionDispatch::IntegrationTest
       assert has_content? 'DC'
       assert has_content? 'MD'
       assert has_content? 'VA'
-      assert has_button? 'Select your line for this session'
+      assert has_button? 'Start'
     end
 
     it 'should redirect to the main dashboard after line set' do
       choose 'DC'
-      click_button 'Select your line for this session'
+      click_button 'Start'
       assert_equal current_path, authenticated_root_path
       assert has_content? 'Your current line: DC'
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -83,7 +83,7 @@ class ActionDispatch::IntegrationTest
 
   def select_line(line = 'DC')
     choose line
-    click_button 'Select your line for this session'
+    click_button 'Start'
   end
 
   def wait_for_element(text)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Change 'Select line for this session' to 'Start'
* Increase size of radio buttons
* Add margin between radio button and text description
Before
<img width="1169" alt="screen shot 2017-09-06 at 4 50 09 pm" src="https://user-images.githubusercontent.com/4335814/30133942-868c0a8e-9323-11e7-9459-15dc2540ca9a.png">

After:
<img width="1175" alt="screen shot 2017-09-06 at 4 49 36 pm" src="https://user-images.githubusercontent.com/4335814/30133951-8c329f2a-9323-11e7-9028-f09672562eb2.png">

It relates to the following issue #s: 
* Fixes #779 
