### PR TITLE
Reorganize gemfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Lint/AmbiguousRegexpLiteral:
 Rails:
   Enabled: true
 
+Bundler/OrderedGems:
+  Enabled: false
+
 AllCops:
   Exclude: 
     - db/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,77 +1,104 @@
 source 'https://rubygems.org'
 ruby '2.4.3'
 
+# Standard rails
 gem 'rails', '>= 5.1'
+gem 'puma' # roar
+gem 'turbolinks', '~> 5.0.0'
+gem 'jbuilder', '~> 2.0'
+gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'nokogiri', '>= 1.8.1'
+gem 'tzinfo-data', require: false
+
+# Asset pipeline
 gem 'sass-rails', '~> 5.0'
+gem 'bootstrap-sass', '~> 3.3', '>= 3.3.6'
 gem 'uglifier', '>= 3.2.0'
 gem 'coffee-rails', '~> 4.2.2'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'turbolinks', '~> 5.0.0'
-gem 'jbuilder', '~> 2.0'
-gem 'sdoc', '~> 0.4.0', group: :doc
-gem 'prawn'
-gem 'bootstrap-sass', '~> 3.3', '>= 3.3.6'
-gem 'bootstrap_form'
-gem 'bootstrap_form-datetimepicker'
+
+# Our database is MongoDB
+gem 'mongoid', '>= 6.2.0', '< 7'
+gem 'bson_ext'
+gem 'mongoid-history', '0.6.1' # gives us object history
+gem 'mongoid_userstamp', git: 'https://github.com/DCAFEngineering/mongoid_userstamp.git',
+                         branch: 'master' # adds created_by and updated_by timestamps
+gem 'mongo_session_store', '>= 3.1.0' # stores sessions in database for security
+gem 'enumerize' # Mongoid doesn't have enum out of the box, so we get it here
+
+# Our authentication library is devise, with oauth2 for google signin
 gem 'devise', '~> 4.3.0'
 gem 'omniauth-google-oauth2', '0.2.1' # TODO upgrade
 gem 'omniauth-oauth2', '1.3.1' # TODO remove this pin
-gem 'mongoid', '>= 6.2.0', '< 7'
-gem 'mongoid-history', '0.6.1'
-gem 'mongoid_userstamp', git: 'https://github.com/DCAFEngineering/mongoid_userstamp.git', branch: 'master'
-gem 'mongo_session_store', '>= 3.1.0'
-gem 'enumerize'
-gem 'bson_ext'
-gem 'figaro'
-gem 'render_async', '~> 0.2.3'
-gem 'gon', '~> 6.1.0'
-gem 'nokogiri', '>= 1.8.1'
-gem 'tzinfo-data', require: false
-gem 'js-routes'
+
+# Lets us use `bootstrap_form_for` in views
+gem 'bootstrap_form'
+gem 'bootstrap_form-datetimepicker'
+
+# Security libraries
 gem 'rack-attack', '~> 5.0.1'
-gem 'rack-test', '~> 0.6.3', require: 'rack/test'
-gem 'clinic_finder', git: 'https://github.com/DCAFEngineering/clinic_finder.git', branch: 'master'
-gem 'geokit'
 gem 'secure_headers', '~> 3.6', '>= 3.6.4'
 
+# Specific useful stuff
+gem 'render_async', '~> 0.2.3' # load slow partials asynchronously
+gem 'prawn' # pledge pdf generation
+gem 'clinic_finder', git: 'https://github.com/DCAFEngineering/clinic_finder.git',
+                     branch: 'master' # powers our clinic finder search
+
+# ????? think we can remove these
+gem 'figaro'
+gem 'gon', '~> 6.1.0'
+gem 'geokit'
+
+# ???? probably can't remove these but it would be nice to try
+gem 'js-routes'
+gem 'rack-test', '~> 0.6.3', require: 'rack/test'
+
 group :development do
-  gem 'shog'
-  gem 'pry'
+  gem 'shog' # makes rails s output color!
   gem 'listen'
-  gem 'rubocop', require: false
+  gem 'rubocop', require: false # our code style / linting system
+
+  # Security scanners that also run in CI
   gem 'brakeman', require: false
   gem 'ruby_audit', require: false
   gem 'bundler-audit', require: false
-  # gem 'dawnscanner', require: false # disable until dawnscanner fixes CD prob
 end
 
 group :development, :test do
-  gem 'byebug'
+  gem 'pry' # pop `pry` in controller code to open up an IRB terminal
+  gem 'byebug' # pop `byebug` in view code for open up an IRB terminal
   gem 'spring'
-  gem 'knapsack'
+  gem 'knapsack' # lets us split up our tets so they run faster in CI
 end
 
 group :test do
-  gem 'shoulda-context'
-  gem 'mini_backtrace'
+  # Useful minitest tools
   gem 'minitest-spec-rails'
   gem 'factory_bot_rails'
-  gem 'faker'
   gem 'database_cleaner'
+  gem 'faker'
+  gem 'timecop'
+
+  # Systemtest related tools
   gem 'capybara'
   gem 'selenium-webdriver'
-  gem 'simplecov', require: false
-  gem 'launchy'
-  gem 'codecov', require: false
-  gem 'timecop'
   gem 'capybara-screenshot'
-  gem 'pdf-inspector', require: "pdf/inspector"
+  gem 'launchy' # open up capybara screenshots automatically with `save_and_open_screenshot`
+
+  # Test coverage related libraries
+  gem 'simplecov', require: false
+  gem 'codecov', require: false
+
+  # Specifics
+  gem 'shoulda-context'
+  gem 'mini_backtrace' # settle down minitest output
+  gem 'pdf-inspector', require: 'pdf/inspector' # test pdf contents
   gem 'minitest-stub-const'
 end
 
 group :production do
-  gem 'puma'
-  gem 'skylight'
-  gem 'sqreen'
+  gem 'skylight' # our newrelic-style efficiency monitoring platform
+  gem 'sqreen' # an active security monitoring platform
 end

--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,8 @@ gem 'devise', '~> 4.3.0'
 gem 'omniauth-google-oauth2', '0.2.1' # TODO upgrade
 gem 'omniauth-oauth2', '1.3.1' # TODO remove this pin
 
-# Lets us use `bootstrap_form_for` in views
+# We use `bootstrap_form_for` in views
 gem 'bootstrap_form'
-gem 'bootstrap_form-datetimepicker'
 
 # Security libraries
 gem 'rack-attack', '~> 5.0.1'
@@ -46,18 +45,16 @@ gem 'prawn' # pledge pdf generation
 gem 'clinic_finder', git: 'https://github.com/DCAFEngineering/clinic_finder.git',
                      branch: 'master' # powers our clinic finder search
 
-# ????? think we can remove these
-gem 'figaro'
-gem 'gon', '~> 6.1.0'
-gem 'geokit'
-
-# ???? probably can't remove these but it would be nice to try
-gem 'js-routes'
-gem 'rack-test', '~> 0.6.3', require: 'rack/test'
+# Stuff that we're targeting removal of
+gem 'figaro' # we handle secrets differently now
+gem 'gon', '~> 6.1.0' # render async does this better
+gem 'geokit' # should be included in clinic_finder instead of here
+gem 'js-routes' # Not sure if this is used anymore
+gem 'bootstrap_form-datetimepicker' # not sure if this is used anymore
 
 group :development do
   gem 'shog' # makes rails s output color!
-  gem 'listen'
+  gem 'listen' # used by systemtests
   gem 'rubocop', require: false # our code style / linting system
 
   # Security scanners that also run in CI
@@ -96,6 +93,7 @@ group :test do
   gem 'mini_backtrace' # settle down minitest output
   gem 'pdf-inspector', require: 'pdf/inspector' # test pdf contents
   gem 'minitest-stub-const'
+  gem 'rack-test', '~> 0.6.3', require: 'rack/test' # needed to test rack-attack
 end
 
 group :production do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Been meaning to do this for a little while -- this reorgs our gemfile so that for the less common libraries, it's clear what's doing what.

I'm going to see if we can take out some of the stuff in `????` sections before I merge, but keeping these here for now.

This pull request makes the following changes:
* reorganizes gemfile, adds mad comments

No view changes.

No issues.