### PR TITLE
use number_field instead of text_field to improve usability

### DIFF
--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="info-form-left col-sm-6">
           <%= f.fields_for patient.fulfillment do |pt| %>
-            <%= pt.text_field :procedure_cost, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
+            <%= pt.number_field :procedure_cost, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
             <%= pt.select :gestation_at_procedure,
                           options_for_select(weeks_options, patient.fulfillment.gestation_at_procedure),
                           label: 'Weeks along at procedure',

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -15,7 +15,7 @@
                                           patient.line),
                                           label: 'Line' %>
           <% end %>
-          <%= f.text_field :age, label: 'Age', autocomplete: 'off' %>
+          <%= f.number_field :age, label: 'Age', autocomplete: 'off' %>
           <%= f.select :race_ethnicity,
                        options_for_select(race_ethnicity_options,
                                           patient.race_ethnicity),

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -33,9 +33,9 @@
     <%#= notes.text_area :full_text, size: '20x5', placeholder: 'Enter notes here' %>
   <%# end %>
 
-  <%= f.text_field :fund_pledge, label: "#{FUND} pledge" %>
+  <%= f.number_field :fund_pledge, label: "#{FUND} pledge" %>
 
-  <%= f.text_field :age, autocomplete: 'off' %>
+  <%= f.number_field :age, autocomplete: 'off' %>
   <%= f.select :race_ethnicity, options_for_select(race_ethnicity_options), label: 'Race / Ethnicity', autocomplete: 'off' %>
   <%= f.select :clinic_id, options_for_select(clinic_options) %>
 

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -70,9 +70,9 @@
                options_for_select(referred_by_options),
                                   autocomplete: 'off' %>
 
-    <%= f.text_field :procedure_cost, label: 'Full cost / abortion cost' %>
-    <%= f.text_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', prepend: '$' %>
-    <%= f.text_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
+    <%= f.number_field :procedure_cost, label: 'Full cost / abortion cost' %>
+    <%= f.number_field :patient_contribution, label: 'Patient contribution', autocomplete: 'off', prepend: '$' %>
+    <%= f.number_field :naf_pledge, label: 'National Abortion Federation pledge', autocomplete: 'off', prepend: '$' %>
 
     <%= f.check_box :pledge_sent, label: 'Pledge sent' %>
 


### PR DESCRIPTION
Makes text forms for age and any $ amount (eg procedure cost) use number_field instead of text_field


* Fixes #1249 