### PR TITLE
Allow admins to change roles ctd

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,10 @@ class ApplicationController < ActionController::Base
     redirect_to root_url unless current_user.admin?
   end
 
+  def confirm_admin_user_async
+    head :unauthorized unless current_user.admin?
+  end
+
   def redirect_unless_has_data_access
     redirect_to root_url unless current_user.allowed_data_access?
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,15 +11,14 @@ class UsersController < ApplicationController
     @users = User.all
   end
 
-  def edit
-  end
+  def edit; end
 
   def search # TODO needs more rigorous testing
-    if params[:search].empty?
-      @results = User.all
-    else
-      @results = User.search params[:search]
-    end
+    @results = if params[:search].empty?
+                 User.all
+               else
+                 User.search params[:search]
+               end
     respond_to { |format| format.js }
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,12 +63,12 @@ class UsersController < ApplicationController
   end
 
   def change_role_to_data_volunteer
-    @user.update role: 'data_volunteer' if user_not_demoting_themself(@user)
+    @user.update role: 'data_volunteer' if user_not_demoting_themself?(@user)
     render 'edit'
   end
 
   def change_role_to_cm
-    @user.update role: 'cm' if user_not_demoting_themself(@user)
+    @user.update role: 'cm' if user_not_demoting_themself?(@user)
     render 'edit'
   end
 
@@ -142,7 +142,7 @@ class UsersController < ApplicationController
     @urgent_patient = Patient.where(urgent_flag: true)
   end
 
-  def user_not_demoting_themself(user)
+  def user_not_demoting_themself?(user)
     if user.id == current_user.id && current_user.role == 'admin'
       flash[:alert] = 'For safety reasons, you are not allowed to change ' \
                       'your role from an admin to a not-admin. Ask another '\

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,4 +15,11 @@ module UsersHelper
       'Active'
     end
   end
+
+  def role_toggle_button(user, new_role)
+    link_to "Change #{user.name}'s role to #{new_role.titleize}",
+            public_send("change_role_to_#{new_role}_path", user),
+            method: :patch,
+            class: 'btn btn-warning'
+  end
 end

--- a/app/models/concerns/user_searchable.rb
+++ b/app/models/concerns/user_searchable.rb
@@ -6,13 +6,12 @@ module UserSearchable
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
 
   class_methods do
-
     def search(name_or_email_str)
-      name_regexp = /#{Regexp.escape(name_or_email_str)}/i
-      email_regexp = (VALID_EMAIL_REGEX).match(name_or_email_str)
+      regexp = /#{Regexp.escape(name_or_email_str)}/i
+      # email_regexp = (VALID_EMAIL_REGEX).match(name_or_email_str)
 
-      all_matching_names = find_name_matches name_regexp
-      all_matching_emails = find_email_matches email_regexp
+      all_matching_names = find_name_matches regexp
+      all_matching_emails = find_email_matches regexp
 
       sort_and_limit_user_matches(all_matching_names, all_matching_emails)
     end

--- a/app/models/concerns/user_searchable.rb
+++ b/app/models/concerns/user_searchable.rb
@@ -8,7 +8,6 @@ module UserSearchable
   class_methods do
     def search(name_or_email_str)
       regexp = /#{Regexp.escape(name_or_email_str)}/i
-      # email_regexp = (VALID_EMAIL_REGEX).match(name_or_email_str)
 
       all_matching_names = find_name_matches regexp
       all_matching_emails = find_email_matches regexp

--- a/app/views/users/_users_table.html.erb
+++ b/app/views/users/_users_table.html.erb
@@ -12,7 +12,7 @@
       <th>Status</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody id='user-results'>
     <% if users.present? %>
       <% users.each do |user| %>
         <tr>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,43 +1,39 @@
-<div class="row">
-  <h1><%= @user.name %></h1>
-</div>
-<div class="row">
-  <div class="col-sm-12">
-    <h3> Status: <%= user_lock_status(@user) %></h3>
-    <h3> Last login: <%= @user.last_sign_in_at %> </h3>
+<div class="col-sm-12">
+  <div class="row" id='user-topline'>
+    <h1><%= @user.name %></h1>
+    <h4>Role: <%= @user.role.to_s %></h4>
+    <p>Status: <%= user_lock_status(@user) %></p>
+    <p>Last login: <%= @user.last_sign_in_at %></p>
   </div>
-</row>
-<div class="row">
-  <div class="col-sm-12">
-    <%#= link_to "Reset Password", reset_password_path(@user), class: "btn btn-primary" %>
-    <% if @user != current_user %>
-      <% if @user.access_locked? %>
-        <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button>
-        <%#= link_to "Unlock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
-      <% else %>
-        <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button>
-        <%#= link_to "Lock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
-      <% end %>
+
+  <div class="row">
+    <h3>Update details</h3>
+    <%= bootstrap_form_for @user, html: { id: 'user-form' } do |f| %>
+      <%= f.text_field :name, label: 'Name', autocomplete: 'off' %>
+
+      <%= f.text_field :email, label: 'Email', autocomplete: 'off' %>
+
+      <%= f.submit "Save", class: 'btn btn-primary' %>
     <% end %>
   </div>
-</row>
-<div class="row">
-  <div class="col-sm-12">
-    <h3> User details </h3>
-    <%= bootstrap_form_for @user, html: { id: 'user-form' } do |f| %>
 
-      <div class="col-sm-6">
-        <%= f.text_field :name, label: 'Name', autocomplete: 'off' %>
-
-        <%= f.text_field :email, label: 'Email', autocomplete: 'off' %>
-
-        <%= f.select :role,
-                   options_for_select(user_role_options,
-                                      @user.role),
-                                      label: 'Role' %>
-
-        <%= f.submit "Save", class: 'btn btn-primary' %>
-        <%= link_to "Cancel", users_path %>
+  <% if @user != current_user %>
+  <div class="row" id='user-panel'>
+    <h3>User panel for administrators</h3>
+    <%#= link_to "Reset Password", reset_password_path(@user), class: "btn btn-primary" %>
+      <%# if @user.access_locked? %>
+        <!-- <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button> -->
+        <%#= link_to "Unlock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
+      <%# else %>
+        <!-- <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button> -->
+        <%#= link_to "Lock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
+      <%# end %>
+      
+      <h4>Update this user's role</h4>
+      <div class="btn-group" role='group'>
+        <%= role_toggle_button @user, 'admin' %>      
+        <%= role_toggle_button @user, 'data_volunteer' %>      
+        <%= role_toggle_button @user, 'cm' %>        
       </div>
     <% end %>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -18,16 +18,16 @@
   </div>
 
   <% if @user != current_user %>
-  <div class="row" id='user-panel'>
-    <h3>User panel for administrators</h3>
-    <%#= link_to "Reset Password", reset_password_path(@user), class: "btn btn-primary" %>
-      <%# if @user.access_locked? %>
-        <!-- <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button> -->
-        <%#= link_to "Unlock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
-      <%# else %>
-        <!-- <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button> -->
-        <%#= link_to "Lock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
-      <%# end %>
+    <div class="row" id='user-panel'>
+      <h3>User panel for administrators</h3>
+      <%#= link_to "Reset Password", reset_password_path(@user), class: "btn btn-primary" %>
+        <%# if @user.access_locked? %>
+          <!-- <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button> -->
+          <%#= link_to "Unlock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
+        <%# else %>
+          <!-- <button type="button" class="btn btn-primary">Toggle Lock (WIP)</button> -->
+          <%#= link_to "Lock Account", toggle_lock_path(@user), class: "btn btn-primary" %>
+        <%# end %>
       
       <h4>Update this user's role</h4>
       <div class="btn-group" role='group'>
@@ -35,6 +35,6 @@
         <%= role_toggle_button @user, 'data_volunteer' %>      
         <%= role_toggle_button @user, 'cm' %>        
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/users/search.js.erb
+++ b/app/views/users/search.js.erb
@@ -1,9 +1,6 @@
-
 <% if @results.any? %>
   $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: @results, autosortable: true }) %>");
-
-<%= render partial: 'shared/activate_stupidtable' %>
-
+  <%= render partial: 'shared/activate_stupidtable' %>
 <% else %>
   $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: nil, autosortable: true }) %>");
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
     patch 'users/:user_id/add_patient/:id', to: 'users#add_patient', as: 'add_patient', defaults: { format: :js }
     patch 'users/:user_id/remove_patient/:id', to: 'users#remove_patient', as: 'remove_patient', defaults: { format: :js }
     post 'users/search', to: 'users#search', as: 'users_search', defaults: { format: :js }
+    patch 'users/:id/change_role_to_admin', to: 'users#change_role_to_admin', as: 'change_role_to_admin'
+    patch 'users/:id/change_role_to_data_volunteer', to: 'users#change_role_to_data_volunteer', as: 'change_role_to_data_volunteer'
+    patch 'users/:id/change_role_to_cm', to: 'users#change_role_to_cm', as: 'change_role_to_cm'
     # TODO reset password
     # get 'users/:id/reset_password', to: 'users#reset_password', as: 'reset_password'
     # TODO toggle lock route

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -21,6 +21,16 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    %w[admin data_volunteer cm].each do |endpoint|
+      it "should redirect if user is not admin - #{endpoint}" do
+        User.role.values.reject { |role| role == :admin }.each do |role|
+          @user.update role: role
+          patch send("change_role_to_#{endpoint}_path".to_sym, @user_2)
+          assert_response :redirect
+        end
+      end
+    end
+
     it 'should respond unauthorized if user is not admin - users_search' do
       User.role.values.reject { |role| role == :admin }.each do |role|
         @user.update role: role

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -141,6 +141,24 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
                      flash[:alert]
       end
     end
+
+    describe 'users demotion rules' do
+      it 'should not let a user demote themself from admin' do
+        patch user_path(@user), params: { user: { role: 'cm' } }
+        assert_includes flash[:alert], 'For safety reasons'
+
+        @user.reload
+        assert_equal 'admin', @user.role
+      end
+
+      it 'should let a user demote others from admin' do
+        @other_admin = create :user, role: 'admin'
+        patch user_path(@other_admin), params: { user: { role: 'cm' } }
+
+        @other_admin.reload
+        assert_equal 'cm', @other_admin.role
+      end
+    end
   end
 
   # TODO test

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -93,8 +93,10 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   describe 'create method' do
     it 'should create a user' do
+      attributes = attributes_for(:user)
+      attributes.delete :role
       assert_difference 'User.count', 1 do
-        post users_path, params: { user: attributes_for(:user) }
+        post users_path, params: { user: attributes }
       end
     end
 

--- a/test/system/call_list_test.rb
+++ b/test/system/call_list_test.rb
@@ -126,6 +126,7 @@ class CallListTest < ApplicationSystemTestCase
 
       assert has_link? 'Clear your call list'
       accept_confirm { click_link 'Clear your call list' }
+      wait_for_ajax
       within :css, '#call_list_content' do
         refute has_text? @patient_2.name
       end

--- a/test/system/change_user_roles_test.rb
+++ b/test/system/change_user_roles_test.rb
@@ -1,0 +1,31 @@
+require 'application_system_test_case'
+
+# Test that the buttons to change user roles work
+class ChangeUserRolesTest < ApplicationSystemTestCase
+  before do
+    @user = create :user, role: 'admin', name: 'Billy'
+    @user2 = create :user, role: 'cm', name: 'Susie'
+    log_in_as @user
+  end
+
+  describe 'changing a user role' do
+    it 'should let you swap roles back and forth' do
+      visit edit_user_path @user2
+      click_link "Change Susie's role to Admin"
+      assert has_content? 'Role: admin'
+
+      click_link "Change Susie's role to Data Volunteer"
+      assert has_content? 'Role: data_volunteer'
+
+      click_link "Change Susie's role to Cm"
+      assert has_content? 'Role: cm'
+    end
+  end
+
+  describe 'trying to change your own role' do
+    it 'should not show you the options to do that' do
+      visit edit_user_path @user
+      refute has_content? "Change Billy's role to Data Volunteer"
+    end
+  end
+end

--- a/test/system/user_management_test.rb
+++ b/test/system/user_management_test.rb
@@ -138,12 +138,5 @@ class UserManagementTest < ApplicationSystemTestCase
       click_link 'john'
       assert has_field? 'Email', with: 'johan@gmail.com'
     end
-
-    it 'allows role editing' do
-      select 'Admin', from: 'Role'
-      click_button 'Save'
-      wait_for_element 'Successfully updated user details'
-      refute_text 'cm'
-    end
   end
 end

--- a/test/system/user_searches_test.rb
+++ b/test/system/user_searches_test.rb
@@ -1,0 +1,42 @@
+require 'application_system_test_case'
+
+# Confirm that user search works like we think it does
+class UserSearchesTest < ApplicationSystemTestCase
+  before do
+    @user = create :user, role: 'admin', email: 'admin_user@dcabortionfund.org'
+    @user2 = create :user, role: 'cm',
+                           email: 'metallica@test.com',
+                           name: 'Metallica'
+    @user3 = create :user, role: 'cm', email: 'mind_eraser@test.com'
+    log_in_as @user
+    visit users_path
+  end
+
+  describe 'searching for users' do
+    it 'should return matching users on name' do
+      fill_in 'Search', with: 'Metallica'
+      click_button 'Search'
+
+      within '#user-results' do
+        assert has_selector?('tr', count: 1)
+      end
+    end
+
+    it 'should return matching users on email' do
+      fill_in 'Search', with: 'test.com'
+      click_button 'Search'
+
+      within '#user-results' do
+        assert has_selector?('tr', count: 2)
+      end
+    end
+
+    it 'should return everybody on blank' do
+      click_button 'Search'
+
+      within '#user-results' do
+        assert has_selector?('tr', count: 3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Continues #1272 - Made a quick change to allow roles to be permitted on update.

This pull request makes the following changes:
* Whitelists user role so an admin can change it
* Adds a safety so admins cannot demote themselves
* Overhauls the users controller test

It relates to the following issue #s: 
* Fixes #1271 

  