### PR TITLE
Remove all btn

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks
 
 task clear_call_lists: :environment do
-  User.all.each(&:clear_call_list)
+  User.all.each(&:clean_call_list_between_shifts)
 end
 
 Knapsack.load_tasks if defined?(Knapsack)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -94,7 +94,7 @@ class UsersController < ApplicationController
   end
 
   def clear_current_user_call_list
-    current_user.patients.clear
+    current_user.clear_call_list
     respond_to do |format|
       format.js { render template: 'users/refresh_patients', layout: false }
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,21 +82,21 @@ class UsersController < ApplicationController
   def add_patient
     current_user.add_patient @patient
     respond_to do |format|
-      format.js { render template: 'users/refresh_patients' }
+      format.js { render template: 'users/refresh_patients', layout: false }
     end
   end
 
   def remove_patient
     current_user.remove_patient @patient
     respond_to do |format|
-      format.js { render template: 'users/refresh_patients'}
+      format.js { render template: 'users/refresh_patients', layout: false }
     end
   end
 
   def clear_current_user_call_list
     current_user.patients.clear
     respond_to do |format|
-      format.js { render template: 'users/refresh_patients' }
+      format.js { render template: 'users/refresh_patients', layout: false }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   before_action :confirm_admin_user, only: [:new, :index, :update]
   before_action :find_user, only: [:update, :edit, :destroy, :reset_password]
 
-  rescue_from Mongoid::Errors::DocumentNotFound, with: -> { head :bad_request }
+  rescue_from Mongoid::Errors::DocumentNotFound, with: -> { head :not_found }
   rescue_from Exceptions::UnauthorizedError, with: -> { head :unauthorized }
 
   def index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,6 @@ class User
   enumerize :role, in: [:cm, :admin, :data_volunteer], predicates: true
   field :call_order, type: Array
 
-
   ## Database authenticatable
   field :email,              type: String, default: ''
   field :encrypted_password, type: String, default: ''
@@ -143,7 +142,7 @@ class User
     ordered_patients
   end
 
-  def clear_call_list
+  def clean_call_list_between_shifts
     if last_sign_in_at.present? &&
        last_sign_in_at < Time.zone.now - TIME_BEFORE_INACTIVE
       patients.clear
@@ -153,6 +152,10 @@ class User
         patients.delete(p) if recently_reached_by_user?(p)
       end
     end
+  end
+
+  def clear_call_list
+    patients.clear
   end
 
   def admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,6 +156,7 @@ class User
 
   def clear_call_list
     patients.clear
+    save
   end
 
   def admin?

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -45,7 +45,7 @@
       <% end %>
     </tbody>
   </table>
-  <% if table_type == 'call_list' && current_user.patients.count > 0%>
+  <% if table_type == 'call_list' && current_user.patients.count.nonzero? %>
     <%= link_to "Clear your call list", clear_current_user_call_list_path(current_user), class:"pull-right text-danger", data: { confirm: "Are you sure you want to clear your current call list? This will also clear completed calls." }, method: :patch, remote: true %>
   <% end %>
 </div>

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -46,6 +46,6 @@
     </tbody>
   </table>
   <% if table_type == 'call_list' && current_user.patients.count.nonzero? %>
-    <%= link_to "Clear your call list", clear_current_user_call_list_path(current_user), class:"pull-right text-danger", data: { confirm: "Are you sure you want to clear your current call list? This will also clear completed calls." }, method: :patch, remote: true %>
+    <%= link_to "Clear your call list", clear_current_user_call_list_path, class: "pull-right text-danger", data: { confirm: "Are you sure you want to clear your current call list? This will also clear completed calls." }, method: :patch, remote: true %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,11 @@ Rails.application.routes.draw do
 
     # User routes behind the authentication wall
     patch 'users/reorder_call_list', to: 'users#reorder_call_list', as: 'reorder_call_list', defaults: { format: :js }
+    patch 'users/clear_current_user_call_list', to: 'users#clear_current_user_call_list', as: 'clear_current_user_call_list', defaults: { format: :js }
     resources :users, only: [:new, :create, :index, :edit, :update]
     patch 'users/:user_id/add_patient/:id', to: 'users#add_patient', as: 'add_patient', defaults: { format: :js }
     patch 'users/:user_id/remove_patient/:id', to: 'users#remove_patient', as: 'remove_patient', defaults: { format: :js }
     post 'users/search', to: 'users#search', as: 'users_search', defaults: { format: :js }
-    patch 'users/:user_id/clear_current_user_call_list', to: 'users#clear_current_user_call_list', as: 'clear_current_user_call_list', defaults: { format: :js }
     # TODO reset password
     # get 'users/:id/reset_password', to: 'users#reset_password', as: 'reset_password'
     # TODO toggle lock route

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -147,9 +147,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    it 'should should return bad request on sketch ids' do
+    it 'should should return not found on sketch ids' do
       patch add_patient_path(@user, 'nopatient'), xhr: true
-      assert_response :bad_request
+      assert_response :not_found
     end
   end
 
@@ -181,7 +181,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     it 'should should return bad request on sketch ids' do
       patch remove_patient_path(@user, 'whatever'), xhr: true
-      assert_response :bad_request
+      assert_response :not_found
     end
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -189,6 +189,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     before do
       patch add_patient_path(@user, @patient_1), xhr: true
       patch add_patient_path(@user, @patient_2), xhr: true
+      @user.reload
     end
 
     it 'should respond successfully' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -200,6 +200,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     it 'should clear all patients for a user' do
       assert_difference '@user.patients.count', -2 do
         patch clear_current_user_call_list_path, xhr: true
+        @user.reload
       end
     end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -189,26 +189,24 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     before do
       patch add_patient_path(@user, @patient_1), xhr: true
       patch add_patient_path(@user, @patient_2), xhr: true
-      assert_equal @user.patients.count, 2
-      patch clear_current_user_call_list_path(@user), xhr: true
-      @user.reload
     end
 
     it 'should respond successfully' do
+      patch clear_current_user_call_list_path, xhr: true
       assert_response :success
     end
 
-    it 'should destroy all patients' do
-      assert_equal @user.patients.count, 0
-    end
-
-    it 'should not destroy patients' do
-      patch add_patient_path(@user, @patient_2), xhr: true
-      assert_no_difference 'Patient.count' do
-        patch clear_current_user_call_list_path(@user), xhr: true
+    it 'should clear all patients for a user' do
+      assert_difference '@user.patients.count', -2 do
+        patch clear_current_user_call_list_path, xhr: true
       end
     end
 
+    it 'should not destroy patients' do
+      assert_no_difference 'Patient.count' do
+        patch clear_current_user_call_list_path, xhr: true
+      end
+    end
   end
 
   describe 'reorder call list' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -101,6 +101,12 @@ class UserTest < ActiveSupport::TestCase
 
       assert_not @user.patients.empty?
     end
+
+    it 'should clear call list when someone invokes the cleanout' do
+      assert_difference '@user.patients.count', -3 do
+        @user.clear_call_list
+      end
+    end
   end
 
   describe 'patient methods' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,13 +65,13 @@ class UserTest < ActiveSupport::TestCase
       assert_equal 1, @user.call_list_patients('DC').count
     end
 
-    it 'should clear calls when patient has been reached' do
+    it 'should clean calls when patient has been reached' do
       assert_equal 0, @user.recently_called_patients.count
       @call = create :call, patient: @patient,
                             created_by: @user,
                             status: 'Reached patient'
       assert_equal 1, @user.recently_called_patients.count
-      @user.clear_call_list
+      @user.clean_call_list_between_shifts
       assert_equal 0, @user.recently_called_patients.count
     end
 
@@ -81,7 +81,7 @@ class UserTest < ActiveSupport::TestCase
                             created_by: @user,
                             status: 'Left voicemail'
       assert_equal 1, @user.recently_called_patients.count
-      @user.clear_call_list
+      @user.clean_call_list_between_shifts
       assert_equal 1, @user.recently_called_patients.count
     end
 
@@ -89,7 +89,7 @@ class UserTest < ActiveSupport::TestCase
       assert_not @user.patients.empty?
       last_sign_in = Time.zone.now - User::TIME_BEFORE_INACTIVE - 1.day
       @user.last_sign_in_at = last_sign_in
-      @user.clear_call_list
+      @user.clean_call_list_between_shifts
 
       assert @user.patients.empty?
     end
@@ -97,7 +97,7 @@ class UserTest < ActiveSupport::TestCase
     it 'should not clear patient list if user signed in recently' do
       assert_not @user.patients.empty?
       @user.last_sign_in_at = Time.zone.now
-      @user.clear_call_list
+      @user.clean_call_list
 
       assert_not @user.patients.empty?
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -97,7 +97,7 @@ class UserTest < ActiveSupport::TestCase
     it 'should not clear patient list if user signed in recently' do
       assert_not @user.patients.empty?
       @user.last_sign_in_at = Time.zone.now
-      @user.clean_call_list
+      @user.clean_call_list_between_shifts
 
       assert_not @user.patients.empty?
     end

--- a/test/system/call_list_test.rb
+++ b/test/system/call_list_test.rb
@@ -115,6 +115,23 @@ class CallListTest < ApplicationSystemTestCase
     end
   end
 
+  describe 'clearing a call list' do
+    before { add_to_call_list @patient_2 }
+
+    it 'should empty out a users call list' do
+      visit authenticated_root_path
+      within :css, '#call_list_content' do
+        assert has_text? @patient_2.name
+      end
+
+      assert has_link? 'Clear your call list'
+      accept_confirm { click_link 'Clear your call list' }
+      within :css, '#call_list_content' do
+        refute has_text? @patient_2.name
+      end
+    end
+  end
+
   private
 
   def add_to_call_list(patient)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

A couple additional things from @tingaloo 's work in #1274 --

* renames existing `clear_call_list` method to be clearer about intent, and adds a `clear_call_list` method that does what this is supposed to
* removes need for associated user id in params, running off current user... OR DOES IT??? (test failure)

UserControllerTest is currently choking, so that sucks. Not sure why and am not in a mind to fix it tonight. 

This pull request makes the following changes:
* Adds remove all patients from your call list btn
* some other assorted cleanup

TK integration test, model test.

![image](https://user-images.githubusercontent.com/3866868/34077683-ab1bacd4-e2d7-11e7-8973-70d75e1a364d.png)

It relates to the following issue #s: 
* Fixes #1202 
