### PR TITLE
ruby 2.4.2 becomes ruby 2.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.2-alpine
+FROM ruby:2.5.0-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.0-alpine
+FROM ruby:2.4.3-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com> 
 
 # configure environment variable

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.0'
+ruby '2.4.3'
 
 gem 'rails', '>= 5.1'
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.2'
+ruby '2.5.0'
 
 gem 'rails', '>= 5.1'
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,7 @@ DEPENDENCIES
   uglifier (>= 3.2.0)
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.3p205
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.5.0
+    version: 2.4.3
   pre:
     - sudo apt-get install libfontconfig
   services:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.4.2
+    version: 2.5.0
   pre:
     - sudo apt-get install libfontconfig
   services:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -36,7 +36,7 @@ If you prefer a local environment, totally cool! We recommend the following:
 
 ### First, ruby dependencies
 * Make sure you have a ruby version manager installed; we recommend either [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/)
-* Install our version of Ruby! We use version `2.5.0` (Usually `rbenv install 2.5.0` or `rvm install 2.5.0` once you have your version manager set up)
+* Install our version of Ruby! We use version `2.4.3` (Usually `rbenv install 2.4.3` or `rvm install 2.4.3` once you have your version manager set up)
 * Install PhantomJS, which our test suite depends on, via `brew install phantomjs`, or `npm install -g phantomjs-prebuilt`, or the [linux instructions](http://phantomjs.org/download.html)
 * Run the command `gem install bundler && bundle install` to install ruby dependences, including `rails`
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -69,7 +69,7 @@ If you don't currently have Rails installed (or are on Windows), Cloud9 makes th
 
 * Sign into `https://c9.io/` and create a new workspace
 * Clone from `git@github.com:{your_github_username}/dcaf_case_management.git` and select the Rails option
-* The terminal at the bottom of your new workspace will have a warning message saying "ruby-2.4.2 is not installed. To install do: `rvm install ruby-2.4.2`". Run that command to install the necessary version of Ruby.
+* The terminal at the bottom of your new workspace will have a warning message saying "ruby-2.4.3 is not installed. To install do: `rvm install ruby-2.4.3`". Run that command to install the necessary version of Ruby.
 * Next, install the bundler gem by entering `gem install bundler` in the terminal.
 * Install MongoDB by entering `sudo apt-get install -y mongodb-org`.
 * Once MongoDB is installed, run `bundle install` in the terminal

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -36,7 +36,7 @@ If you prefer a local environment, totally cool! We recommend the following:
 
 ### First, ruby dependencies
 * Make sure you have a ruby version manager installed; we recommend either [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/)
-* Install our version of Ruby! We use version `2.4.2` (Usually `rbenv install 2.4.2` or `rvm install 2.4.2` once you have your version manager set up)
+* Install our version of Ruby! We use version `2.5.0` (Usually `rbenv install 2.5.0` or `rvm install 2.5.0` once you have your version manager set up)
 * Install PhantomJS, which our test suite depends on, via `brew install phantomjs`, or `npm install -g phantomjs-prebuilt`, or the [linux instructions](http://phantomjs.org/download.html)
 * Run the command `gem install bundler && bundle install` to install ruby dependences, including `rails`
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We've got us a ruby vuln. Not an emergency since we don't do ftp though.

This pull request makes the following changes:
* Bumps ruby to ~2.5.0~ 2.4.3

No view changes. 

No issues.

  