### PR TITLE
Make CM Resources a config

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,11 +6,6 @@
     "postdeploy": "bundle exec rake db:mongoid:create_indexes"
   },
   "env": {
-    "CM_RESOURCES_URL": {
-      "description": "usually a link to the google drive folder with CM resources in it",
-      "value": "",
-      "required": false
-    },
     "CSP_VIOLATION_URI": {
       "description": "from your CSP report endpoint",
       "value": "26d24d139baa52b71da9637b14c7d17b.report-uri.io/r/default"

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -1,0 +1,9 @@
+module NavbarHelper
+  def cm_resources_link
+    url = Config.find_or_create_by(config_key: 'resources_url').options.first
+
+    content_tag :li do
+      link_to 'CM Resources', url, target: '_blank'
+    end if url.present?
+  end
+end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -6,7 +6,18 @@ class Config
   include Mongoid::History::Trackable
   extend Enumerize
 
-  CONFIG_FIELDS = [:insurance, :external_pledge_source, :pledge_limit_help_text, :language].freeze
+  # Comma separated configs
+  CONFIG_FIELDS = [
+    :insurance, :external_pledge_source, :pledge_limit_help_text,
+    :language, :resources_url].freeze
+
+  # Define overrides for particular config fields
+  HELP_TEXT_OVERRIDES = {
+    resources_url: 'A link to a Google Drive folder with CM resources. ' \
+                   'Displayed in the top left on the navbar if set. ' \
+                   'Do not separate with commas. ' \
+                   'Ex: https://drive.google.com/drive/my-resource-dir'
+  }
 
   # Fields
   enumerize :config_key, in: CONFIG_FIELDS
@@ -29,6 +40,10 @@ class Config
   # Methods
   def options
     config_value[:options]
+  end
+
+  def help_text_override
+    HELP_TEXT_OVERRIDES[config_key.to_sym]
   end
 
   def self.autosetup

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -9,15 +9,14 @@ class Config
   # Comma separated configs
   CONFIG_FIELDS = [
     :insurance, :external_pledge_source, :pledge_limit_help_text,
-    :language, :resources_url].freeze
+    :language, :resources_url
+  ].freeze
 
   # Define overrides for particular config fields
   HELP_TEXT_OVERRIDES = {
     resources_url: 'A link to a Google Drive folder with CM resources. ' \
-                   'Displayed in the top left on the navbar if set. ' \
-                   'Do not separate with commas. ' \
                    'Ex: https://drive.google.com/drive/my-resource-dir'
-  }
+  }.freeze
 
   # Fields
   enumerize :config_key, in: CONFIG_FIELDS
@@ -42,8 +41,11 @@ class Config
     config_value[:options]
   end
 
-  def help_text_override
-    HELP_TEXT_OVERRIDES[config_key.to_sym]
+  def help_text
+    text = HELP_TEXT_OVERRIDES[config_key.to_sym]
+    return text if text
+
+    'Please separate with commas.'
   end
 
   def self.autosetup

--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -4,15 +4,14 @@
       <%= f.text_area :options, label: "#{config.config_key.to_s.humanize} options",
                                 value: config.config_value.try(:values_at, 'options')
                                                           .try(:join, ', '),
-                                help: 'Please separate with commas if applicable.',
+                                help: config.help_text,
                                 id: "config_options_#{config.config_key}" %>
       <%= f.submit "Update options for #{config.config_key.to_s.humanize}", class: 'btn btn-primary' %>
     <% end %>  
   </div>
 
   <div class="col-md-6" id="<%= config.config_key.to_s %>_options_list">
-    <% if config.help_text_override.present? %>
-      <%= config.help_text_override %>
+    <% if Config::HELP_TEXT_OVERRIDES[config.config_key.to_sym] %>
     <% else %>
       <label>Current options are:</label>
       <br />

--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -4,16 +4,21 @@
       <%= f.text_area :options, label: "#{config.config_key.to_s.humanize} options",
                                 value: config.config_value.try(:values_at, 'options')
                                                           .try(:join, ', '),
-                                help: 'Please separate with commas.',
+                                help: 'Please separate with commas if applicable.',
                                 id: "config_options_#{config.config_key}" %>
       <%= f.submit "Update options for #{config.config_key.to_s.humanize}", class: 'btn btn-primary' %>
     <% end %>  
   </div>
 
   <div class="col-md-6" id="<%= config.config_key.to_s %>_options_list">
-    <label>Current options are:</label>
-    <% public_send("#{config.config_key}_options").each do |opt| %>
-      <%= opt %><br />
+    <% if config.help_text_override.present? %>
+      <%= config.help_text_override %>
+    <% else %>
+      <label>Current options are:</label>
+      <br />
+      <% public_send("#{config.config_key}_options").each do |opt| %>
+        <%= opt %><br />
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -3,9 +3,7 @@
     <% if session[:line] %>
       <li class="navbar-text-alt"><%= current_line_display %></li>
     <% end %>
-    <% if ENV['CM_RESOURCES_URL'] %>
-      <li><%= link_to 'CM Resources', ENV['CM_RESOURCES_URL'], target: '_blank' %></li>
-    <% end %>
+    <%= cm_resources_link %>
   <% end %>
 </ul>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,7 @@ fail 'No running seeds in prod' unless [nil, 'Sandbox'].include? ENV['DARIA_FUND
 Patient.destroy_all
 User.destroy_all
 Clinic.destroy_all
+Config.destroy_all
 
 # Create google SSO user
 # puts "Creating user with email #{ARGV[1]}..."
@@ -139,13 +140,14 @@ patient_in_completed_calls.calls.create! status: 'Left voicemail',
                                         created_by: user
 
 # Create insurance and external pledge source keysets
-Config.destroy_all
 Config.create config_key: :insurance,
               config_value: { options: ['DC Medicaid', 'MD Medicaid', 'VA Medicaid', 'Other Insurance']}
 Config.create config_key: :external_pledge_source,
               config_value: { options: ['Baltimore Abortion Fund', 'Metallica Abortion Fund']}
 Config.create config_key: :pledge_limit_help_text,
               config_value: { options: ['Pledge Limit Guidelines:', '1st trimester (7-12 weeks): $100', '2nd trimester (12-24 weeks): $300', 'Later care (25+ weeks): $600']}
+Config.create config_key: :language,
+              config_value: { options: ['Spanish', 'French', 'Korean']}
 Config.create config_key: :language,
               config_value: { options: ['Spanish', 'French', 'Korean']}
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -148,7 +148,7 @@ Config.create config_key: :pledge_limit_help_text,
               config_value: { options: ['Pledge Limit Guidelines:', '1st trimester (7-12 weeks): $100', '2nd trimester (12-24 weeks): $300', 'Later care (25+ weeks): $600']}
 Config.create config_key: :language,
               config_value: { options: ['Spanish', 'French', 'Korean']}
-Config.create config_key: :language,
+Config.create config_key: :resources_url,
               config_value: { options: ['Spanish', 'French', 'Korean']}
 
 # Reporting fixtures

--- a/test/helpers/navbar_helper_test.rb
+++ b/test/helpers/navbar_helper_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class NavbarHelperTest < ActionView::TestCase
+  include ERB::Util
+
+  describe 'cm_resources_link' do
+    before do
+      @config = create :config, config_key: 'resources_url',
+                                config_value: { options: ['https://www.google.com'] }
+    end
+
+    it 'should return nil if config is not set' do
+      @config.update config_value: { options: [] }
+      refute cm_resources_link
+    end
+
+    it 'should return a link if config set' do
+      expected_link = '<li><a target="_blank" href="https://www.google.com">CM Resources</a></li>'
+      assert_equal expected_link, cm_resources_link
+    end
+  end
+end

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -49,10 +49,10 @@ class ConfigTest < ActiveSupport::TestCase
     end
 
     it 'should retrieve help text if set' do
-      refute @config.help_text_override
+      refute @config.help_text
 
       @config.update config_key: 'resources_url'
-      assert_includes @config.help_text_override,
+      assert_includes @config.help_text,
                       'A link to a Google Drive'
     end
 

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -48,8 +48,8 @@ class ConfigTest < ActiveSupport::TestCase
                    ['DC Medicaid', 'No insurance', "Don't know"]
     end
 
-    it 'should retrieve help text if set' do
-      refute @config.help_text
+    it 'should retrieve appropriate help text if set' do
+      assert_equal 'Please separate with commas.', @config.help_text
 
       @config.update config_key: 'resources_url'
       assert_includes @config.help_text,

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -48,6 +48,14 @@ class ConfigTest < ActiveSupport::TestCase
                    ['DC Medicaid', 'No insurance', "Don't know"]
     end
 
+    it 'should retrieve help text if set' do
+      refute @config.help_text_override
+
+      @config.update config_key: 'resources_url'
+      assert_includes @config.help_text_override,
+                      'A link to a Google Drive'
+    end
+
     describe 'autosetup' do
       before { Config.destroy_all }
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds a config for CM Resources link in the top navbar, and does some wiring to get the env var out of the way.

This pull request makes the following changes:
* New config value, plus the option to override it
* Tweak the view to pull from the config instead of the value

Shows up like so:

![screen shot 2018-06-22 at 1 44 15 am](https://user-images.githubusercontent.com/3866868/41761737-00e27912-75be-11e8-90b5-26589082b3c7.png)



It relates to the following issue #s: 
* Fixes #1268 
