### PR TITLE
Bump ruby to 2.4.2, nokogiri to 1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.1-alpine
+FROM ruby:2.4.2-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.1'
+ruby '2.4.2'
 
 gem 'rails', '>= 5.0.0', '< 5.1'
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     mini_backtrace (0.1.3)
       minitest (> 1.2.0)
       rails (>= 2.3.3)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     minitest-ci (3.2.0)
       minitest (>= 5.0.6)
@@ -199,8 +199,8 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -422,7 +422,7 @@ DEPENDENCIES
   uglifier (>= 3.2.0)
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.4.2p198
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.4.1
+    version: 2.4.2
   pre:
     - sudo apt-get install libfontconfig
     - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -40,7 +40,7 @@ If you prefer a local environment, totally cool! We recommend the following:
 
 ### First, ruby dependencies
 * Make sure you have a ruby version manager installed; we recommend either [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/)
-* Install our version of Ruby! We use version `2.4.1` (Usually `rbenv install 2.4.1` or `rvm install 2.4.1` once you have your version manager set up)
+* Install our version of Ruby! We use version `2.4.2` (Usually `rbenv install 2.4.2` or `rvm install 2.4.2` once you have your version manager set up)
 * Install PhantomJS, which our test suite depends on, via `brew install phantomjs`, or `npm install -g phantomjs-prebuilt`, or the [linux instructions](http://phantomjs.org/download.html)
 * Run the command `gem install bundler && bundle install` to install ruby dependences, including `rails`
 
@@ -73,7 +73,7 @@ If you don't currently have Rails installed (or are on Windows), Cloud9 makes th
 
 * Sign into `https://c9.io/` and create a new workspace
 * Clone from `git@github.com:{your_github_username}/dcaf_case_management.git` and select the Rails option
-* The terminal at the bottom of your new workspace will have a warning message saying "ruby-2.4.1 is not installed. To install do: `rvm install ruby-2.4.1`". Run that command to install the necessary version of Ruby.
+* The terminal at the bottom of your new workspace will have a warning message saying "ruby-2.4.2 is not installed. To install do: `rvm install ruby-2.4.2`". Run that command to install the necessary version of Ruby.
 * Next, install the bundler gem by entering `gem install bundler` in the terminal.
 * Install MongoDB by entering `sudo apt-get install -y mongodb-org`.
 * Once MongoDB is installed, run `bundle install` in the terminal


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bumps nokogiri and ruby for security patches.

This pull request makes the following changes:
* Nokogiri to 1.8.1 to path a libxml vulnerability
* Ruby to 2.4.2 to patch whatever the latest round of small security fixes is

No view changes, no issues. 

@lomky  or @KatSDC can you sign off on these changes when you get a sec? 