### PR TITLE
Set actionmailer settings in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,10 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: '3000'
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Quick fix in development config that will let links in password reset emails work. Not production facing, so good to merge after we confirm tests all pass.

This pull request makes the following changes:
* Sets the default URL to localhost and port to 3000 when running in development mode

No views.

No issues.