### PR TITLE
Port over integration tests beginning with the letter S and T

### DIFF
--- a/test/system/select_line_test.rb
+++ b/test/system/select_line_test.rb
@@ -1,9 +1,8 @@
-require 'test_helper'
+require 'application_system_test_case'
 
 # Tests around line selection behavior
-class SelectLineTest < ActionDispatch::IntegrationTest
+class SelectLineTest < ApplicationSystemTestCase
   before do
-    Capybara.current_driver = :poltergeist
     @user = create :user
     log_in @user
   end

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -1,27 +1,27 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class SubmitPledgeTest < ActionDispatch::IntegrationTest
+# Tests around plege submission behavior
+class SubmitPledgeTest < ApplicationSystemTestCase
   before do
-    Capybara.current_driver = :poltergeist
     @user = create :user, role: :data_volunteer
     @clinic = create :clinic
     @patient = create :patient, clinic: @clinic,
                                 appointment_date: Time.zone.now + 14,
                                 fund_pledge: 500,
                                 urgent_flag: true
+
     log_in_as @user
     visit edit_patient_path @patient
     has_text? 'First and last name'
   end
-
-  after { Capybara.use_default_driver }
 
   # this is a test for a persistent turbolinks bug
   it 'should load properly without other page touches' do
     visit dashboard_path
     click_link @patient.name
     find('#submit-pledge-button').click
-    sleep 2
+    wait_for_ajax
+
     assert has_text? 'Confirm the following information is correct'
   end
 
@@ -31,7 +31,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_element 'Patient name'
       assert has_text? 'Confirm the following information is correct'
       find('#pledge-next').click
-      sleep 2 # out of ideas
+      wait_for_ajax
 
       wait_for_no_element 'Confirm the following information is correct'
       assert has_text? 'Generate your pledge form'
@@ -61,7 +61,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_element 'Patient name'
       assert has_text? 'Confirm the following information is correct'
       find('#pledge-next').click
-      sleep 2 # out of ideas
+      wait_for_ajax
 
       wait_for_no_element 'Confirm the following information is correct'
       assert has_text? 'Generate your pledge form'
@@ -103,7 +103,7 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_element 'If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page'
       assert has_text? 'Cancel pledge:'
       find('#pledge-next').click
-      sleep 1 # :(
+      wait_for_ajax
 
       assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
       find('#pledge-next').click
@@ -126,8 +126,6 @@ class SubmitPledgeTest < ActionDispatch::IntegrationTest
       wait_for_no_element 'Cancel pledge:'
       assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
       find('#patient_pledge_sent').click
-      wait_for_ajax
-      sleep 1 # out of ideas
       wait_for_ajax
 
       find('#pledge-next').click

--- a/test/system/table_content_test.rb
+++ b/test/system/table_content_test.rb
@@ -1,6 +1,7 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class TableContentTest < ActionDispatch::IntegrationTest
+# Testing around call list table content
+class TableContentTest < ApplicationSystemTestCase
   # problematic test
   before do
     @user = create :user


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Port over integration tests beginning with S and T

This pull request makes the following changes:
* That thing I said

No view changes

It relates to the following issue #s: 
* Bumps #1318 
