### PR TITLE
Changed the label of the 'Referred by' dropdown #fixes-1499

### DIFF
--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -84,6 +84,7 @@
           <%= f.select :referred_by,
                        options_for_select(referred_by_options,
                                           patient.referred_by),
+                                          label: "How patient heard about #{FUND}",
                                           autocomplete: 'off' %>
 
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Changed the label as per the issue #1499 

(If there are changes to the views, please include a screenshot so we know what to look for!)
<img width="1244" alt="screen shot 2018-10-23 at 5 18 58 am" src="https://user-images.githubusercontent.com/69629/47325823-4dda1d80-d683-11e8-8b7f-44728d867940.png">


It relates to the following issue #s: 
* Fixes #1499
