### PR TITLE
Port system tests starting with U and V

### DIFF
--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -1,6 +1,7 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class UpdatingConfigsTest < ActionDispatch::IntegrationTest
+# Confirm behavior around updating fund-editable settings
+class UpdatingConfigsTest < ApplicationSystemTestCase
   describe 'non-admin redirect' do
     [:data_volunteer, :cm].each do |role|
       it "should deny access as a #{role.to_s}" do
@@ -14,14 +15,11 @@ class UpdatingConfigsTest < ActionDispatch::IntegrationTest
 
   describe 'admin usage' do
     before do
-      Capybara.current_driver = :poltergeist
       @patient = create :patient
       @user = create :user, role: :admin
       log_in_as @user
       visit configs_path
     end
-
-    after { Capybara.use_default_driver }
 
     describe 'updating a config - insurance' do
       it 'should update and be available' do

--- a/test/system/urgent_cases_test.rb
+++ b/test/system/urgent_cases_test.rb
@@ -1,15 +1,11 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class UrgentCasesTest < ActionDispatch::IntegrationTest
+# Test behavior around urgent cases list
+class UrgentCasesTest < ApplicationSystemTestCase
   before do
-    Capybara.current_driver = :poltergeist
     @patient = create :patient, name: 'Susan Everyteen', urgent_flag: true
     @user = create :user
     log_in_as @user
-  end
-
-  after do
-    Capybara.use_default_driver
   end
 
   describe 'urgent cases section' do

--- a/test/system/user_management_test.rb
+++ b/test/system/user_management_test.rb
@@ -1,8 +1,8 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class UserManagementTest < ActionDispatch::IntegrationTest
+# Confirm user management functionality
+class UserManagementTest < ApplicationSystemTestCase
   before do
-    Capybara.current_driver = :poltergeist
     @user = create :user,
                    name: 'john',
                    email: 'user@dcaf.com',

--- a/test/system/voicemail_preference_in_call_modal_test.rb
+++ b/test/system/voicemail_preference_in_call_modal_test.rb
@@ -1,14 +1,12 @@
-require 'test_helper'
+require 'application_system_test_case'
 
-class VoicemailPreferenceInCallModalTest < ActionDispatch::IntegrationTest
+# Confirm display behavior around whether a patient should receive VMs
+class VoicemailPreferenceInCallModalTest < ApplicationSystemTestCase
   before do
-    Capybara.current_driver = :poltergeist
     @patient = create :patient, name: 'Susan Everyteen'
     @user = create :user
     log_in_as @user
   end
-
-  after { Capybara.use_default_driver }
 
   describe 'different voicemail preferences and links' do
     describe 'no voicemail' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Port over system tests starting with U and V. After this, we'll remove some of the old integration test artifacts like poltergeist, phantom, etc., and rerack knapsack.

This pull request makes the following changes:
* Does what it says on the label

No view changes

It relates to the following issue #s: 
* Bumps #1318 
