### PR TITLE
Fix permissioning for user edit, accountants controller, and 

### DIFF
--- a/app/controllers/accountants_controller.rb
+++ b/app/controllers/accountants_controller.rb
@@ -1,7 +1,7 @@
 # Controller pertaining to accountant functions, usually fulfillments.
 class AccountantsController < ApplicationController
-  before_action :confirm_data_access, only: [:index, :edit]
-  before_action :confirm_data_access_async, only: [:search]
+  before_action :confirm_data_access, only: [:index]
+  before_action :confirm_data_access_async, only: [:search, :edit]
   before_action :find_patient, only: [:edit]
 
   def index

--- a/app/controllers/accountants_controller.rb
+++ b/app/controllers/accountants_controller.rb
@@ -1,7 +1,7 @@
 # Controller pertaining to accountant functions, usually fulfillments.
 class AccountantsController < ApplicationController
-  before_action :confirm_admin_user, only: [:index, :edit]
-  before_action :confirm_admin_user_async, only: [:search]
+  before_action :confirm_data_access, only: [:index, :edit]
+  before_action :confirm_data_access_async, only: [:search]
   before_action :find_patient, only: [:edit]
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,8 +34,12 @@ class ApplicationController < ActionController::Base
     head :unauthorized unless current_user.admin?
   end
 
-  def redirect_unless_has_data_access
+  def confirm_data_access
     redirect_to root_path unless current_user.allowed_data_access?
+  end
+
+  def confirm_data_access_async
+    head :unauthorized unless current_user.allowed_data_access?
   end
 
   def confirm_user_not_disabled!

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,7 +1,7 @@
 # Create, edit, and update patients. The main patient view is edit.
 class PatientsController < ApplicationController
   before_action :confirm_admin_user, only: [:destroy]
-  before_action :redirect_unless_has_data_access, only: [:index]
+  before_action :confirm_data_access, only: [:index]
   before_action :find_patient, only: [:edit, :update, :download, :destroy]
   rescue_from Mongoid::Errors::DocumentNotFound,
               with: -> { redirect_to root_path }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,8 @@
 # Controller for automatically generated service reporting across lines.
 class ReportsController < ApplicationController
+  before_action :confirm_data_access, only: [:index]
+  before_action :confirm_data_access_async, only: [:report]
+
   def index; end
 
   def report

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 # Additional user methods in parallel with Devise -- all pertaining to call list
 class UsersController < ApplicationController
-  before_action :confirm_admin_user, only: [:new, :index, :update,
+  before_action :confirm_admin_user, only: [:new, :index, :update, :edit,
                                             :change_role_to_admin,
                                             :change_role_to_data_volunteer,
                                             :change_role_to_cm,

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,38 +1,82 @@
 require 'test_helper'
 
 class ReportsControllerTest < ActionDispatch::IntegrationTest
-  before do
-    @user = create :user
-    sign_in @user
-    @patient = create :patient,
-                      name: 'Susie Everyteen',
-                      primary_phone: '123-456-7890',
-                      other_phone: '333-444-5555'
-  end
-
-  describe 'index method' do
+  describe 'endpoints' do
     before do
-      get reports_path
+      @data_volunteer = create :user, role: :data_volunteer
+      sign_in @data_volunteer
+      @patient = create :patient,
+                        name: 'Susie Everyteen',
+                        primary_phone: '123-456-7890',
+                        other_phone: '333-444-5555'
     end
 
-    it 'should return success' do
-      assert_response :success
+    describe 'index method' do
+      before do
+        get reports_path
+      end
+
+      it 'should return success' do
+        assert_response :success
+      end
+    end
+
+    describe 'report method' do
+      it 'should return success on proper timeframe' do
+        get patients_report_path(timeframe: 'weekly'), xhr: true
+        assert_response :success
+        get patients_report_path(timeframe: 'monthly'), xhr: true
+        assert_response :success
+        get patients_report_path(timeframe: 'yearly'), xhr: true
+        assert_response :success
+      end
+
+      it 'should return not_acceptable on bad timeframe' do
+        get patients_report_path(timeframe: 'nonexistent'), xhr: true
+        assert_response 406
+      end
     end
   end
 
-  describe 'report method' do
-    it 'should return success on proper timeframe' do
-      get patients_report_path(timeframe: 'weekly'), xhr: true
-      assert_response :success
-      get patients_report_path(timeframe: 'monthly'), xhr: true
-      assert_response :success
-      get patients_report_path(timeframe: 'yearly'), xhr: true
-      assert_response :success
+  describe 'permissioning' do
+    describe 'index' do
+      [:admin, :data_volunteer].each do |permission|
+        it "should allow data vol or above - #{permission.to_s}" do
+          user = create :user, role: permission
+          sign_in user
+          get reports_path
+          assert_response :success
+        end
+      end
+
+      [:cm].each do |permission|
+        it "should deny CM or below data access - #{permission}" do
+          user = create :user, role: permission
+          sign_in user
+          get reports_path
+          assert_redirected_to root_url
+        end
+      end
     end
 
-    it 'should return 406 on bad timeframe' do
-      get patients_report_path(timeframe: 'nonexistent'), xhr: true
-      assert_response 406
+    describe 'report' do
+      [:admin, :data_volunteer].each do |permission|
+        it "should allow data vol or above - #{permission.to_s}" do
+          user = create :user, role: permission
+          sign_in user
+          get patients_report_path(timeframe: 'weekly'), xhr: true
+          assert_response :success
+        end
+      end
+
+      [:cm].each do |permission|
+        it "should deny CM or below data access - #{permission}" do
+          user = create :user, role: permission
+          sign_in user
+          get patients_report_path(timeframe: 'weekly'), xhr: true
+          assert_response :unauthorized
+        end
+      end
     end
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -21,6 +21,15 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    it "should redirect if user is not admin - edit_user" do
+      User.role.values.reject { |role| role == :admin }.each do |role|
+        @user_2 = create :user
+        @user.update role: role
+        get edit_user_path(@user)
+        assert_response :redirect
+      end
+    end
+
     %w[admin data_volunteer cm].each do |endpoint|
       it "should redirect if user is not admin - #{endpoint}" do
         User.role.values.reject { |role| role == :admin }.each do |role|

--- a/test/system/accountant_workflow_test.rb
+++ b/test/system/accountant_workflow_test.rb
@@ -34,7 +34,7 @@ class AccountantWorkflowTest < ApplicationSystemTestCase
   end
 
   describe 'admin wall' do
-    [:cm, :data_volunteer].each do |role|
+    [:cm].each do |role|
       it "should ban nonadmins from accessing accounting page - #{role}" do
         @nonadmin_user = create :user, role: role
         log_out


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Want to emphasize that none of these are huge holes, none of them involve db writes, and they're only accessible if you have a valid CM account already, and know some key stuff about our system. That's no excuse to not patch though.

This explicitly sets some data access permissioning on accountants and reports controller endpts, and makes user edit admin-only. Users should be able to edit their own data still via their own devise panel. 

This pull request makes the following changes:
* only data vols can access reporting and accounting endpoints now
* only admins can access user panels
* unit tests!

It relates to the following issue #s: 
* Fixes #1456 
* Fixes #1455 

Tagging in one of @tingaloo @mdworken or @lomky for approval