### PR TITLE
Delete flaky tests we are never going to fix

### DIFF
--- a/test/system/call_list_test.rb
+++ b/test/system/call_list_test.rb
@@ -76,24 +76,6 @@ class CallListTest < ApplicationSystemTestCase
         assert has_no_text? @patient.name
       end
     end
-
-    # TODO flaky test and I have no idea why
-    # it 'should time a call out after 8 hours' do
-    #   sign_out
-    #   travel(9.hours) do
-    #     log_in_as @user
-    #     wait_for_element 'Your completed calls'
-    #     sleep 5
-
-    #     within :css, '#completed_calls_content' do
-    #       assert has_no_text? @patient.name
-    #     end
-
-    #     within :css, '#call_list_content' do
-    #       assert has_text? @patient.name
-    #     end
-    #   end
-    # end
   end
 
   describe 'patient edit page call log' do

--- a/test/system/navbar_links_test.rb
+++ b/test/system/navbar_links_test.rb
@@ -6,21 +6,6 @@ class NavbarLinksTest < ApplicationSystemTestCase
     log_in_as @user
   end
 
-  # Can't test this under the current systemtest model. TODO maybe move to its own integration test.
-  # describe 'additional resources link' do
-  #   it 'should display if env var is set' do
-  #     ENV['CM_RESOURCES_URL'] = 'www.google.com'
-  #     visit authenticated_root_path
-  #     assert has_link? 'CM Resources', href: 'www.google.com'
-  #   end
-
-  #   it 'should not display if env var is not set' do
-  #     ENV['CM_RESOURCES_URL'] = nil
-  #     visit authenticated_root_path
-  #     refute has_link? 'CM Resources'
-  #   end
-  # end
-
   describe 'user dropdown' do
     before { click_link @user.name }
     it 'should display the profile link' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

"Fixing" some tests that are going to soak up more time than they're worth. Know when you're beaten, etc.

This pull request makes the following changes:
* Remove call list time travel test
* Remove navbar test that requires subbing out env vars, which we can't do in puma

no view changes

It relates to the following issue #s: 
* Fixes #1312 
* Fixes #1313 
* Bumps #Y
