### PR TITLE
Budget bar tweak for deploy: comment out the Remaining figure

### DIFF
--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -18,9 +18,12 @@
           <%= number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0, precision: 0)  %> <%= type  %> (<%= expenditures[type].count %> patients)
         </div>
       <% end %>
+      <%# TODO Commenting out until the config is ready %>
+      <!-- 
       <div class="col-sm-4">
         <%= number_to_currency(budget_bar_remaining(expenditures, limit), precision: 0) %> remaining
       </div>
+      -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I think at first it will be more trouble than it's worth to set this up, until we have a config that does it, so commenting it out for now.

This pull request makes the following changes:
* Comment out the remaining div in budget bar
