### PR TITLE
Clear call lists based on actual last sign in instead of second to last sign in

### DIFF
--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -55,7 +55,7 @@ module CallListable
        current_sign_in_at < Time.zone.now - TIME_BEFORE_INACTIVE
       clear_call_list
     else
-      patients.each { patients.delete(p) if recently_reached_by_user?(p) }
+      patients.each { |p| patients.delete(p) if recently_reached_by_user?(p) }
     end
   end
 

--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -50,9 +50,10 @@ module CallListable
   TIME_BEFORE_INACTIVE = 2.weeks
 
   def clean_call_list_between_shifts
-    if last_sign_in_at.present? &&
-       last_sign_in_at < Time.zone.now - TIME_BEFORE_INACTIVE
-      patients.clear
+    last_activity = [last_sign_in_at, current_sign_in_at].reject(&:nil?).max
+    if last_activity.present? &&
+       last_activity < Time.zone.now - TIME_BEFORE_INACTIVE
+      clear_call_list
     else
       patients.each do |p|
         # TODO: reexamine this behavior in awhile

--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -50,15 +50,12 @@ module CallListable
   TIME_BEFORE_INACTIVE = 2.weeks
 
   def clean_call_list_between_shifts
-    last_activity = [last_sign_in_at, current_sign_in_at].reject(&:nil?).max
-    if last_activity.present? &&
-       last_activity < Time.zone.now - TIME_BEFORE_INACTIVE
+    # current_sign_in_at is a devise field set to the user's last login
+    if current_sign_in_at.present? &&
+       current_sign_in_at < Time.zone.now - TIME_BEFORE_INACTIVE
       clear_call_list
     else
-      patients.each do |p|
-        # TODO: reexamine this behavior in awhile
-        patients.delete(p) if recently_reached_by_user?(p)
-      end
+      patients.each { patients.delete(p) if recently_reached_by_user?(p) }
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -101,7 +101,9 @@ class UserTest < ActiveSupport::TestCase
 
     it 'should clear call list when someone invokes the cleanout' do
       assert_difference '@user.patients.count', -3 do
-        @user.clear_call_list
+        assert_no_difference 'Patient.count' do
+          @user.clear_call_list
+        end
       end
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -85,7 +85,7 @@ class UserTest < ActiveSupport::TestCase
     it 'should clear patient list when user has not logged in' do
       assert_not @user.patients.empty?
       last_sign_in = Time.zone.now - User::TIME_BEFORE_INACTIVE - 1.day
-      @user.last_sign_in_at = last_sign_in
+      @user.current_sign_in_at = last_sign_in
       @user.clean_call_list_between_shifts
 
       assert @user.patients.empty?
@@ -93,7 +93,7 @@ class UserTest < ActiveSupport::TestCase
 
     it 'should not clear patient list if user signed in recently' do
       assert_not @user.patients.empty?
-      @user.last_sign_in_at = Time.zone.now
+      @user.current_sign_in_at = Time.zone.now
       @user.clean_call_list_between_shifts
 
       assert_not @user.patients.empty?


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

See #1476 for an explanation, but in a nutshell current sign in at gets populated slightly differently than we thought it did.

This pull request makes the following changes:
* take the max of current sign in at and last sign in at when deciding whehter or not to clear a call list

It relates to the following issue #s: 
* Fixes #1476 
