### PR TITLE
bump loofah to 2.2.1 to get a security warning to shush

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem 'geokit' # should be included in clinic_finder instead of here
 gem 'js-routes' # Not sure if this is used anymore
 gem 'bootstrap_form-datetimepicker' # not sure if this is used anymore
 
+# Stuff we're hardsetting because of security concerns
+gem 'loofah', '>= 2.2.1'
+
 group :development do
   gem 'shog' # makes rails s output color!
   gem 'listen' # used by systemtests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -393,6 +393,7 @@ DEPENDENCIES
   knapsack
   launchy
   listen
+  loofah (>= 2.2.1)
   mini_backtrace
   minitest-spec-rails
   minitest-stub-const


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

There's a security vuln in libxml2 expressed in the loofah gem etc etc. This bumps the lib to a patched version.

This pull request makes the following changes:
* gem loofah >= 2.2.1 && bundle update

No issues or view changes.