### PR TITLE
Make fax service in the footer settable by env var

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,7 +10,7 @@
 <div id="app_footer" class="container text-center margin-bottom-sm">
 	<a href="http://dcabortionfund.org/">DC Abortion Fund</a> -- <a href="tel:202-452-7464"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 202-452-7464</a><br>
 	<a href="https://prochoice.org/">National Abortion Federation</a> -- <a href="tel:800-772-9100"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 800-772-9100</a><br>
-	<a href="http://onlinefaxes.com">onlinefaxes.com</a>
+	<a href="https://<%= FUND_FAX_SERVICE %>" target='_blank'><%= FUND_FAX_SERVICE %></a>
 </div><!-- end container -->
 
 <div class="container text-center margin-bottom-sm">

--- a/config/initializers/env_var_constants.rb
+++ b/config/initializers/env_var_constants.rb
@@ -12,3 +12,4 @@ LINES = if ENV['DARIA_LINES'].present?
 FUND_FULL = ENV['DARIA_FUND_FULL'] || 'DC Abortion Fund'
 FUND_DOMAIN = FUND_FULL.gsub(' ', '').downcase
 FUND = ENV['DARIA_FUND'] || 'DCAF'
+FUND_FAX_SERVICE = ENV['DARIA_FAX_SERVICE'] || 'onlinefaxes.com'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

BRAAF requested the ability to set their own fax service URL in the footer, so hooking that up for them. 

This pull request makes the following changes:
* Adds a constant `FUND_FAX_SERVICE` for use in places, defaulting to the DCAF option
* plugs it into the footer
* also makes clicking that link open in a new tab

It relates to the following issue #s: 
* Bumps #1214 


@colinmcglynn  for review please!