### PR TITLE
remove an encompassing form-group that caused inconsistent spacing

### DIFF
--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -30,12 +30,8 @@
 
           <div class="col-sm-6">
             <div class="info-form-right">
-              <%= f.form_group :resolved_without_fund do %>
-                <%= f.check_box :resolved_without_fund, label: "Resolved without assistance from #{FUND}" %>
-              <% end %>
-              <%= f.form_group :referred_to_clinic do %>
-                <%= f.check_box :referred_to_clinic, label: 'Referred to clinic' %>
-              <% end %>
+              <%= f.check_box :resolved_without_fund, label: "Resolved without assistance from #{FUND}" %>
+              <%= f.check_box :referred_to_clinic, label: 'Referred to clinic' %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

On the abortion information form there are two sets of checkboxes. The set under the input field is wrapped in a checkbox class div whereas the second set to the right were wrapped in a checkbox class div within a form-group div. The margins on the nesting of those two divs was causing the inconsistency. My quick fix is to remove the encompassing form-group as the checkbox class provides better styling for the checkboxes.

This pull request makes the following changes:
* Removes two encompassing form-group divs from the `app/views/patients/_abortion_information.html.erb`

![b4_after](https://user-images.githubusercontent.com/25264303/31049483-f9edaaa0-a5e8-11e7-8053-0946ebdc2f18.jpg)


It relates to the following issue #s: 
* Fixes #1248
