### PR TITLE
Export correct fund fulfillment expenditure column

### DIFF
--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -46,7 +46,7 @@ module Exportable
     "Fulfilled" => :fulfilled,
     "Procedure date" => :procedure_date,
     "Gestation at procedure in weeks" => :gestation_at_procedure,
-    "Procedure cost" => :procedure_cost,
+    "Procedure cost" => :procedure_cost_amount,
     "Check number" => :check_number,
     "Date of Check" => :date_of_check
 


### PR DESCRIPTION
The field for Procedure cost (what DCAF paid) was incorrectly exporting procedure_cost from the patient model instead of procedure_cost from the fulfillment model. This fixes that.


@colinxfleming is it okay if we expedite this fix since it's so low risk and will be really useful for the Data Team? I'll help address #1402 at a later time.

Fixes #1401 