### PR TITLE
Update secure headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'rack-attack', '~> 5.0.1'
 gem 'rack-test', '~> 0.6.3', require: 'rack/test'
 gem 'clinic_finder', '~> 0.0.1'
 gem 'geokit'
-gem 'secure_headers', '~> 3.6', '>= 3.6.4'
+gem 'secure_headers', '~> 5'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,8 +303,8 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    secure_headers (3.6.7)
-      useragent
+    secure_headers (5.0.4)
+      useragent (>= 0.15.0)
     selenium-webdriver (3.5.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -411,7 +411,7 @@ DEPENDENCIES
   ruby_audit
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  secure_headers (~> 3.6, >= 3.6.4)
+  secure_headers (~> 5)
   selenium-webdriver
   shoulda-context
   simplecov

--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -5,10 +5,10 @@ SecureHeaders::Configuration.default do |config|
   config.csp = {
     preserve_schemes: true, # default: false.
     default_src: %w('self'),
-    script_src: ["'self'", "'unsafe-eval'", gon_gem_sha, popover_sha],
+    script_src: ["'self'", "'unsafe-eval'", gon_gem_sha, popover_sha, 'https'],
     font_src: %w('self' fonts.gstatic.com),
     connect_src: %w('self'),
-    style_src: %w('self' 'unsafe-inline'),
+    style_src: %w('self' 'unsafe-inline' https),
     report_uri: ["https://#{ENV['CSP_VIOLATION_URI']}/csp/reportOnly"]
   }
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We're good on #893 -- this nails it shut the rest of the way by bringing the secure headers gem up to speed.

This pull request makes the following changes:
* bump secure headers from 3 to 5
* slight change to policy to reflect new defaults
* resolve ugly merge conflict

No view changes.

**We should make sure to test this in sandbox since this has caused silent failures before!

It relates to the following issue #s: 
* Fixes #893 
