### PR TITLE
remove user searches from patient searchable

### DIFF
--- a/app/models/concerns/patient_searchable.rb
+++ b/app/models/concerns/patient_searchable.rb
@@ -22,25 +22,6 @@ module PatientSearchable
 
     private
 
-    def find_name_matches_user(name_regexp)
-      if nonempty_regexp? name_regexp
-        primary_names = User.where name: name_regexp
-        other_names = User.where other_contact: name_regexp
-        return (primary_names | other_names)
-      end
-      []
-    end
-
-    def sort_and_limit_user_matches(*matches)
-      all_matches = matches.reduce do |results, matches_of_type|
-        results | matches_of_type
-      end
-
-      all_matches.sort { |a, b|
-        b.updated_at <=> a.updated_at
-      }.first(SEARCH_LIMIT)
-    end
-
     def sort_and_limit_patient_matches(*matches)
       all_matches = matches.reduce do |results, matches_of_type|
         results | matches_of_type


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I was looking through the test coverage and noticed that these two methods were never being called.  They are user search methods in the patient searchable module and probably dont belong.

This pull request makes the following changes:
* Remove unused private search methods that are not used.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1516 
* Bumps #Y
