### PR TITLE
Remove dropdown row UI

### DIFF
--- a/app/views/clinics/index.html.erb
+++ b/app/views/clinics/index.html.erb
@@ -5,10 +5,12 @@
   <tr>
     <th>Clinic name</th>
     <th>Address</th>
-    <th>Cit</th>
+    <th>City</th>
     <th>State</th>
     <th>ZIP</th>
-    <th></th>
+    <th>NAF</th>
+    <th>Medicaid</th>
+    <th>Gestational Limit (Days)</th>
   </tr>
 
   <% @clinics.each do |clinic| %>
@@ -19,37 +21,20 @@
       <td><%= clinic.state %></td>
       <td><%= clinic.zip %></td>
       <td>
-        <a role="button" data-toggle="collapse" data-parent="#accordion" href='#<%= clinic.id %>' aria-expanded="false" aria-controls='<%= clinic.id %>' id='clinic-toggle-<%= clinic.id %>'>
-          <i class="short-full glyphicon glyphicon-chevron-down accordion-toggle-down"></i>
-          <i class="short-full glyphicon glyphicon-chevron-up accordion-toggle-up"></i>
-        </a>
-      </td>
-    </tr>
-
-    <tr id='clinic-<%= clinic.id %>-detail' class="collapse collapsible-clinic-details" role="tabpanel">
-      <td>
         <div class="accepts-naf clinic-detail-group">
-          <label>Accepts NAF?</label>
           <p class="blush"><%= clinic.accepts_naf ? 'Yes' : 'No' %></p>
         </div>
       </td>
       <td>
         <div class="accepts_medicaid clinic-detail-group">
-          <label>Accepts Medicaid?</label>
           <p class="blush"><%= clinic.accepts_medicaid ? 'Yes' : 'No' %></p>
         </div>
       </td>
       <td>
         <div class="gestational-limit clinic-detail-group">
-          <label>Gestational Limit</label>
           <p class="blush"><%= clinic.gestational_limit %></p>
         </div>
       </td>
-
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
     </tr>
   <% end %>
 </table>

--- a/test/system/clinic_management_test.rb
+++ b/test/system/clinic_management_test.rb
@@ -19,14 +19,6 @@ class ClinicManagementTest < ApplicationSystemTestCase
       within :css, '#clinics_table' do
         assert has_text? @clinic.name
       end
-
-      # TODO revisit this after viewing clinic details is less clunky
-      # find("#clinic-toggle-#{@clinic.id}").click
-      # wait_for_ajax
-      # within :css, "clinic-#{@clinic.id}-detail" do
-      #   assert has_text? 'Accepts Medicaid?'
-      #   assert has_text? 'Yes'
-      # end
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Clinics view used a dropdown row to show/hide additional info about a
given clinic. This UI was buggy. The dropdown row was implemented
through Bootstrap toggle and defined on a `<tr>` tag.

Bootstrap's toggle does not play well with the HTML `<table>` tag. A
workaround is possible but difficult. Instead, this commit takes the
three extra fields from the dropdown row and adds them as additional
columns within the table.

Before this commit, there were 5 columns of data and a chevron toggle
that would reveal 3 more columns of data in a dropdown row. Now
there is no chevron toggle, and the table displays 8 columns of data at
all times.

Old screen:

![screenshot](https://user-images.githubusercontent.com/15312106/35476771-a84a91c4-0383-11e8-91fb-adbc966e7efd.png)

New screen: 
![screenshot-2018-1-28 daria](https://user-images.githubusercontent.com/15312106/35486404-872416a6-043b-11e8-83dc-6d03c4a1ba78.png)


It relates to the following issue #s: 
* Fixes #1353 
