### PR TITLE
Fixing documentation for setting up locally (related to ruby upgrade …

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -36,7 +36,7 @@ If you prefer a local environment, totally cool! We recommend the following:
 
 ### First, ruby dependencies
 * Make sure you have a ruby version manager installed; we recommend either [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/)
-* Install our version of Ruby! We use version `2.5.1` (Usually `rbenv install 2.5.1` or `rvm install 2.5.1` once you have your version manager set up)
+* Install our version of Ruby! We use version `2.5.3` (Usually `rbenv install 2.5.3` or `rvm install 2.5.3` once you have your version manager set up)
 * Install PhantomJS, which our test suite depends on, via `brew install phantomjs`, or `npm install -g phantomjs-prebuilt`, or the [linux instructions](http://phantomjs.org/download.html)
 * Run the command `gem install bundler && bundle install` to install ruby dependences, including `rails`
 
@@ -69,7 +69,7 @@ If you don't currently have Rails installed (or are on Windows), Cloud9 makes th
 
 * Sign into `https://c9.io/` and create a new workspace
 * Clone from `git@github.com:{your_github_username}/dcaf_case_management.git` and select the Rails option
-* The terminal at the bottom of your new workspace will have a warning message saying "ruby-2.5.1 is not installed. To install do: `rvm install ruby-2.5.1`". Run that command to install the necessary version of Ruby.
+* The terminal at the bottom of your new workspace will have a warning message saying "ruby-2.5.3 is not installed. To install do: `rvm install ruby-2.5.3`". Run that command to install the necessary version of Ruby.
 * Next, install the bundler gem by entering `gem install bundler` in the terminal.
 * Install MongoDB by entering `sudo apt-get install -y mongodb-org`.
 * Once MongoDB is installed, run `bundle install` in the terminal


### PR DESCRIPTION
…to 2.5.3).

I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)
The documentation had not been updated to reflect the new version of ruby. When I cloned the repo and wanted to run the app, following the setup gave me incorrect information.

This pull request makes the following changes:
* Changed the documentation for setup to refer to the correct version of ruby.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1508 
* Bumps #Y
