### PR TITLE
#1420 add audited field to patient w validations and checks

### DIFF
--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -7,6 +7,8 @@ class ArchivedPatient
   # Concerns
   include Exportable
 
+  before_save :check_if_audited
+
   # Relationships
   belongs_to :clinic
   embeds_one :fulfillment
@@ -142,5 +144,12 @@ class ArchivedPatient
 
     archived_patient.save!
     archived_patient
+  end
+end
+
+# check if a patient has been audited; allow them to be archived if they were NOT audited but were created more than two years ago
+def check_if_audited
+  unless self.audited
+    self.created_at > 2.years.ago ? true : false
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -94,6 +94,7 @@ class Patient
   field :resolved_without_fund, type: Boolean
   field :pledge_generated_at, type: Time
   field :pledge_sent_at, type: Time
+  field :audited, type: Boolean, default: false
 
   # Indices
   index({ primary_phone: 1 }, unique: true)
@@ -110,6 +111,7 @@ class Patient
             :initial_call_date,
             :created_by_id,
             :line,
+            :audited,
             presence: true
   validates :primary_phone, format: /\d{10}/,
                             length: { is: 10 }

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -21,7 +21,7 @@
                                           patient.race_ethnicity),
                                           label: 'Race / Ethnicity',
                                           autocomplete: 'off' %>
-                                          
+
           <%= f.form_group :language do %>
             <%= f.select :language,
                        options_for_select(language_options,
@@ -109,6 +109,8 @@
                               checked: patient.special_circumstances.include?('Prison'), namespace: 'Prison' }, 'Prison', '' %>
             </div>
           <% end %>
+
+          <%= f.check_box :audited, label: 'Has patient fulfillment been audited?' %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Related to #1420 , I added an `audited` boolean field to Patients, which translates to a check box on the front end for the case manager to check if the Patient has been audited. As per the issue, I also added a check to see if the Patient was created more than two years ago (chosen arbitrarily; let me know if I should change!), and if so, they will be archived regardless of if they've been audited.

<img width="647" alt="screen shot 2018-10-23 at 8 42 54 pm" src="https://user-images.githubusercontent.com/10843135/47398920-4149d980-d704-11e8-8db8-c2b00d9e77c6.png">

I haven't worked with Mongo very much, so plz let me know if I've jacked this up!

It relates to the following issue #s: 
* Fixes #1420 
