### PR TITLE
Port over integration tests whose names start with C

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,7 +67,7 @@ class UsersController < ApplicationController
     @user.password, @user.password_confirmation = hex
     if @user.save
       flash[:notice] = 'User created!'
-      redirect_to session.delete(:return_to)
+      redirect_to users_path
     else
       # TODO if validation errors, render creation page with error msgs
       render 'new'

--- a/test/system/change_log_test.rb
+++ b/test/system/change_log_test.rb
@@ -1,8 +1,8 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class ChangeLogTest < ActionDispatch::IntegrationTest
+# Confirm that changes to patient record show up in the changelog
+class ChangeLogTest < ApplicationSystemTestCase
   before do
-    Capybara.current_driver = :poltergeist
     @user = create :user, email: 'first_user@email.com'
     @patient = create :patient, name: 'tester',
                                 primary_phone: '1231231234',
@@ -11,10 +11,6 @@ class ChangeLogTest < ActionDispatch::IntegrationTest
 
     log_in_as @user
     visit edit_patient_path(@patient)
-  end
-
-  after do
-    Capybara.use_default_driver
   end
 
   describe 'viewing the changelog' do

--- a/test/system/create_new_external_pledge_test.rb
+++ b/test/system/create_new_external_pledge_test.rb
@@ -1,8 +1,8 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class CreateNewExternalPledgeTest < ActionDispatch::IntegrationTest
+# Test around creating a new external pledge for a fund
+class CreateNewExternalPledgeTest < ApplicationSystemTestCase
   before do
-    Capybara.current_driver = :poltergeist
     @user = create :user
     @patient = create :patient
     log_in_as @user
@@ -10,8 +10,6 @@ class CreateNewExternalPledgeTest < ActionDispatch::IntegrationTest
     wait_for_element 'Abortion Information'
     click_link 'Abortion Information'
   end
-
-  after { Capybara.use_default_driver }
 
   describe 'creating and viewing a pledge' do
     it 'should let you create a new pledge' do

--- a/test/system/create_user_test.rb
+++ b/test/system/create_user_test.rb
@@ -19,26 +19,18 @@ class CreateUserTest < ApplicationSystemTestCase
 
     it 'should be able to create user' do
       assert has_field? 'Email'
-      fill_in 'Email', with: 'test@test.com'
-
-      assert has_field? 'Name'
+      fill_in 'Email', with: 'test@example.com'
       fill_in 'Name', with: 'Test User'
-
       click_button 'Add'
       assert has_content? 'Active', count: 2
     end
 
     it 'should validate form correctly' do
       click_button 'Add'
-
       assert_text "can't be blank"
 
       fill_in 'Email', with: 'test@test'
-
-      assert_no_difference 'Devise.mailer.deliveries.count' do
-        click_button 'Add'
-      end
-
+      click_button 'Add'
       assert_text 'is invalid'
     end
   end

--- a/test/system/create_user_test.rb
+++ b/test/system/create_user_test.rb
@@ -1,14 +1,7 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class CreateUserTest < ActionDispatch::IntegrationTest
-  before do
-    Capybara.current_driver = :poltergeist
-  end
-
-  after do
-    Capybara.use_default_driver
-  end
-
+# Behavior and permissioning around creating new users
+class CreateUserTest < ApplicationSystemTestCase
   describe 'nonadmin user' do
     before { visit root_path }
 
@@ -21,17 +14,10 @@ class CreateUserTest < ActionDispatch::IntegrationTest
     before do
       @user = create :user, role: :admin
       log_in_as @user
-      @mail_mock = Minitest::Mock.new
-      @mail_mock.expect :deliver_now, nil
+      visit new_user_path
     end
 
     it 'should be able to create user' do
-      click_link 'Admin'
-      assert_text 'User Management'
-      click_link 'User Management'
-      wait_for_element 'User Account Management'
-      click_link 'Add New User'
-
       assert has_field? 'Email'
       fill_in 'Email', with: 'test@test.com'
 
@@ -43,7 +29,6 @@ class CreateUserTest < ActionDispatch::IntegrationTest
     end
 
     it 'should validate form correctly' do
-      visit new_user_path
       click_button 'Add'
 
       assert_text "can't be blank"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Moves over integration tests starting with the letter C.

This pull request makes the following changes:
* Moves over integration tests starting with the letter C.

No view changes.

It relates to the following issue #s: 
* Bumps #1318
