### PR TITLE
Upgrade oauth gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,7 @@ gem 'enumerize' # Mongoid doesn't have enum out of the box, so we get it here
 
 # Our authentication library is devise, with oauth2 for google signin
 gem 'devise', '~> 4.4'
-gem 'omniauth-google-oauth2', '0.2.1' # TODO upgrade
-gem 'omniauth-oauth2', '1.3.1' # TODO remove this pin
+gem 'omniauth-google-oauth2', '0.5.3'
 
 # We use `bootstrap_form_for` in views
 gem 'bootstrap_form'

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'mongo_session_store', '>= 3.1.0' # stores sessions in database for security
 gem 'enumerize' # Mongoid doesn't have enum out of the box, so we get it here
 
 # Our authentication library is devise, with oauth2 for google signin
-gem 'devise', '~> 4.3'
+gem 'devise', '~> 4.4'
 gem 'omniauth-google-oauth2', '0.2.1' # TODO upgrade
 gem 'omniauth-oauth2', '1.3.1' # TODO remove this pin
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (7.1.2.3)
       execjs
-    bcrypt (3.1.11)
+    bcrypt (3.1.12)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -102,7 +102,7 @@ GEM
     coffee-script-source (1.12.2)
     colored (1.2)
     concurrent-ruby (1.0.5)
-    crass (1.0.3)
+    crass (1.0.4)
     database_cleaner (1.6.2)
     devise (4.4.3)
       bcrypt (~> 3.0)
@@ -138,7 +138,7 @@ GEM
       request_store (>= 1.0)
     hashery (2.1.2)
     hashie (3.5.6)
-    i18n (1.0.0)
+    i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -253,7 +253,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.1)
     puma (3.11.3)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-attack (5.1.0)
       rack
     rack-test (0.6.3)
@@ -394,7 +394,7 @@ DEPENDENCIES
   codecov
   coffee-rails (~> 4.2.2)
   database_cleaner
-  devise (~> 4.3)
+  devise (~> 4.4)
   enumerize
   factory_bot_rails
   faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       multi_json
       request_store (>= 1.0)
     hashery (2.1.2)
-    hashie (3.5.6)
+    hashie (3.5.7)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
@@ -210,7 +210,7 @@ GEM
       easy_diff
       mongoid (>= 3.0)
       mongoid-compatibility
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.0)
@@ -222,14 +222,15 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.6.1)
+    omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
-    omniauth-google-oauth2 (0.2.1)
-      omniauth (~> 1.0)
-      omniauth-oauth2
-    omniauth-oauth2 (1.3.1)
-      oauth2 (~> 1.0)
+    omniauth-google-oauth2 (0.5.3)
+      jwt (>= 1.5)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.5)
+    omniauth-oauth2 (1.5.0)
+      oauth2 (~> 1.1)
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     parallel (1.12.1)
@@ -419,8 +420,7 @@ DEPENDENCIES
   mongoid-history (= 0.6.1)
   mongoid_userstamp!
   nokogiri (>= 1.8.1)
-  omniauth-google-oauth2 (= 0.2.1)
-  omniauth-oauth2 (= 1.3.1)
+  omniauth-google-oauth2 (= 0.5.3)
   pdf-inspector
   prawn
   pry

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,8 +24,7 @@ class User
           :validatable,
           :lockable,
           :timeoutable,
-          :omniauthable,
-          :omniauth_providers => [:google_oauth2]
+          :omniauthable, omniauth_providers: [:google_oauth2]
   # :rememberable
   # :confirmable
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -235,7 +235,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth :google_oauth2, ENV['DARIA_GOOGLE_KEY'], ENV['DARIA_GOOGLE_SECRET']
+  config.omniauth :google_oauth2, ENV['DARIA_GOOGLE_KEY'], ENV['DARIA_GOOGLE_SECRET'], {}
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

The oauth library ecosystem has resolved its weird hangups, so we can unpin a couple of our oauth libraries. And keeping oauth libraries up to date is important, because ~ authentication~ !

This pull request makes the following changes:
* bump `devise`
* bump `omniauth-google-oauth2`

I could get this to work locally but we should be sure to hammer on it on sandbox too.

It relates to the following issue #s: 
* Fixes #1171 
