### PR TITLE
Change order of call creation in seeding to avoid renaming thing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,21 +50,6 @@ end
 
 # Create associated objects
 Patient.all.each do |patient|
-  # Create calls for patient
-  5.times do
-    patient.calls.create! status: 'Left voicemail',
-                          created_at: 3.days.ago,
-                          created_by: user2 unless patient.name == 'Patient 9'
-  end
-
-  if patient.name == 'Patient 0'
-    10.times do
-      patient.calls.create! status: 'Reached patient',
-                            created_at: 3.days.ago,
-                            created_by: user2
-    end
-  end
-
   # Add example of patient with other contact info
   if patient.name == 'Patient 1'
     patient.update! name: "Other Contact info - 1", other_contact: "Jane Doe",
@@ -104,6 +89,22 @@ Patient.all.each do |patient|
     patient.update! name: "Resolved without DCAF - 5",
                     resolved_without_fund: true
   end
+
+  # Create calls for patient
+  5.times do
+    patient.calls.create! status: 'Left voicemail',
+                          created_at: 3.days.ago,
+                          created_by: user2 unless patient.name == 'Patient 9'
+  end
+
+  if patient.name == 'Patient 0'
+    10.times do
+      patient.calls.create! status: 'Reached patient',
+                            created_at: 3.days.ago,
+                            created_by: user2
+    end
+  end
+
 
   patient.save
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fun facts about our seeds:

* they're not relational

That means that the name sticks, and because a bunch of our fake patients get renamed in the seed process, that means a little bit of unhelpful confusion when events get created reflecting their old names. So we're reordering the call creation a little bit.

This pull request makes the following changes:
* Reorders the seed file so calls get created after renaming

It relates to the following issue #s: 
* Fixes #1294 
