### PR TITLE
Add port in development to fix password reset link sent to email

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { :host => 'localhost' }
+  config.action_mailer.default_url_options = { :host => 'localhost', port: '3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
related to #1266, doesn't fix it yet

It fixes email link sent in development environment to have correct port
http://localhost/... --> http://localhost:3000/...