### PR TITLE
WIP - Rails 5.2: Bump secure headers and straighten out CSP conflicts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'bootstrap_form'
 
 # Security libraries
 gem 'rack-attack', '~> 5.1'
-gem 'secure_headers', '~> 3.6', '>= 3.6.4'
+gem 'secure_headers', '~> 5'
 
 # For pagination
 gem 'kaminari-mongoid', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,8 +332,8 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    secure_headers (3.6.7)
-      useragent
+    secure_headers (5.0.5)
+      useragent (>= 0.15.0)
     selenium-webdriver (3.8.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -379,7 +379,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
     url (0.3.2)
-    useragent (0.16.8)
+    useragent (0.16.10)
     warden (1.2.7)
       rack (>= 1.0)
     websocket-driver (0.7.0)
@@ -446,7 +446,7 @@ DEPENDENCIES
   ruby_audit
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  secure_headers (~> 3.6, >= 3.6.4)
+  secure_headers (~> 5)
   selenium-webdriver
   shog
   shoulda-context


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Rails 5.2 introduces a conflicting CSP utility, which breaks a slew of tests. This straightens all that out in its own branch.

This pull request makes the following changes:
* Secure headers to latest major release
* Probably changing some nonce functions around

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Bumps #1411

