### PR TITLE
Undo global call list nuking every night

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
 
-task clear_call_lists: :environment do
+task clean_call_list: :environment do
   User.all.each(&:clean_call_list_between_shifts)
 end
 

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -1,6 +1,6 @@
 desc 'Clean up call lists, unmark urgent patients, destroy old events'
 task nightly_cleanup: :environment do
-  User.all.each { |user| user.clear_call_list }
+  User.all.each { |user| user.clean_call_list_between_shifts }
   puts "#{Time.now} -- cleared all recently reached patients from call lists"
 
   Patient.trim_urgent_patients


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

BRAF brought this to my attention in an email. This is definitely not intended behavior -- should only clear out after a two weeks have passed. SORRY EVERYONE.

This pull request makes the following changes:
* undo accidentally clearing out literally everyone's call list literally every night. sorry.

It relates to the following issue #s: 
No issues. 