### PR TITLE
Add noopener nofollow to new tab links

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,7 +10,7 @@
 <div id="app_footer" class="container text-center margin-bottom-sm">
 	<a href="http://dcabortionfund.org/"><%= FUND_FULL %></a> -- <a href="tel:<%= FUND_PHONE %>"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> <%= FUND_PHONE %></a><br>
 	<a href="https://prochoice.org/">National Abortion Federation</a> -- <a href="tel:800-772-9100"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 800-772-9100</a><br>
-	<a href="https://<%= FUND_FAX_SERVICE %>" target='_blank'><%= FUND_FAX_SERVICE %></a>
+	<%= link_to FUND_FAX_SERVICE, "http://#{FUND_FAX_SERVICE}", target: '_blank', rel: 'noopener nofollow' %>
 </div><!-- end container -->
 
 <div class="container text-center margin-bottom-sm">

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -32,7 +32,7 @@
 
   <div class="row hide" data-step="3" data-title="Submit and send your pledge:">
     <p class="col-sm-12">Awesome, you generated a <%= FUND %> Pledge! Thanks!</p>
-    <p class="col-sm-12">Your pledge should appear in your computer's downloads. Find the document and go to <a href="http://www.onlinefaxes.com" target="_blank">onlinefaxes.com</a> to submit the pledge for your client.</p>
+    <p class="col-sm-12">Your pledge should appear in your computer's downloads. Find the document and go to <%= link_to FUND_FAX_SERVICE, "http://#{FUND_FAX_SERVICE}", target: '_blank', rel: 'noopener nofollow' %> to submit the pledge for your client.</p>
     <p class="col-sm-12"><strong>Once you've completed the online fax process, please use the check box below to indicate your pledge has been sent.</strong></p>
     <div class="col-sm-12">
       <%= bootstrap_form_for patient, id: 'pledge-create-modal-form', remote: true do |f| %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Was working on something unrelated and and discovered that `target='_blank'` in links is a minor security flaw. It's not really a problem for us since I don't think we're pulling in anything external, but, you know.

This pull request makes the following changes:
* Adds `rel='noreferrer nofollow'` to a pair of links
* Missed a spot on changing online faxes to an env var, fixes that as long as I'm wrenching around

No view changes.

No issue.

@valeriecodes could I get a review at your leisure, if you'd be so kind? 