### PR TITLE
Cancel checkbox 2

### DIFF
--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -1,58 +1,62 @@
-<%= render '/shared/multi_modal', disable_next: disable_continue?(patient), :captured => capture { %>
-
 <% if not patient.pledge_sent %>
-  <div class="row hide" data-step="1" data-title="Confirm the following information is correct:">
-    <% if patient.pledge_info_present? %>
-      <% patient.pledge_info_errors.each do |error| %>
-        <div class="form-error col-sm-12">Data required: <%= error %></div>
+  <%= render '/shared/multi_modal', disable_next: disable_continue?(patient), :captured => capture { %>
+    <div class="row hide" data-step="1" data-title="Confirm the following information is correct:">
+      <% if patient.pledge_info_present? %>
+        <% patient.pledge_info_errors.each do |error| %>
+          <div class="form-error col-sm-12">Data required: <%= error %></div>
+        <% end %>
       <% end %>
-    <% end %>
-    <div class='col-sm-12'><span class="pledge_modal_category">Patient name:</span> <%= patient.name %></div>
-    <div class='col-sm-12'><span class="pledge_modal_category">Patient ID:</span> <%= patient.identifier %></div>
-    <div class='col-sm-12'><span class="pledge_modal_category">Pledge amount:</span> $<%= patient.fund_pledge %> </div>
-    <div class='col-sm-12'><span class="pledge_modal_category">Appointment date:</span> <%= patient.appointment_date_display %></div>
-    <div class='col-sm-12'><span class="pledge_modal_category">Clinic name:</span> <%= patient.clinic.try :name %></div>
-  </div>
+      <div class='col-sm-12'><span class="pledge_modal_category">Patient name:</span> <%= patient.name %></div>
+      <div class='col-sm-12'><span class="pledge_modal_category">Patient ID:</span> <%= patient.identifier %></div>
+      <div class='col-sm-12'><span class="pledge_modal_category">Pledge amount:</span> $<%= patient.fund_pledge %> </div>
+      <div class='col-sm-12'><span class="pledge_modal_category">Appointment date:</span> <%= patient.appointment_date_display %></div>
+      <div class='col-sm-12'><span class="pledge_modal_category">Clinic name:</span> <%= patient.clinic.try :name %></div>
+    </div>
 
-  <div class="row hide" data-step="2" data-title="Generate your pledge form:" id="generate-pledge-form">
-    <% if ENV['DARIA_PLEDGE_GENERATOR_DISABLED'] %>
-      <p>Please generate your pledge form and click next.</p>
-    <% else %>
-      <div class="alert alert-danger" style="display:none;"> You need to enter your name in the box to sign and download the pledge </div>
-      <p class="col-sm-12"><strong>Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the fax to the clinic.</strong></p>
+    <div class="row hide" data-step="2" data-title="Generate your pledge form:" id="generate-pledge-form">
+      <% if ENV['DARIA_PLEDGE_GENERATOR_DISABLED'] %>
+        <p>Please generate your pledge form and click next.</p>
+      <% else %>
+        <div class="alert alert-danger" style="display:none;"> You need to enter your name in the box to sign and download the pledge </div>
+        <p class="col-sm-12"><strong>Note that this does NOT send your pledge to the clinic! Please click to the next page after generating your form to record that you have sent the fax to the clinic.</strong></p>
 
+        <div class="col-sm-12">
+          <%= bootstrap_form_tag url: generate_pledge_patient_path(patient), method: 'get' do |f| %>
+            <%= f.text_field :case_manager_name, label: 'Enter your name in this box to sign your pledge:' %>
+            <%= f.submit 'Generate your pledge', class: 'btn btn-large btn-primary' %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="row hide" data-step="3" data-title="Submit and send your pledge:">
+      <p class="col-sm-12">Awesome, you generated a <%= FUND %> Pledge! Thanks!</p>
+      <p class="col-sm-12">Your pledge should appear in your computer's downloads. Find the document and go to <%= link_to FUND_FAX_SERVICE, "http://#{FUND_FAX_SERVICE}", target: '_blank', rel: 'noopener nofollow' %> to submit the pledge for your client.</p>
+      <p class="col-sm-12"><strong>Once you've completed the online fax process, please use the check box below to indicate your pledge has been sent.</strong></p>
       <div class="col-sm-12">
-        <%= bootstrap_form_tag url: generate_pledge_patient_path(patient), method: 'get' do |f| %>
-          <%= f.text_field :case_manager_name, label: 'Enter your name in this box to sign your pledge:' %>
-          <%= f.submit 'Generate your pledge', class: 'btn btn-large btn-primary' %>
+        <%= bootstrap_form_for patient, id: 'pledge-create-modal-form', remote: true do |f| %>
+          <%= f.check_box :pledge_sent, label: 'I sent the pledge' %>
         <% end %>
       </div>
+    </div>
+  <% } %>
+<% else %>
+  <div class="modal-header">
+    <h4 class="modal-title">Cancel Pledge</h4>
+  </div>
+  <div class="modal-body">
+    <div class="row">
+      <div class="col-sm-12">
+        <p>Are you sure you want to cancel this pledge?</p>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default js-btn-step pull-left" style="color:red;" data-dismiss="modal">No</button>
+
+    <%= form_for @patient, html:{id:'cancel-pledge-form'}, remote: true do |f|%>    
+      <%= f.hidden_field :pledge_sent, :value=> false %>
+      <%= f.submit 'Yes', class:"btn btn-success js-btn-step", id: 'cancel-pledge-submit'%>
     <% end %>
   </div>
-
-  <div class="row hide" data-step="3" data-title="Submit and send your pledge:">
-    <p class="col-sm-12">Awesome, you generated a <%= FUND %> Pledge! Thanks!</p>
-    <p class="col-sm-12">Your pledge should appear in your computer's downloads. Find the document and go to <%= link_to FUND_FAX_SERVICE, "http://#{FUND_FAX_SERVICE}", target: '_blank', rel: 'noopener nofollow' %> to submit the pledge for your client.</p>
-    <p class="col-sm-12"><strong>Once you've completed the online fax process, please use the check box below to indicate your pledge has been sent.</strong></p>
-    <div class="col-sm-12">
-      <%= bootstrap_form_for patient, id: 'pledge-create-modal-form', remote: true do |f| %>
-        <%= f.check_box :pledge_sent, label: 'I sent the pledge' %>
-      <% end %>
-    </div>
-  </div>
-<% else %>
-  <div class="row hide" data-step="1" data-title="Cancel pledge:">
-    <p class="col-sm-12">If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page.</p>
-  </div>
-
-  <div class="row hide" data-step="2" data-title="Cancel pledge:">
-    <p class="col-sm-12">To confirm you want to cancel this pledge, please uncheck the check box below.</p>
-    <div class="col-sm-12">
-      <%= bootstrap_form_for patient, id: 'pledge-create-modal-form', remote: true do |f| %>
-        <%= f.check_box :pledge_sent, label: 'Uncheck this box to rescind the pledge' %>
-      <% end %>
-    </div>
-  </div>
 <% end %>
-
-<% } %>

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -54,9 +54,9 @@
   <div class="modal-footer">
     <button type="button" class="btn btn-default js-btn-step pull-left" style="color:red;" data-dismiss="modal">No</button>
 
-    <%= form_for @patient, html:{id:'cancel-pledge-form'}, remote: true do |f|%>    
-      <%= f.hidden_field :pledge_sent, :value=> false %>
-      <%= f.submit 'Yes', class:"btn btn-success js-btn-step", id: 'cancel-pledge-submit'%>
+    <%= bootstrap_form_for @patient, html: { id:'cancel-pledge-form' }, remote: true do |f|%>    
+      <%= f.hidden_field :pledge_sent, value: false %>
+      <%= f.submit 'Yes', class: "btn btn-success js-btn-step", id: 'cancel-pledge-submit'%>
     <% end %>
   </div>
 <% end %>

--- a/app/views/patients/pledge.js.erb
+++ b/app/views/patients/pledge.js.erb
@@ -5,11 +5,20 @@ $('.modal-content').append(
 );
 
 $('.modal').modal('toggle');
-$('.js-title-step span').slice(1).remove();
-var el = $(".js-title-step").contents()
 
-if (el.length > 2) {
-  el.slice(2,el.length).remove();
-}
+<% if (!@patient.pledge_sent) %>
 
-$('#pledge-modal').modalSteps();
+  $('.js-title-step span').slice(1).remove();
+  var el = $(".js-title-step").contents()
+
+  if (el.length > 2) {
+    el.slice(2,el.length).remove();
+  }
+
+  $('#pledge-modal').modalSteps();
+
+<% else %>
+  $('#cancel-pledge-form').on('submit', function() {
+    $('.modal').modal('hide');
+  })
+<% end %>

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -82,34 +82,12 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       wait_for_element 'Patient information'
     end
 
-    it 'should render after opening call modal' do
-      click_link 'Call Log'
-      wait_for_element 'Record new call'
-      wait_for_element "Call #{@patient.name} now:"
-
-      find('#cancel-pledge-button').click
-      wait_for_ajax
-
-      wait_for_element 'If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page'
-      assert has_text? 'Cancel pledge:'
-      find('#pledge-next').click
-      wait_for_ajax
-
-      wait_for_no_element 'Cancel pledge:'
-      assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
-    end
-
     it 'should not cancel if not rescinded' do
       assert has_link? 'Cancel pledge'
       find('#cancel-pledge-button').click
 
-      wait_for_element 'If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page'
-      assert has_text? 'Cancel pledge:'
-      find('#pledge-next').click
-      wait_for_ajax
-
-      assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
-      find('#pledge-next').click
+      assert has_text? 'Are you sure you want to cancel the pledge?'
+      click_button 'No'
 
       wait_for_ajax
       wait_for_element 'Patient information'
@@ -121,17 +99,10 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_link? 'Cancel pledge'
       find('#cancel-pledge-button').click
 
-      wait_for_element 'If you wish to cancel a pledge (such as to change it and resend it), please proceed to the next page'
-      assert has_text? 'Cancel pledge:'
-      find('#pledge-next').click
+      wait_for_element 'Are you sure you want to cancel the pledge?'
+      click_button has_text? 'Yes'
       wait_for_ajax
 
-      wait_for_no_element 'Cancel pledge:'
-      assert has_text? 'To confirm you want to cancel this pledge, please uncheck the check box below.'
-      find('#patient_pledge_sent').click
-      wait_for_ajax
-
-      find('#pledge-next').click
       assert has_link? 'Submit pledge'
       assert has_content? Patient::STATUSES[:no_contact]
       refute has_link? 'Fulfillment'

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -86,7 +86,7 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_link? 'Cancel pledge'
       find('#cancel-pledge-button').click
 
-      assert has_text? 'Are you sure you want to cancel the pledge?'
+      assert has_text? 'Are you sure you want to cancel this pledge?'
       click_button 'No'
 
       wait_for_ajax
@@ -99,7 +99,7 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_link? 'Cancel pledge'
       find('#cancel-pledge-button').click
 
-      wait_for_element 'Are you sure you want to cancel the pledge?'
+      wait_for_element 'Are you sure you want to cancel this pledge?'
       click_button has_text? 'Yes'
       wait_for_ajax
 

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -100,7 +100,7 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       find('#cancel-pledge-button').click
 
       wait_for_element 'Are you sure you want to cancel this pledge?'
-      click_button has_text? 'Yes'
+      click_button 'Yes'
       wait_for_ajax
 
       assert has_link? 'Submit pledge'

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -218,7 +218,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       wait_for_ajax
 
       fill_in 'Check #', with: '444-22'
-      # fill_in 'Date of check', with: 2.weeks.from_now.strftime('%m/%d/%Y')
+      fill_in 'Date of check', with: 2.weeks.from_now.strftime('%m/%d/%Y')
 
       click_away_from_field
       wait_for_ajax


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Picks up changes in #1227 and resolves test failures/merge conflicts, pretty much. 

This pull request makes the following changes (copied from @SamuelLangenfeld 's):
 * removes checkbox from the cancel pledge modal
* changes _pledge.html.erb to only call views/shared/multi-modal for submitting a pledge, not cancelling. Cancelling a pledge is only one step.

![image](https://user-images.githubusercontent.com/3866868/34808811-3b0da08c-f65f-11e7-9c6d-c3d367742e25.png)

Fixes #1046 
