### PR TITLE
Bump rails html sanitizer to squelch vulnerability warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'bootstrap_form-datetimepicker' # not sure if this is used anymore
 
 # Stuff we're hardsetting because of security concerns
 gem 'loofah', '>= 2.2.1'
+gem 'rails-html-sanitizer', '>= 1.0.4'
 
 group :development do
   gem 'shog' # makes rails s output color!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -258,8 +258,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.1.5)
       actionpack (= 5.1.5)
       activesupport (= 5.1.5)
@@ -411,6 +411,7 @@ DEPENDENCIES
   rack-attack (~> 5.0.1)
   rack-test (~> 0.6.3)
   rails (>= 5.1)
+  rails-html-sanitizer (>= 1.0.4)
   render_async (~> 0.2.3)
   rubocop
   ruby_audit


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

`bundle update rails-html-sanitizer`

This pull request makes the following changes:
* that thing

No changes to views.

See #1397 
