### PR TITLE
1237 - Reenabled add to call list link

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,16 +1,26 @@
+# Functions to display events for activity feed
 module EventsHelper
   def display_event(event)
     safe_join [
-      tag(:span, class: ['glyphicon', "glyphicon-#{event.glyphicon}", 'event-item']),
+      tag(:span,
+          class: ['glyphicon', "glyphicon-#{event.glyphicon}", 'event-item']),
       log_entry(event)
     ], ' '
   end
 
   def log_entry(event)
-    time = "#{event.created_at.display_time}"
+    time = event.created_at.display_time.to_s
     str = "-- #{event.cm_name} #{event.event_text}"
-    pt_link = link_to "#{event.patient_name}.", edit_patient_path(event.patient_id)
-    add_link = '' # add_link = link_to '(Add to call list)', add_patient_path(current_user, event.patient_id), method: :patch, remote: true
+    pt_link = link_to(
+      "#{event.patient_name}.",
+      edit_patient_path(event.patient_id)
+    )
+    add_link = link_to(
+      '(Add to call list)',
+      add_patient_path(current_user, event.patient_id),
+      method: :patch,
+      remote: true
+    )
 
     safe_join [time, str, pt_link, add_link], ' '
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I did some formatting cleanup in this helper and otherwise just uncommented the previous link code.

This pull request makes the following changes:
* Re-enables add to call list link

![add_to_call_list_link](https://user-images.githubusercontent.com/1838489/30302159-322509ec-972d-11e7-96dd-4b6315cf83e9.PNG)


It relates to the following issue #s: 
* Fixes #1237 
