### PR TITLE
Squash n+1 query on changelog

### DIFF
--- a/app/models/concerns/history_trackable.rb
+++ b/app/models/concerns/history_trackable.rb
@@ -3,7 +3,7 @@ module HistoryTrackable
   extend ActiveSupport::Concern
 
   def assemble_audit_trails
-    history_tracks.sort_by(&:created_at).reverse
+    history_tracks.includes(:created_by).sort_by(&:created_at).reverse
   end
 
   def recent_history_tracks


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I was looking for this in an unrelated spot and found it on the plane. This should significantly improve load time of the patient view for patients with a lot of edits, and also improve reload after updates.

This pull request makes the following changes:
* slap an includes on the query to join in user data

No view changes, no issues. 