### PR TITLE
Add textable option to voicemail preferences

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -111,7 +111,7 @@ class PatientsController < ApplicationController
 
   PATIENT_INFORMATION_PARAMS = [
     :line, :age, :race_ethnicity, :language,
-    :voicemail_preference, :city, :state, :county, :zip, :other_contact, :other_phone,
+    :voicemail_preference, :textable, :city, :state, :county, :zip, :other_contact, :other_phone,
     :other_contact_relationship, :employment_status, :income,
     :household_size_adults, :household_size_children, :insurance, :referred_by,
     special_circumstances: []

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -15,7 +15,8 @@ module DashboardsHelper
   def voicemail_options
     enum_text = { not_specified: 'No instructions; no ID VM',
                   no: 'Do not leave a voicemail',
-                  yes: 'Voicemail OK, ID OK' }
+                  yes: 'Voicemail OK, ID OK',
+                  text: 'Text preferred'}
     vm_options = Patient.voicemail_preference.values
     vm_options.map! { |option| option.to_sym }
 

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -16,7 +16,7 @@ module DashboardsHelper
     enum_text = { not_specified: 'No instructions; no ID VM',
                   no: 'Do not leave a voicemail',
                   yes: 'Voicemail OK, ID OK',
-                  text: 'Text preferred'}
+                }
     vm_options = Patient.voicemail_preference.values
     vm_options.map! { |option| option.to_sym }
 

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -25,7 +25,7 @@ class ArchivedPatient
 
   # Fields pulled from initial Patient
   field :voicemail_preference
-  enumerize :voicemail_preference, in: [:not_specified, :no, :yes], default: :not_specified
+  enumerize :voicemail_preference, in: [:not_specified, :no, :yes, :text], default: :not_specified
   field :line
   enumerize :line, in: LINES, default: LINES[0] # See config/initializers/env_vars.rb
   field :language, type: String

--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -25,7 +25,8 @@ class ArchivedPatient
 
   # Fields pulled from initial Patient
   field :voicemail_preference
-  enumerize :voicemail_preference, in: [:not_specified, :no, :yes, :text], default: :not_specified
+  enumerize :voicemail_preference, in: [:not_specified, :no, :yes], default: :not_specified
+  field :textable, type: Boolean
   field :line
   enumerize :line, in: LINES, default: LINES[0] # See config/initializers/env_vars.rb
   field :language, type: String

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -58,7 +58,7 @@ class Patient
 
   # Contact-related info
   field :voicemail_preference
-  enumerize :voicemail_preference, in: [:not_specified, :no, :yes, :text], default: :not_specified
+  enumerize :voicemail_preference, in: [:not_specified, :no, :yes], default: :not_specified
 
   field :line
   enumerize :line, in: LINES, default: LINES[0] # See config/initializers/env_vars.rb

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -50,6 +50,7 @@ class Patient
   # Searchable info
   field :name, type: String # strip
   field :primary_phone, type: String
+  field :textable, type: Boolean
   field :other_contact, type: String
   field :other_phone, type: String
   field :other_contact_relationship, type: String
@@ -57,7 +58,7 @@ class Patient
 
   # Contact-related info
   field :voicemail_preference
-  enumerize :voicemail_preference, in: [:not_specified, :no, :yes], default: :not_specified
+  enumerize :voicemail_preference, in: [:not_specified, :no, :yes, :text], default: :not_specified
 
   field :line
   enumerize :line, in: LINES, default: LINES[0] # See config/initializers/env_vars.rb

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -21,7 +21,7 @@
                                           patient.race_ethnicity),
                                           label: 'Race / Ethnicity',
                                           autocomplete: 'off' %>
-                                          
+
           <%= f.form_group :language do %>
             <%= f.select :language,
                        options_for_select(language_options,
@@ -33,6 +33,9 @@
           <%= f.select :voicemail_preference,
                        options_for_select(voicemail_options,
                                           patient.voicemail_preference) %>
+
+          <%= f.check_box :textable, label: 'Textable', autocomplete: 'off' %>
+
 
           <div class="row">
             <div class="col-sm-8">

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -20,6 +20,7 @@ $('#change_log').html(
 
 // Rerack urgent status
 $('#patient_urgent_flag').prop('checked', <%= @patient.urgent_flag? %>);
+$('#patient_textable').prop('checked', <%-@patient.textable? %> );
 
 // if pledge is sent, re-rack fulfillment info
 <% if current_user.allowed_data_access? && @patient.pledge_sent? %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,6 +45,7 @@ Clinic.create! name: 'Sample Clinic without NAF', street_address: '1811 14th Str
                  primary_phone: "123-123-123#{i}",
                  initial_call_date: 3.days.ago,
                  urgent_flag: flag,
+                 textable: flag,
                  last_menstrual_period_weeks: (i + 1 * 2),
                  last_menstrual_period_days: 3,
                  created_by: user2
@@ -392,7 +393,7 @@ end
   # Patient 1 drops off immediately
   next if patient_number.odd?
 
-  # We reach Patient 2 
+  # We reach Patient 2
   patient.update!(
     # header info - hand filled in
     appointment_date: 630.days.ago,

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -179,7 +179,8 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
 
       fill_in 'State', with: 'DC'
       fill_in 'County', with: 'Wash'
-      select 'Text preferred', from: 'patient_voicemail_preference'
+      select 'Voicemail OK', from: 'patient_voicemail_preference'
+      check 'Textable'
       wait_for_ajax
 
       select 'Spanish', from: 'patient_language'
@@ -212,7 +213,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'City', with: 'Washington'
         assert has_field? 'State', with: 'DC'
         assert has_field? 'County', with: 'Wash'
-        assert_equal 'text', find('#patient_voicemail_preference').value
+        assert_equal 'yes', find('#patient_voicemail_preference').value
         assert_equal 'Spanish', find('#patient_language').value
 
         assert_equal 'Part-time', find('#patient_employment_status').value
@@ -225,6 +226,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert_equal 'Spanish', find('#patient_language').value
         assert has_checked_field? 'Homelessness'
         assert has_checked_field? 'Prison'
+        assert has_checked_field? 'Textable'
         assert has_no_css? '#patient_line'
       end
     end

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -179,7 +179,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
 
       fill_in 'State', with: 'DC'
       fill_in 'County', with: 'Wash'
-      select 'Voicemail OK', from: 'patient_voicemail_preference'
+      select 'Text preferred', from: 'patient_voicemail_preference'
       wait_for_ajax
 
       select 'Spanish', from: 'patient_language'
@@ -212,7 +212,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'City', with: 'Washington'
         assert has_field? 'State', with: 'DC'
         assert has_field? 'County', with: 'Wash'
-        assert_equal 'yes', find('#patient_voicemail_preference').value
+        assert_equal 'text', find('#patient_voicemail_preference').value
         assert_equal 'Spanish', find('#patient_language').value
 
         assert_equal 'Part-time', find('#patient_employment_status').value
@@ -222,7 +222,6 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert_equal '3', find('#patient_household_size_children').value
         assert_equal 'Other state Medicaid', find('#patient_insurance').value
         assert_equal 'Other abortion fund', find('#patient_referred_by').value
-        assert_equal 'yes', find('#patient_voicemail_preference').value
         assert_equal 'Spanish', find('#patient_language').value
         assert has_checked_field? 'Homelessness'
         assert has_checked_field? 'Prison'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Add text option to voicemail preferences.

<img width="567" alt="screen shot 2018-10-20 at 14 04 48" src="https://user-images.githubusercontent.com/8662824/47258975-30356a00-d471-11e8-9f33-0362e8bd6401.png">

This pull request makes the following changes:
* Add text field to voicemail options

It relates to the following issue #s: 
* Fixes #1498 
