### PR TITLE
Lock inactive users after 9 months of inactivity

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -19,7 +19,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def log_in_user_via_google
     flash[:notice] = I18n.t 'devise.omniauth_callbacks.success',
                             kind: 'Google'
-    sign_in_and_redirect @user, event: :authentication
+    sign_in @user, event: :authentication
+    redirect_to root_path
   end
 
   def reject_login

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User
     inactive_no_logins = where(:role.nin => [:admin],
                                :last_sign_in_at => nil,
                                :created_at.lt => cutoff_date)
-    (inactive_no_logins | inactive_has_logged_in).each do |set|
+    [inactive_no_logins, inactive_has_logged_in].each do |set|
       set.update disabled_by_fund: true
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,6 @@ class User
     [inactive_no_logins, inactive_has_logged_in].each do |set|
       set.update disabled_by_fund: true
     end
-    fail 'until oauth login updates last_sign_in_at'
   end
 
   # ticket 241 recently called criteria:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,12 +111,12 @@ class User
 
   def self.disable_inactive_users
     cutoff_date = Time.zone.now - TIME_BEFORE_DISABLED_BY_FUND
-    inactive_has_logged_in = where(:role.nin => :admin,
+    inactive_has_logged_in = where(:role.nin => [:admin],
                                    :last_sign_in_at.lt => cutoff_date)
-    inactive_no_logins = where(:role.nin => :admin,
+    inactive_no_logins = where(:role.nin => [:admin],
                                :last_sign_in_at => nil,
                                :created_at.lt => cutoff_date)
-    [inactive_no_logins, inactive_has_logged_in].each do |set|
+    (inactive_no_logins | inactive_has_logged_in).each do |set|
       set.update disabled_by_fund: true
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,6 +85,7 @@ class User
   validate :secure_password
 
   TIME_BEFORE_INACTIVE = 2.weeks
+  TIME_BEFORE_DISABLED_BY_FUND = 9.months
 
   def secure_password
     return true if password.nil?
@@ -106,6 +107,19 @@ class User
   def toggle_disabled_by_fund
     # Since toggle skips callbacks...
     update disabled_by_fund: !disabled_by_fund
+  end
+
+  def self.disable_inactive_users
+    cutoff_date = Time.zone.now - TIME_BEFORE_DISABLED_BY_FUND
+    inactive_has_logged_in = where(:role.nin => :admin,
+                                   :last_sign_in_at.lt => cutoff_date)
+    inactive_no_logins = where(:role.nin => :admin,
+                               :last_sign_in_at => nil,
+                               :created_at.lt => cutoff_date)
+    [inactive_no_logins, inactive_has_logged_in].each do |set|
+      set.update_all disabled_by_fund: true
+    end
+    fail 'until oauth login updates last_sign_in_at'
   end
 
   # ticket 241 recently called criteria:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,7 +117,7 @@ class User
                                :last_sign_in_at => nil,
                                :created_at.lt => cutoff_date)
     [inactive_no_logins, inactive_has_logged_in].each do |set|
-      set.update_all disabled_by_fund: true
+      set.update disabled_by_fund: true
     end
     fail 'until oauth login updates last_sign_in_at'
   end

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -3,6 +3,9 @@ task nightly_cleanup: :environment do
   User.all.each { |user| user.clean_call_list_between_shifts }
   puts "#{Time.now} -- cleared all recently reached patients from call lists"
 
+  User.disable_inactive_users
+  puts "#{Time.now} -- locked accounts of users who have not logged in since #{9.months.ago}"
+
   Patient.trim_urgent_patients
   puts "#{Time.now} -- trimmed urgent patients"
 
@@ -14,5 +17,4 @@ task nightly_cleanup: :environment do
 
   ArchivedPatient.archive_fulfilled_patients!
   puts "#{Time.now} -- archived fulfilled patients"
-
 end

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -4,7 +4,7 @@ task nightly_cleanup: :environment do
   puts "#{Time.now} -- cleared all recently reached patients from call lists"
 
   User.disable_inactive_users
-  puts "#{Time.now} -- locked accounts of users who have not logged in since #{9.months.ago}"
+  puts "#{Time.now} -- locked accounts of users who have not logged in since #{User::TIME_BEFORE_DISABLED_BY_FUND.ago}"
 
   Patient.trim_urgent_patients
   puts "#{Time.now} -- trimmed urgent patients"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -233,7 +233,7 @@ class UserTest < ActiveSupport::TestCase
         # No locking admins or users with recent activity
         [@admin, @nondisabled_user].each do |user|
           user.reload
-          refute user.disabled_by_fund?
+          assert_not user.disabled_by_fund?
         end
       end
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -216,12 +216,25 @@ class UserTest < ActiveSupport::TestCase
     end
 
     describe 'nightly cleanup task - disable_inactive_users' do
-      it 'should find inactive users with logins before cutoff and disable' do
-        fail
+      before do
+        @disabled_user = create(:user, last_sign_in_at: 10.months.ago)
+        @admin = create(:user, role: :admin, last_sign_in_at: 11.months.ago)
+        @no_login_user = create(:user, created_at: 12.months.ago)
+        @nondisabled_user = create(:user, last_sign_in_at: 8.months.ago)
+        User.disable_inactive_users
       end
 
-      it 'should not disable admins' do
-        fail
+      it 'should find inactive users with logins before cutoff and disable' do
+        [@disabled_user, @no_login_user].each do |user|
+          user.reload
+          assert user.disabled_by_fund?
+        end
+
+        # No locking admins or users with recent activity
+        [@admin, @nondisabled_user].each do |user|
+          user.reload
+          refute user.disabled_by_fund?
+        end
       end
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -214,5 +214,15 @@ class UserTest < ActiveSupport::TestCase
       @user.reload
       assert @user.disabled_by_fund
     end
+
+    describe 'nightly cleanup task - disable_inactive_users' do
+      it 'should find inactive users with logins before cutoff and disable' do
+        fail
+      end
+
+      it 'should not disable admins' do
+        fail
+      end
+    end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We talked about avoiding having too many inactive but usable accounts by locking after 6 months. This sets up disabling them after 9 months, to allow a little bit of wiggle room and to reduce threat vectors for funds with a lot of CMs.

TK is writing tests, and I also noticed that logging in from oauth doesn't update the `last_sign_in_at` field on User, so we'll want to make an adjustment to the `from_omniauth` method to handle that.

This pull request makes the following changes:
* Add a command to the nightly cleanup task
* Add a user command to get and lock/disabled_by_fund user accounts

No view changes.

It relates to the following issue #s: 
* Fixes #713 