### PR TITLE
Organize test_helper better, remove dead ref to poltergeist

### DIFF
--- a/test/integration_helper.rb
+++ b/test/integration_helper.rb
@@ -1,5 +1,15 @@
 # Helpers for browser junk
 module IntegrationHelper
+  def sign_in(user)
+    post user_session_path \
+      'user[email]' => user.email,
+      'user[password]' => user.password
+  end
+
+  def choose_line(line)
+    post lines_path, params: { line: line.to_s }
+  end
+
   def log_in_as(user, line = 'DC')
     log_in user
     select_line line

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,4 +69,6 @@ class ActionDispatch::IntegrationTest
   OmniAuth.config.test_mode = true
 
   before { Capybara.reset_sessions! }
+
+  # for controllers
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Cleans up our test helper to squelch some redundancies and get the CI specific stuff in one place, instead of a few diff places.

Also, we aren't using poltergeist anymore!

This pull request makes the following changes:
* no codecov reports if not in ci
* gets all the CI stuff in one place
* removes dead reference to poltergeist

No view changes.

No issues.

ps:

```
$ rails test
Run options: --seed 36133

# Running:

....................................................................................................................................................................................................................................................................................................................................................................

Finished in 72.519962s, 4.9090 runs/s, 10.3971 assertions/s.
356 runs, 754 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /Users/colin/repos/dcaf_case_management/coverage. 1290 / 1380 LOC (93.48%) covered.
```

note the lack of error json! 💯 
