### PR TITLE
Show inactive clinics in clinic dropdown

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -64,7 +64,7 @@ module PatientsHelper
                             .map { |clinic| [clinic.name, clinic.id] }
                             .unshift nil
     inactive_clinics = clinics.reject(&:active)
-                              .map { |clinic| ["(Not currently working with DCAF) -- #{clinic.name}", clinic.id] }
+                              .map { |clinic| ["(Not currently working with DCAF) - #{clinic.name}", clinic.id] }
                               .unshift ['--- INACTIVE CLINICS ---', nil]
     active_clinics | inactive_clinics
   end

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -59,10 +59,14 @@ module PatientsHelper
   end
 
   def clinic_options
-    Clinic.where(active: true)
-          .sort_by(&:name)
-          .map { |clinic| [clinic.name, clinic.id] }
-          .unshift nil
+    clinics = Clinic.all.sort_by(&:name)
+    active_clinics = clinics.select(&:active)
+                            .map { |clinic| [clinic.name, clinic.id] }
+                            .unshift nil
+    inactive_clinics = clinics.reject(&:active)
+                              .map { |clinic| ["(Not currently working with DCAF) -- #{clinic.name}", clinic.id] }
+                              .unshift ['--- INACTIVE CLINICS ---', nil]
+    active_clinics | inactive_clinics
   end
 
   def disable_continue?(patient)

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -50,6 +50,22 @@ class PatientsHelperTest < ActionView::TestCase
         assert Config.find_by(config_key: 'insurance')
       end
     end
+
+    describe 'clinic options' do
+      before do
+        @active = create :clinic, name: 'active clinic', active: true
+        @inactive = create :clinic, name: 'closed clinic', active: false
+      end
+
+      it 'should return all clinics' do
+        expected_clinic_array = [nil,
+                                 [@active.name, @active.id],
+                                 ['--- INACTIVE CLINICS ---', nil],
+                                 ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id]]
+
+        assert_same_elements clinic_options, expected_clinic_array
+      end
+    end
   end
 
   %w(race_ethnicity employment_status insurance income referred_by

--- a/test/integration/filter_medicaid_clinics_test.rb
+++ b/test/integration/filter_medicaid_clinics_test.rb
@@ -4,8 +4,8 @@ class FilterMedicaidClinicsTest < ActionDispatch::IntegrationTest
   before do
     Capybara.current_driver = :poltergeist
     @user = create :user, role: :cm
-    @Medicaid_clinic = create :clinic, name: 'Medicaid Accepted', accepts_medicaid: true
-    @nonMedicaid_clinic = create :clinic, name: 'No Medicaid here', accepts_medicaid: false
+    @medicaid_clinic = create :clinic, name: 'Medicaid Accepted', accepts_medicaid: true
+    @non_medicaid_clinic = create :clinic, name: 'No Medicaid here', accepts_medicaid: false
     @patient = create :patient
     log_in_as @user
     visit edit_patient_path @patient
@@ -15,19 +15,19 @@ class FilterMedicaidClinicsTest < ActionDispatch::IntegrationTest
 
   describe 'filtering to just Medicaid clinics' do
     it 'should filter to only Medicaid clinics when box is checked' do
-      assert has_select? 'patient_clinic_id', options: ['', @Medicaid_clinic.name,
-                                                             @nonMedicaid_clinic.name]
+      assert has_select? 'patient_clinic_id', with_options: [@medicaid_clinic.name,
+                                                             @non_medicaid_clinic.name]
 
       check 'medicaid_filter'
       sleep 1
       options_with_filter = find('#patient_clinic_id').all('option')
                                                       .map { |opt| { name: opt.text, disabled: opt['disabled'] } }
 
-      assert options_with_filter.find { |x| x[:name] == @nonMedicaid_clinic.name }[:disabled] == true
-      assert options_with_filter.find { |x| x[:name] == @Medicaid_clinic.name }[:disabled] == false
+      assert options_with_filter.find { |x| x[:name] == @non_medicaid_clinic.name }[:disabled] == true
+      assert options_with_filter.find { |x| x[:name] == @medicaid_clinic.name }[:disabled] == false
 
       # try to select and watch it not work
-      select @nonMedicaid_clinic.name, from: 'patient_clinic_id'
+      select @non_medicaid_clinic.name, from: 'patient_clinic_id'
       assert_equal '', find('#patient_clinic_id').value
     end
   end

--- a/test/integration/filter_naf_clinics_test.rb
+++ b/test/integration/filter_naf_clinics_test.rb
@@ -15,7 +15,7 @@ class FilterNafClinicsTest < ActionDispatch::IntegrationTest
 
   describe 'filtering to just NAF clinics' do
     it 'should filter to only NAF clinics when box is checked' do
-      assert has_select? 'patient_clinic_id', options: ['', @naf_clinic.name,
+      assert has_select? 'patient_clinic_id', with_options: [@naf_clinic.name,
                                                              @nonnaf_clinic.name]
 
       check 'naf_filter'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Some EOY reporting has made it clear that removing clinics from the roll entirely if we aren't working with them isn't a great option. So that people can still select them, this moves them to a bottom portion and marks them as inactive -- this way people doing reconciliation or fulfillments can still add them.

This pull request makes the following changes:
* Adds inactive clinics to the clinics helper
* Adds a test for said helper

Looks like so 

<img width="438" alt="screen shot 2017-11-17 at 6 58 33 pm" src="https://user-images.githubusercontent.com/3866868/32974083-96fd0f56-cbc9-11e7-8221-2c2321074882.png">

cc @alisonnjones @NerdyGirl537  -- can I get an approval of this strategy from you all?

It relates to the following issue #s: 
* Fixes #1305 
