### PR TITLE
fix problems with fulfillment view and csv export #1393, #1401, #1402

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -124,7 +124,7 @@ class PatientsController < ApplicationController
 
   FULFILLMENT_PARAMS = [
     fulfillment: [:fulfilled, :procedure_date, :gestation_at_procedure,
-                  :procedure_cost, :check_number, :date_of_check]
+                  :fulfillment_paid_by_DARIA_fund, :check_number, :date_of_check]
   ].freeze
 
   OTHER_PARAMS = [:urgent_flag, :initial_call_date, :pledge_sent].freeze

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -124,7 +124,7 @@ class PatientsController < ApplicationController
 
   FULFILLMENT_PARAMS = [
     fulfillment: [:fulfilled, :procedure_date, :gestation_at_procedure,
-                  :fulfillment_paid_by_DARIA_fund, :check_number, :date_of_check]
+                  :fulfillment_paid_by_fund, :check_number, :date_of_check]
   ].freeze
 
   OTHER_PARAMS = [:urgent_flag, :initial_call_date, :pledge_sent].freeze

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -46,7 +46,7 @@ module Exportable
     "Fulfilled" => :fulfilled,
     "Procedure date" => :procedure_date,
     "Gestation at procedure in weeks" => :gestation_at_procedure,
-    "DARIA Fund Expenditure" => :fulfillment_paid_by_DARIA_fund,
+    "DARIA Fund Expenditure" => :fulfillment_paid_by_fund,
     "Check number" => :check_number,
     "Date of Check" => :date_of_check
 
@@ -59,8 +59,8 @@ module Exportable
     fulfillment.try :fulfilled
   end
 
-  def fulfillment_paid_by_DARIA_fund
-    fulfillment.try :fulfillment_paid_by_DARIA_fund
+  def fulfillment_paid_by_fund
+    fulfillment.try :fulfillment_paid_by_fund
   end
 
   def procedure_date

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -46,7 +46,7 @@ module Exportable
     "Fulfilled" => :fulfilled,
     "Procedure date" => :procedure_date,
     "Gestation at procedure in weeks" => :gestation_at_procedure,
-    "Procedure cost" => :procedure_cost,
+    "DARIA Fund Expenditure" => :fulfillment_paid_by_DARIA_fund,
     "Check number" => :check_number,
     "Date of Check" => :date_of_check
 
@@ -57,6 +57,10 @@ module Exportable
 
   def fulfilled
     fulfillment.try :fulfilled
+  end
+
+  def fulfillment_paid_by_DARIA_fund
+    fulfillment.try :fulfillment_paid_by_DARIA_fund
   end
 
   def procedure_date

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -12,7 +12,7 @@ class Fulfillment
   field :fulfilled, type: Boolean
   field :procedure_date, type: Date
   field :gestation_at_procedure, type: String
-  field :procedure_cost, type: Integer
+  field :fulfillment_paid_by_DARIA_fund, type: Integer
   field :check_number, type: String
   field :date_of_check, type: Date
 

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -12,7 +12,7 @@ class Fulfillment
   field :fulfilled, type: Boolean
   field :procedure_date, type: Date
   field :gestation_at_procedure, type: String
-  field :fulfillment_paid_by_DARIA_fund, type: Integer
+  field :fulfillment_paid_by_fund, type: Integer
   field :check_number, type: String
   field :date_of_check, type: Date
 

--- a/app/views/accountants/_table_content_row.html.erb
+++ b/app/views/accountants/_table_content_row.html.erb
@@ -1,6 +1,6 @@
 <td><%= patient.clinic&.name %></td>
 <td><%= link_to patient.initials, edit_patient_path(patient) %></td>
-<td><%= number_to_currency patient.fulfillment&.fulfillment_paid_by_DARIA_fund, precision: 0 %></td>
+<td><%= number_to_currency patient.fulfillment&.fulfillment_paid_by_fund, precision: 0 %></td>
 <td><%= patient.fulfillment&.gestation_at_procedure_display %></td>
 <td><%= patient.pledge_sent_at&.display_date %></td>
 <td><%= patient.fulfillment&.check_number%></td>

--- a/app/views/accountants/_table_content_row.html.erb
+++ b/app/views/accountants/_table_content_row.html.erb
@@ -1,6 +1,6 @@
 <td><%= patient.clinic&.name %></td>
 <td><%= link_to patient.initials, edit_patient_path(patient) %></td>
-<td><%= number_to_currency patient.fulfillment&.procedure_cost, precision: 0 %></td>
+<td><%= number_to_currency patient.fulfillment&.fulfillment_paid_by_DARIA_fund, precision: 0 %></td>
 <td><%= patient.fulfillment&.gestation_at_procedure_display %></td>
 <td><%= patient.pledge_sent_at&.display_date %></td>
 <td><%= patient.fulfillment&.check_number%></td>

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -1,5 +1,5 @@
 <section id="pledge_fulfillment_content">
-  <%= bootstrap_form_for patient, html: { id: 'pledge_fulfillment_form' }, remote: true do |f| %>
+  <%= bootstrap_nested_form_for patient, html: { id: 'pledge_fulfillment_form' }, remote: true do |f| %>
     <div class="col-sm-12">
       <div class="row">
         <div class="col-sm-12">
@@ -25,7 +25,7 @@
         </div>
         <div class="info-form-left col-sm-6">
           <%= f.fields_for @patient.fulfillment do |pt| %>
-            <%= pt.number_field :fulfillment_paid_by_DARIA_fund, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
+            <%= pt.number_field :fulfillment_paid_by_fund, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
             <%= pt.select :gestation_at_procedure,
                           options_for_select(weeks_options, patient.fulfillment.gestation_at_procedure),
                           label: 'Weeks along at procedure',

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -1,5 +1,5 @@
 <section id="pledge_fulfillment_content">
-  <%= bootstrap_nested_form_for patient, html: { id: 'pledge_fulfillment_form' }, remote: true do |f| %>
+  <%= bootstrap_form_for patient, html: { id: 'pledge_fulfillment_form' }, remote: true do |f| %>
     <div class="col-sm-12">
       <div class="row">
         <div class="col-sm-12">

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -17,15 +17,15 @@
       </div>
       <div class="row">
         <div class="col-sm-12">
-          <%= f.fields_for patient.fulfillment do |pt| %>
+          <%= f.fields_for @patient.fulfillment do |pt| %>
             <%= pt.form_group :fulfilled do %>
               <%= pt.check_box :fulfilled, label: 'Pledge fulfilled', autocomplete: 'off' %>
             <% end %>
           <% end %>
         </div>
         <div class="info-form-left col-sm-6">
-          <%= f.fields_for patient.fulfillment do |pt| %>
-            <%= pt.number_field :procedure_cost, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
+          <%= f.fields_for @patient.fulfillment do |pt| %>
+            <%= pt.number_field :fulfillment_paid_by_DARIA_fund, label: 'Abortion care $', autocomplete: 'off', prepend: '$'%>
             <%= pt.select :gestation_at_procedure,
                           options_for_select(weeks_options, patient.fulfillment.gestation_at_procedure),
                           label: 'Weeks along at procedure',
@@ -36,7 +36,7 @@
           <% end %>
         </div>
         <div class="info-form-right col-sm-6">
-          <%= f.fields_for patient.fulfillment do |pt| %>
+          <%= f.fields_for @patient.fulfillment do |pt| %>
             <%= pt.text_field :check_number, label: 'Check #', autocomplete: 'off'%>
             <%= pt.date_field :date_of_check, label: 'Date of check', autocomplete: 'off' %>
           <% end %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Main changes are:
1) Fixed the fact the bootstrap form for fulfillment wasn't actually updating the database
2) Renamed things so we weren't using :procedure_cost in two different ways.




It relates to the following issue #s: 
* Fixes #1393 #1401 #1402 



Cribbing from #1058  the console script *should* be something  like:

Fulfillment.all.each do |f|
  f.update procedure_paid_by_fund: pt[:procedure_cost]
  f.unset :procedure_cost
end
