### PR TITLE
Add city to export file

### DIFF
--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -15,6 +15,7 @@ module Exportable
     "Age" => :age_range,
     "State" => :state,
     "County" => :county,
+    "City" => :city,
     "Race or Ethnicity" => :race_ethnicity,
     "Employment Status" => :employment_status,
     "Minors in Household" => :get_household_size_children,


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We're putting `city` in export, per request of a fund. This does that thing.

This is already porting over in archived patient, so we should be good to go after this.

This pull request makes the following changes:
* one-line change to add city to the export file. SWEET

No view changes.

It relates to the following issue #s: 
* Fixes #1449 
