### PR TITLE
Fixed delete duplicate user button

### DIFF
--- a/app/views/patients/_delete_duplicate_patient_button.html.erb
+++ b/app/views/patients/_delete_duplicate_patient_button.html.erb
@@ -1,3 +1,0 @@
-<% if current_user.admin? %>
-  <%= link_to 'Delete duplicate patient record', patient_path(patient), class: 'btn btn-danger', method: :delete, data: { confirm: "Are you sure you want to delete #{patient.name}? Only do this if you're sure this is a duplicate patient for the same pregnancy. (Seriously, no takebacks!)" }, remote: true %>
-<% end %>

--- a/app/views/patients/_delete_duplicate_patient_button.html.erb
+++ b/app/views/patients/_delete_duplicate_patient_button.html.erb
@@ -1,0 +1,3 @@
+<% if current_user.admin? %>
+  <%= link_to 'Delete duplicate patient record', patient_path(patient), class: 'btn btn-danger', method: :delete, data: { confirm: "Are you sure you want to delete #{patient.name}? Only do this if you're sure this is a duplicate patient for the same pregnancy. (Seriously, no takebacks!)" }, remote: true %>
+<% end %>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -1,4 +1,4 @@
-<div id="`patient_dashboard_content`">
+<div id="patient_dashboard_content">
   <%= bootstrap_form_for patient, html: { id: 'patient_dashboard_form' }, remote: true do |f| %>
     <div class="col-sm-4" >
       <%= f.text_field :name, label: 'First and last name', autocomplete: 'off' %>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -1,4 +1,4 @@
-<div id="patient_dashboard_content">
+<div id="`patient_dashboard_content`">
   <%= bootstrap_form_for patient, html: { id: 'patient_dashboard_form' }, remote: true do |f| %>
     <div class="col-sm-4" >
       <%= f.text_field :name, label: 'First and last name', autocomplete: 'off' %>
@@ -26,9 +26,7 @@
         <%= f.date_field :appointment_date, label: 'Appointment date', autocomplete: 'off', help: "Approx gestation at appt: #{patient.last_menstrual_period_at_appt}" %>
       </div>
       <div class="row">
-        <% if false # current_user.admin? -- This is getting triggered when setting appointment date for some reason? %>
-          <%= button_to 'Delete duplicate patient record', patient_path(patient), class: 'btn btn-danger', method: :delete, data: { confirm: "Are you sure you want to delete #{patient.name}? Only do this if you're sure this is a duplicate patient for the same pregnancy. (Seriously, no takebacks!)" } %>
-        <% end %>
+        <%= render 'delete_duplicate_patient_button', patient: patient %>
       </div>
     </div>
   <% end %>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -26,7 +26,9 @@
         <%= f.date_field :appointment_date, label: 'Appointment date', autocomplete: 'off', help: "Approx gestation at appt: #{patient.last_menstrual_period_at_appt}" %>
       </div>
       <div class="row">
-        <%= render 'delete_duplicate_patient_button', patient: patient %>
+        <% if current_user.admin? %>
+          <%= link_to 'Delete duplicate patient record', patient_path(patient), class: 'btn btn-danger', method: :delete, data: { confirm: "Are you sure you want to delete #{patient.name}? Only do this if you're sure this is a duplicate patient for the same pregnancy. (Seriously, no takebacks!)" }, remote: true %>
+        <% end %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Changed from button to link_to

This pull request makes the following changes:
* Fixed delete duplication patient to not fire on update.

It relates to the following issue #s: 
* Fixes #1407
