### PR TITLE
Allow fund information from env vars in footer

### DIFF
--- a/app/services/pledge_form_generator.rb
+++ b/app/services/pledge_form_generator.rb
@@ -77,7 +77,7 @@ class PledgeFormGenerator
       pdf.text case_manager_name
       pdf.text 'DC Abortion Fund'
       pdf.text 'P.O. Box 65061'
-      pdf.text 'Tel: 202-452-7464'
+      pdf.text "Tel: #{FUND_PHONE}"
       pdf.text 'E-mail: info@dcabortionfund.org'
       pdf.text 'Web: www.dcabortionfund.org'
     end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -8,7 +8,7 @@
 </div><!-- end container -->
 	  
 <div id="app_footer" class="container text-center margin-bottom-sm">
-	<a href="http://dcabortionfund.org/">DC Abortion Fund</a> -- <a href="tel:202-452-7464"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 202-452-7464</a><br>
+	<a href="http://dcabortionfund.org/"><%= FUND_FULL %></a> -- <a href="tel:<%= FUND_PHONE %>"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> <%= FUND_PHONE %></a><br>
 	<a href="https://prochoice.org/">National Abortion Federation</a> -- <a href="tel:800-772-9100"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 800-772-9100</a><br>
 	<a href="http://onlinefaxes.com">onlinefaxes.com</a>
 </div><!-- end container -->

--- a/config/initializers/env_var_constants.rb
+++ b/config/initializers/env_var_constants.rb
@@ -11,4 +11,5 @@ LINES = if ENV['DARIA_LINES'].present?
 # Definition of fund
 FUND_FULL = ENV['DARIA_FUND_FULL'] || 'DC Abortion Fund'
 FUND_DOMAIN = FUND_FULL.gsub(' ', '').downcase
+FUND_PHONE = ENV['DARIA_FUND_PHONE'] || '202-452-7464'
 FUND = ENV['DARIA_FUND'] || 'DCAF'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Per #1214 this makes it possible to set a DARIA_FUND_PHONE

This pull request makes the following changes:
* Uses an env var `DARIA_FUND_PHONE` to set a fund's phone number (defaulting to DCAF's #)
* Switches out the hardset DCAF to`DARIA_FUND_FULL` in the footer

It relates to the following issue #s: 
* Bumps #1214 

@lomky for review please! 