### PR TITLE
WIP Use USA.gov styling for alerts

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -346,3 +346,14 @@ $daria-color-lt : #825fb9;
 #flash {
   position: fixed;
 }
+
+/*Just success rn*/
+.alert {
+  border-left: 10px solid #3c763d;
+  color: black;
+}
+
+.flash-glyphicon {
+  color: black;
+  padding-right: 10px;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -116,16 +116,6 @@ $font-size: 17px;
   padding: 15px 30px;
 }
 
-#flash {
-  position: absolute;
-  width: 100%;
-  z-index: 999;
-  transition-duration: .5s;
-  &:hover {
-    opacity: .5;
-  }
-}
-
 // General styling artifacts
 // make all images responsive by default
 img {
@@ -343,14 +333,25 @@ $daria-color-lt : #825fb9;
   }
 }
 
-#flash {
+/*#flash {
   position: fixed;
 }
-
+*/
 /*Just success rn*/
-.alert {
+.flash {
   border-left: 10px solid #3c763d;
   color: black;
+  /*position: fixed;*/
+}
+
+#flash {
+  position: fixed;
+  width: 100%;
+  z-index: 999;
+  transition-duration: .5s;
+  &:hover {
+    opacity: .5;
+  }
 }
 
 .flash-glyphicon {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/app/helpers/layouts_helper.rb
+++ b/app/helpers/layouts_helper.rb
@@ -1,0 +1,30 @@
+module LayoutsHelper
+  def flash_msg(name, msg)
+    btn = content_tag :button, '&times;', type: 'button', class: 'close',
+                               data: { dismiss: 'alert' }, 
+                               aria: { hidden: true }
+    glyph = tag :span, class: ['glyphicon', alert_glyphicon_for(name)],
+                aria: { hidden: true }
+    body = content_tag :div, msg, id: "flash_#{name}"
+    content = safe_join [btn, glyph, body], ''
+
+    content_tag :div, content, class: ['alert', alert_type_for(name)],
+                               style: alert_style_for(name)
+  end
+
+  private
+
+  def alert_type_for(name)
+    name.to_s == 'notice' ? 'alert-success' : 'alert-danger'
+  end
+
+  def alert_style_for(name)
+    return 'check' if name.to_s == 'notice'
+    'danger'
+  end
+
+  def alert_glyphicon_for(name)
+    return 'glyphicon-check' if name.to_s == 'notice'
+    'glyphicon-exclamation'
+  end
+end

--- a/app/helpers/layouts_helper.rb
+++ b/app/helpers/layouts_helper.rb
@@ -1,11 +1,14 @@
 module LayoutsHelper
   def flash_msg(name, msg)
-    btn = content_tag :button, '&times;', type: 'button', class: 'close',
+    close_glyph = tag :span, class: ['glyphicon', 'glyphicon-remove'],
+                aria: { hidden: true }
+    btn = content_tag :button, close_glyph, type: 'button', class: 'close',
                                data: { dismiss: 'alert' }, 
                                aria: { hidden: true }
-    glyph = tag :span, class: ['glyphicon', alert_glyphicon_for(name)],
+
+    glyph = tag :span, class: ['glyphicon', 'flash-glyphicon', alert_glyphicon_for(name)],
                 aria: { hidden: true }
-    body = content_tag :div, msg, id: "flash_#{name}"
+    body = content_tag :span, msg, id: "flash_#{name}"
     content = safe_join [btn, glyph, body], ''
 
     content_tag :div, content, class: ['alert', alert_type_for(name)],
@@ -24,7 +27,7 @@ module LayoutsHelper
   end
 
   def alert_glyphicon_for(name)
-    return 'glyphicon-check' if name.to_s == 'notice'
-    'glyphicon-exclamation'
+    return 'glyphicon-ok-sign' if name.to_s == 'notice'
+    'glyphicon-exclamation-sign'
   end
 end

--- a/app/helpers/layouts_helper.rb
+++ b/app/helpers/layouts_helper.rb
@@ -11,7 +11,7 @@ module LayoutsHelper
     body = content_tag :span, msg, id: "flash_#{name}"
     content = safe_join [btn, glyph, body], ''
 
-    content_tag :div, content, class: ['alert', alert_type_for(name)],
+    content_tag :div, content, id: 'flash', class: ['alert', alert_type_for(name)],
                                style: alert_style_for(name)
   end
 

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,9 +1,9 @@
-<div id="flash">
-  <div class="col-sm-10">
+<!-- <div id="flash"> -->
+  <!-- <div class="col-sm-10"> -->
     <% flash.each do |name, msg| %>
       <% if name != 'timedout' && msg.length > 0 %>
         <%= flash_msg(name, msg) %>
       <% end %>
     <% end %>
-  </div>  
-</div>
+  <!-- </div>   -->
+<!-- </div> -->

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -2,10 +2,7 @@
   <div class="col-sm-10">
   <% flash.each do |name, msg| %>
     <% if name != 'timedout' && msg.length > 0 %>
-      <div class="alert alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">
-        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-        <%= content_tag :div, msg, :id => "flash_#{name}" %>
-      </div>
+      <%= flash_msg(name, msg) %>
     <% end %>
   <% end %>
   </div>

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,9 +1,9 @@
-<div id='flash'>
+<div id="flash">
   <div class="col-sm-10">
-  <% flash.each do |name, msg| %>
-    <% if name != 'timedout' && msg.length > 0 %>
-      <%= flash_msg(name, msg) %>
+    <% flash.each do |name, msg| %>
+      <% if name != 'timedout' && msg.length > 0 %>
+        <%= flash_msg(name, msg) %>
+      <% end %>
     <% end %>
-  <% end %>
-  </div>
+  </div>  
 </div>

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -52,6 +52,6 @@ if($('#row-<%= @patient.id %>')) {
 // flash the result
 $('#flash').html('<%= escape_javascript(render partial: "layouts/messages") %>');
 $('#flash').removeClass().hide().fadeIn('slow');
-setTimeout(function() {
-  $('#flash').hide();
-}, 5000);
+// setTimeout(function() {
+//   $('#flash').hide();
+// }, 5000);


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

My reign of terror against long open issues continues with usa.gov styling for alerts.

Still TK:

Tests
Side bar
Black text and close glyphicon
Fix the alerts partial rendering (why is it indented like that)
Use this as an excuse to tidy up the frontend assets

This pull request makes the following changes:
* Success and warning alerts follow the usa.gov style

No screenshots until it's done.

It relates to the following issue #s: 
* Fixes #728 
