### PR TITLE
Migrating from FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :test do
   gem 'minitest-reporters'
   gem 'mini_backtrace'
   gem 'minitest-spec-rails'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'faker'
   gem 'database_cleaner'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,10 +115,10 @@ GEM
       activesupport (>= 3.2)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.8.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faker (1.7.3)
       i18n (~> 0.5)
@@ -376,7 +376,7 @@ DEPENDENCIES
   database_cleaner
   devise (~> 4.2.1)
   enumerize
-  factory_girl_rails
+  factory_bot_rails
   faker
   figaro
   geokit

--- a/lib/tasks/factory_girl.rake
+++ b/lib/tasks/factory_girl.rake
@@ -1,15 +1,15 @@
-namespace :factory_girl do
-  desc "Verify that all FactoryGirl factories are valid"
+namespace :factory_bot do
+  desc "Verify that all FactoryBot factories are valid"
   task lint: :environment do
     if Rails.env.test?
       begin
         DatabaseCleaner.start
-        FactoryGirl.lint
+        FactoryBot.lint
       ensure
         DatabaseCleaner.clean
       end
     else
-      system("bundle exec rake factory_girl:lint RAILS_ENV='test'")
+      system("bundle exec rake factory_bot:lint RAILS_ENV='test'")
     end
   end
 end

--- a/test/factories/call.rb
+++ b/test/factories/call.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :call do
     association :patient
     status 'Reached patient'
-    created_by { FactoryGirl.create(:user) }
+    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/factories/clinic.rb
+++ b/test/factories/clinic.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :clinic do
     sequence :name do |n| 
       "Friendly Clinic #{n}"

--- a/test/factories/config.rb
+++ b/test/factories/config.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :config do
     config_key :insurance
     config_value options: ['DC Medicaid', 'No insurance', "Don't know"]
-    created_by { FactoryGirl.create(:user) }
+    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/factories/event.rb
+++ b/test/factories/event.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :event do
     event_type 'Reached patient'
     cm_name 'Yolorita'

--- a/test/factories/external_pledge.rb
+++ b/test/factories/external_pledge.rb
@@ -1,10 +1,10 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :external_pledge do
     patient
     sequence :source do |n|
       "Fund #{n}"
     end
     amount 100
-    created_by { FactoryGirl.create(:user) }
+    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/factories/fulfillment.rb
+++ b/test/factories/fulfillment.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :fulfillment do
     patient
-    created_by { FactoryGirl.create(:user) }
+    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/factories/note.rb
+++ b/test/factories/note.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :note do
     patient
     full_text 'behold, a note'
-    created_by { FactoryGirl.create(:user) }
+    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/factories/patient.rb
+++ b/test/factories/patient.rb
@@ -1,9 +1,9 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :patient do
     name 'New Patient'
     sequence(:primary_phone, 100) { |n| "127-#{n}-1111" }
     line 'DC'
-    created_by { FactoryGirl.create(:user) }
+    created_by { FactoryBot.create(:user) }
     initial_call_date { 2.days.ago }
   end
 end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     name 'Billy Everyteen'
     sequence :email do |n|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ end
 DatabaseCleaner.clean_with :truncation
 
 class ActiveSupport::TestCase
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
 
   before { DatabaseCleaner.start }
   after  { DatabaseCleaner.clean }


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I changed the `FactoryGirl` gem to `FactoryBot`, and changed all references to it.

This pull request makes the following changes:
* Change FactoryGirl to FactoryBot

It relates to the following issue #s: 
* Fixes #1285
