### PR TITLE
Handle search across lines

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -185,16 +185,15 @@ class Patient
     #
     # See https://github.com/DCAFEngineering/dcaf_case_management/issues/825
     ##
-    # phones are unique, so there should be zero or one match
-    match = Patient.where(primary_phone: primary_phone).first
+    phone_match = Patient.where(primary_phone: primary_phone).first
 
-    if match
+    if phone_match
       # skip when an existing patient updates and matches itself
-      if match._id == self._id
+      if phone_match.id == self.id
         return
       end
 
-      patients_line = match[:line]
+      patients_line = phone_match[:line]
       volunteers_line = line
       if volunteers_line == patients_line
         errors.add(:this_phone_number_is_already_taken, "on this line.")

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -194,7 +194,7 @@ class Patient
       if volunteers_line == patients_line
         errors.add(:this_phone_number_is_already_taken, "on this line.")
       else
-        errors.add(:this_phone_number_is_already_taken, "on the #{patients_line}. Please contact the case manager on duty at the #{volunteers_line} line to confirm which line the patient should be under. If the line needs to be changed, please contact the CM Directors.")
+        errors.add(:this_phone_number_is_already_taken, "on the #{patients_line} line. If you need the patient's line changed, please contact the CM directors.")
       end
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,7 +248,7 @@ end
   # initial create data from voicemail
   patient = Patient.create!(
     name: "Archive Dataful Patient #{patient_number}",
-    primary_phone: "321-0#{patient_number}0-004#{rand(10)}",
+    primary_phone: "321-0#{patient_number}0-005#{rand(10)}",
     voicemail_preference: "yes",
     line: 'DC',
     language: "Spanish",

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -109,7 +109,7 @@ class DataEntryTest < ApplicationSystemTestCase
       end
 
       it 'should return an error on a duplicate phone' do
-        assert has_text? 'Primary phone is already taken'
+        assert has_text? 'This phone number is already taken'
         assert_equal current_path, data_entry_path
       end
     end


### PR DESCRIPTION
Resolves: #825 

This change resolves a frustration point for CMs. Whenever they try to
register a patient whose phone number already exists in the system, they
will receive an error message stating the number is a duplicate. This
should not be a problem since CMs search for the number in the database
before creation. However, the search functionality is limited to the
CM's existing line, while the uniqueness check works across the entire
database.

For example, if the number 123-123-1231 exists on the DC line and the CM
is logged into the VA line, then they will receive no results when
searching for 123-123-1231. This implies a new patient. Then when the CM
creates a new patient with 123-123-1231, they will get an error saying
the number already exists.

To address this issue, I added a custom validator that tells the CM when
the patient already exists on a different line.

_(Additional side effect: I changed one of the phone numbers in `seed.rb`. 
Patient models are validated for unique phone numbers. Two of the
creation methods in seed.rb use the same template string to generate
phone numbers, which means there's a chance for the same number to be
generated twice.)_

If these changes look good, I can add some unit tests.
