### PR TITLE
Update nokogiri, byebug, and capybara

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,14 +75,14 @@ GEM
     bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (9.1.0)
-    capybara (2.16.1)
+    byebug (10.0.0)
+    capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      xpath (>= 2.0, < 4.0)
     capybara-screenshot (1.0.18)
       capybara (>= 1.0, < 3)
       launchy
@@ -199,7 +199,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.2.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -238,7 +238,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.1)
     puma (3.9.1)
-    rack (2.0.3)
+    rack (2.0.4)
     rack-attack (5.0.1)
       rack
     rack-test (0.6.3)
@@ -359,8 +359,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bumps a pair of dev dependencies (byebug and capybara), with a couple of secondary gem updates along the way.

This pull request makes the following changes:
* `bundle update byebug`
* `bundle update capybara`

No view changes.

No issues. 