### PR TITLE
Use DARIA_FUND env var instead of FUND

### DIFF
--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <%= link_to "DARIA - " + (ENV['FUND'] ? ENV['FUND'] : Rails.env), root_path, class: 'navbar-brand' %>
+      <%= link_to "DARIA - " + (ENV['DARIA_FUND'] || Rails.env), root_path, class: 'navbar-brand' %>
     </div>
     <div class="collapse navbar-collapse">
       <%= render 'layouts/navigation_links' %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <%= link_to "DARIA - " + (ENV['DARIA_FUND'] || Rails.env), root_path, class: 'navbar-brand' %>
+      <%= link_to "DARIA - " + (ENV['DARIA_FUND_FULL'] || Rails.env), root_path, class: 'navbar-brand' %>
     </div>
     <div class="collapse navbar-collapse">
       <%= render 'layouts/navigation_links' %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-fail 'No running seeds in prod' unless [nil, 'Test Sandbox'].include? ENV['FUND']
+fail 'No running seeds in prod' unless [nil, 'Sandbox'].include? ENV['DARIA_FUND']
 
 # if ARGV[1].blank?
 #   puts "\n****SEED FAILED, but it's easy to fix****\n" \

--- a/lib/tasks/seed_training.rake
+++ b/lib/tasks/seed_training.rake
@@ -1,4 +1,3 @@
-
 namespace :db do
   namespace :seed do
     desc 'Generate 20 training accounts - training-account-n@test.com'

--- a/lib/tasks/seed_training.rake
+++ b/lib/tasks/seed_training.rake
@@ -3,7 +3,7 @@ namespace :db do
   namespace :seed do
     desc 'Generate 20 training accounts - training-account-n@test.com'
     task :training => :environment do
-      fail 'No running seeds in prod' unless [nil, 'Test Sandbox'].include? ENV['FUND']
+      fail 'No running seeds in prod' unless [nil, 'Sandbox'].include? ENV['DARIA_FUND']
 
       # Create two test users
       20.times do |i|

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -53,7 +53,7 @@ module IntegrationHelper
   end
 
   def go_to_dashboard
-    click_link "DARIA - #{(ENV['DARIA_FUND'] || Rails.env)}"
+    click_link "DARIA - #{FUND_FULL}"
   end
 
   def click_away_from_field

--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -53,7 +53,7 @@ module IntegrationHelper
   end
 
   def go_to_dashboard
-    click_link "DARIA - #{(ENV['FUND'] ? ENV['FUND'] : Rails.env)}"
+    click_link "DARIA - #{(ENV['DARIA_FUND'] || Rails.env)}"
   end
 
   def click_away_from_field


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We don't set `FUND` in app.json, so we should depreciate it. This takes out all refs to it in favor of either `DARIA_FUND` or `DARIA_FUND_FULL` env vars. This should prevent us from accidentally blowing something up by accident.

This pull request makes the following changes:
* FUND -> DARIA_FUND

It relates to the following issue #s: 
* Fixes #1259 
