### PR TITLE
Install sqreen's devise plugin to block sketch signups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,4 +107,5 @@ end
 group :production do
   gem 'skylight' # our newrelic-style efficiency monitoring platform
   gem 'sqreen' # an active security monitoring platform
+  gem 'devise_sqreener' # A sqreen devise plugin
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    devise_sqreener (0.1.1)
     docile (1.1.5)
     easy_diff (1.0.0)
     enumerize (2.2.2)
@@ -395,6 +396,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2.2)
   database_cleaner
   devise (~> 4.3)
+  devise_sqreener
   enumerize
   factory_bot_rails
   faker

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User
           :registerable,
           :recoverable,
           :trackable,
+          :sqreenable,
           :validatable,
           :lockable,
           :timeoutable,
@@ -72,6 +73,11 @@ class User
   field :failed_attempts, type: Integer, default: 0
   # field :unlock_token,    type: String
   field :locked_at,       type: Time
+
+  ## Sqreenable
+  field :sqreened_email,              type: String
+  field :current_sqreened_sign_in_ip, type: String
+  field :last_sqreened_sign_in_ip,    type: String
 
   # An extra hard shutoff field for when a fund wants to shut off a user acct.
   # We call this disabling in the app, but users/CMs see this as 'Lock/Unlock'.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -259,4 +259,18 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # Sqreenable
+  # Block signins if the email or IP is sketchy via the sqreen api
+  if Rails.env.production?
+    config.sqreen_api_token = ENV['SQREEN_TOKEN']
+    config.sqreen_block_sign_in =  -> (email, ip, user)  {ip && (ip['risk_score'] > 40 ||
+                                                                 ip['is_known_attacker'] ||
+                                                                 ip['ip_geo'].country_code != 'USA' ||
+                                                                 ip['is_tor']) }
+    config.sqreen_block_sign_in =  -> (email, ip, user) { email && (email['is_email_harmful'] ||
+                                                                    email['is_known_attacker'] ||
+                                                                    email['security_events_count'] ||
+                                                                    email['is_disposable']) }
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Installs a sqreen plugin to block iffy signups. More later because it's late. Still need to confirm that this doesn't just break signups via some local testing. 

This pull request makes the following changes:
* Installs sqreener devise gem

No view changes.

It relates to the following issue #s: 
* Fixes #1372
