### PR TITLE
modify flash notice in patients contoller #update to give timestamp

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -64,7 +64,7 @@ class PatientsController < ApplicationController
     end
     if @patient.update_attributes patient_params
       @patient.reload
-      flash.now[:notice] = 'Patient info successfully saved'
+      flash.now[:notice] = "Patient info successfully saved at #{Time.zone.now.strftime("%-m-%-d-%Y %l:%M %p")}"
     else
       error = @patient.errors.full_messages.to_sentence
       flash.now[:alert] = error


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds a timestamp to the success notice in patients_controller update method.

This pull request makes the following changes:
* Modifies patients_controller #update to give a timestamp in the flash notice.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1179