### PR TITLE
Install minitest optional-retry and cover our flaky tests with it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :test do
 
   # Specifics
   gem 'shoulda-context'
+  gem 'minitest-optional_retry' # retry flaky tests 3 times
   gem 'mini_backtrace' # settle down minitest output
   gem 'pdf-inspector', require: 'pdf/inspector' # test pdf contents
   gem 'minitest-stub-const'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
     minitest (5.11.3)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
+    minitest-optional_retry (0.0.2)
+      minitest (~> 5.0)
     minitest-spec-rails (5.4.0)
       minitest (~> 5.0)
       rails (>= 4.1)
@@ -416,6 +418,7 @@ DEPENDENCIES
   loofah (>= 2.2.1)
   mini_backtrace
   minitest-ci
+  minitest-optional_retry
   minitest-spec-rails
   minitest-stub-const
   mongo_session_store (>= 3.1.0)

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class PatientTest < ActiveSupport::TestCase
+  extend Minitest::OptionalRetry
+
   before do
     @user = create :user
     @patient = create :patient, other_phone: '111-222-3333',

--- a/test/system/logging_calls_test.rb
+++ b/test/system/logging_calls_test.rb
@@ -1,6 +1,8 @@
 require 'application_system_test_case'
 
 class LoggingCallsTest < ApplicationSystemTestCase
+  extend Minitest::OptionalRetry
+
   before do
     @patient = create :patient, name: 'Susan Everyteen',
                                 primary_phone: '123-123-1234'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I am deeply annoyed by our flaky tests, which seem to fail one out of every five times or so. So I'm throwing in a retry gem.

This pull request makes the following changes:
* Add `minitest-optional_retry` as recommended by the minitest dude
* palm slap it into `logging_calls_test` and `patient_test`

No view changes.

It relates to the following issue #s: 
* Fixes #1326 
