### PR TITLE
Get turbolinks working with the activity log

### DIFF
--- a/app/views/dashboards/_activity_log.html.erb
+++ b/app/views/dashboards/_activity_log.html.erb
@@ -2,6 +2,6 @@
   <h1 class='border-bottom title'><%= current_line %> Call Line Activity Log</h1>
 
   <div id="activity_log_content">
-    <%= render_async events_path, nonce: content_security_policy_script_nonce %>
+    <%= render_async events_path, nonce: content_security_policy_script_nonce, 'data-turbolinks-track': 'reload' %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,10 +10,9 @@
     <%= javascript_include_tag :application %>
     <%= csrf_meta_tags %>
     <%= Gon::Base.render_data %>
+    <%= content_for :render_async %>
   </head>
   <body>
-    <%= content_for :render_async %>
-
     <% if current_user.present? %>
       <header>
         <%= render 'layouts/navigation' %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turbolinks does not love inline javascript, so we had to add a tag to the JS.

And, for some dumb reason, put `render_async` in the head. Why that is is totally lost on me. I probably owe the render_async folks a readme PR after this.

This pull request makes the following changes:
* Make the activity log load when following links in the app

No issue, I think.

Going to invoke admin priv and merge so we can get this out today.