### PR TITLE
remove session referer to mitigate potential security problems #1457

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
 
   def new
     @user = User.new
-    session[:return_to] ||= request.referer
+    session[:return_to] ||= users_path
   end
 
   def update


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Changes: After using the create users form, we now redirect to users_path instead of the session referrer. This will produce the same behavior as before of going back to the main users list, but is more secure.

It relates to the following issue #s: 
* Fixes #1457 