### PR TITLE
Fix Tablesort after Search Bug

### DIFF
--- a/app/assets/javascripts/table_sorting.coffee
+++ b/app/assets/javascripts/table_sorting.coffee
@@ -2,21 +2,19 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
-ready = ->
+$(document).on 'turbolinks:load', ->
   # make the columns of all of the tables sortable
   sortTables()
-$(document).on 'ready page:load', ready
 
 sortTables = ->
-  autosortable_tables = [ '#call_list table', '#completed_calls table', '#urgent_patients table', '#user-list table']
-  autosortable_tables.forEach ( table ) ->
-      stupidtable = $( table ).stupidtable()
-
-      # when a column is clicked, make sure to reset all of the other columns back to [-]
-      stupidtable.on 'beforetablesort', ( event, data ) ->
-          stupidtable.find( 'th' ).filter( ( i ) -> return i isnt data.column ).find( '.arrow' ).html( '[-]' )
-
-      # when a column is clicked, show an up or down arrow appropriately
-      stupidtable.on 'aftertablesort', ( event, data ) ->
-          arrow = if data.direction is $.fn.stupidtable.dir.ASC then '[&uarr;]' else '[&darr;]'
-          stupidtable.find( 'th' ).eq( data.column ).find( '.arrow' ).html( arrow )
+  $('table').each (index) ->
+    stupidtable = undefined
+    stupidtable = $(this).stupidtable()
+    stupidtable.on 'beforetablesort', (event, data) ->
+      stupidtable.find('th').filter((i) ->
+        i != data.column
+      ).find('.arrow').html '[-]'
+    stupidtable.on 'aftertablesort', (event, data) ->
+      arrow = undefined
+      arrow = if data.direction == $.fn.stupidtable.dir.ASC then '[&uarr;]' else '[&darr;]'
+      stupidtable.find('th').eq(data.column).find('.arrow').html arrow

--- a/app/assets/javascripts/table_sorting.coffee
+++ b/app/assets/javascripts/table_sorting.coffee
@@ -2,18 +2,21 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
-jQuery ->
-  $(document).on 'ready page:load', ->
-    # make the columns of all of the tables sortable
-    autosortable_tables = [ '#call_list table', '#completed_calls table', '#urgent_patients table', '#user-list table']
-    autosortable_tables.forEach ( table ) ->
-        stupidtable = $( table ).stupidtable()
+ready = ->
+  # make the columns of all of the tables sortable
+  sortTables()
+$(document).on 'ready page:load', ready
 
-        # when a column is clicked, make sure to reset all of the other columns back to [-]
-        stupidtable.on 'beforetablesort', ( event, data ) ->
-            stupidtable.find( 'th' ).filter( ( i ) -> return i isnt data.column ).find( '.arrow' ).html( '[-]' )
+sortTables = ->
+  autosortable_tables = [ '#call_list table', '#completed_calls table', '#urgent_patients table', '#user-list table']
+  autosortable_tables.forEach ( table ) ->
+      stupidtable = $( table ).stupidtable()
 
-        # when a column is clicked, show an up or down arrow appropriately
-        stupidtable.on 'aftertablesort', ( event, data ) ->
-            arrow = if data.direction is $.fn.stupidtable.dir.ASC then '[&uarr;]' else '[&darr;]'
-            stupidtable.find( 'th' ).eq( data.column ).find( '.arrow' ).html( arrow )
+      # when a column is clicked, make sure to reset all of the other columns back to [-]
+      stupidtable.on 'beforetablesort', ( event, data ) ->
+          stupidtable.find( 'th' ).filter( ( i ) -> return i isnt data.column ).find( '.arrow' ).html( '[-]' )
+
+      # when a column is clicked, show an up or down arrow appropriately
+      stupidtable.on 'aftertablesort', ( event, data ) ->
+          arrow = if data.direction is $.fn.stupidtable.dir.ASC then '[&uarr;]' else '[&darr;]'
+          stupidtable.find( 'th' ).eq( data.column ).find( '.arrow' ).html( arrow )

--- a/app/views/shared/_activate_stupidtable.js.erb
+++ b/app/views/shared/_activate_stupidtable.js.erb
@@ -1,0 +1,15 @@
+
+$('table').each(function(index) {
+  var stupidtable;
+  stupidtable = $(this).stupidtable();
+  stupidtable.on('beforetablesort', function(event, data) {
+    return stupidtable.find('th').filter(function(i) {
+      return i !== data.column;
+    }).find('.arrow').html('[-]');
+  });
+  return stupidtable.on('aftertablesort', function(event, data) {
+    var arrow;
+    arrow = data.direction === $.fn.stupidtable.dir.ASC ? '[&uarr;]' : '[&darr;]';
+    return stupidtable.find('th').eq(data.column).find('.arrow').html(arrow);
+  });
+});

--- a/app/views/users/search.js.erb
+++ b/app/views/users/search.js.erb
@@ -1,6 +1,26 @@
 
 <% if @results.any? %>
-  $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: @results }) %>");
+  $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: @results, autosortable: true }) %>");
+
+  //TODO figure out way to import function from /javascripts/table_sorting.coffee
+  var autosortable_tables;
+autosortable_tables = ['#call_list table', '#completed_calls table', '#urgent_patients table', '#user-list table'];
+
+autosortable_tables.forEach(function(table) {
+  var stupidtable;
+  stupidtable = $(table).stupidtable();
+  stupidtable.on('beforetablesort', function(event, data) {
+    return stupidtable.find('th').filter(function(i) {
+      return i !== data.column;
+    }).find('.arrow').html('[-]');
+  });
+  return stupidtable.on('aftertablesort', function(event, data) {
+    var arrow;
+    arrow = data.direction === $.fn.stupidtable.dir.ASC ? '[&uarr;]' : '[&darr;]';
+    return stupidtable.find('th').eq(data.column).find('.arrow').html(arrow);
+  });
+});
+
 <% else %>
-  $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: nil }) %>");
+  $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: nil, autosortable: true }) %>");
 <% end %>

--- a/app/views/users/search.js.erb
+++ b/app/views/users/search.js.erb
@@ -2,24 +2,7 @@
 <% if @results.any? %>
   $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: @results, autosortable: true }) %>");
 
-  //TODO figure out way to import function from /javascripts/table_sorting.coffee
-  var autosortable_tables;
-autosortable_tables = ['#call_list table', '#completed_calls table', '#urgent_patients table', '#user-list table'];
-
-autosortable_tables.forEach(function(table) {
-  var stupidtable;
-  stupidtable = $(table).stupidtable();
-  stupidtable.on('beforetablesort', function(event, data) {
-    return stupidtable.find('th').filter(function(i) {
-      return i !== data.column;
-    }).find('.arrow').html('[-]');
-  });
-  return stupidtable.on('aftertablesort', function(event, data) {
-    var arrow;
-    arrow = data.direction === $.fn.stupidtable.dir.ASC ? '[&uarr;]' : '[&darr;]';
-    return stupidtable.find('th').eq(data.column).find('.arrow').html(arrow);
-  });
-});
+<%= render partial: 'shared/activate_stupidtable' %>
 
 <% else %>
   $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: nil, autosortable: true }) %>");


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fix sorting by date after searching for a user.
A not so neat hack by calling the entire autosort function after a search completes. There might be a better way calling a javascript function elsewhere but I forget how to do so.

This pull request makes the following changes:
* Call autosorting table after search.js.erb dispatches


(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1099 
* Bumps #Y
