### PR TITLE
Adding in build command for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 web:
   image: colinxfleming/dcaf_case_management
+  build: .
   command: rails s -p 3000 -b 0.0.0.0
   volumes:
     - .:/usr/src/app


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds in build command for `docker-compose`

I noticed we were missing an explicit command for `docker-compose build` so I'm adding this in for people who use `docker-compose` such as @geoffreyyip 

This pull request makes the following changes:
* Small change to `docker-compose`
