### PR TITLE
New checkbox field for ultrasound info

### DIFF
--- a/app/assets/javascripts/patients.coffee
+++ b/app/assets/javascripts/patients.coffee
@@ -58,6 +58,11 @@ $(document).on 'turbolinks:load', ->
   $(document).on "change", ".edit_patient", ->
     $(this).submit()
 
+  # Toggle visibility of "Ultrasound completed?" checkbox based on selected state
+  $('[href="#abortion_information"]').click ->
+    ultrasoundCheckbox = $('[for="patient_completed_ultrasound"]')
+    if($('#patient_line')[0].value != 'VA') then ultrasoundCheckbox.hide() else ultrasoundCheckbox.show()
+
   $(document).on "change", "#pledge_fulfillment_form", ->
     markFulfilledWhenFieldsChecked()
     $(this).submit()

--- a/app/assets/javascripts/patients.coffee
+++ b/app/assets/javascripts/patients.coffee
@@ -58,11 +58,6 @@ $(document).on 'turbolinks:load', ->
   $(document).on "change", ".edit_patient", ->
     $(this).submit()
 
-  # Toggle visibility of "Ultrasound completed?" checkbox based on selected state
-  $('[href="#abortion_information"]').click ->
-    ultrasoundCheckbox = $('[for="patient_completed_ultrasound"]')
-    if($('#patient_line')[0].value != 'VA') then ultrasoundCheckbox.hide() else ultrasoundCheckbox.show()
-
   $(document).on "change", "#pledge_fulfillment_form", ->
     markFulfilledWhenFieldsChecked()
     $(this).submit()

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -118,7 +118,7 @@ class PatientsController < ApplicationController
   ].freeze
 
   ABORTION_INFORMATION_PARAMS = [
-    :clinic_id, :resolved_without_fund, :referred_to_clinic,
+    :clinic_id, :resolved_without_fund, :referred_to_clinic, :completed_ultrasound,
     :procedure_cost, :patient_contribution, :naf_pledge, :fund_pledge
   ].freeze
 

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -74,6 +74,6 @@ module TooltipsHelper
   end
 
   def mandatory_ultrasound_help_text
-    'State of VA requires since 2012 people seeking abortions to complete ultrasounds!'
+    'If you are in a state that requires ultrasounds and the patient has completed one, you can log it here.'
   end
 end

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -72,4 +72,8 @@ module TooltipsHelper
       particular clinic.
     TEXT
   end
+
+  def mandatory_ultrasound_help_text
+    'State of VA requires since 2012 people seeking abortions to complete ultrasounds!'
+  end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -82,6 +82,7 @@ class Patient
   field :special_circumstances, type: Array, default: []
   field :referred_by, type: String
   field :referred_to_clinic, type: Boolean
+  field :completed_ultrasound, type: Boolean
 
   # Status and pledge related fields
   field :appointment_date, type: Date

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -65,6 +65,12 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
           <div class="col-sm-6">
             <%= f.number_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', prepend: '$' %>
+            <div class="form-group">
+              <%= f.check_box :completed_ultrasound,
+                              label: 'Ultrasound completed?',
+                              label_class: 'tooltip-header-checkbox',
+                              data: { 'tooltip-text': mandatory_ultrasound_help_text } %>
+            </div>
             <div class="info-form-left form-group outstanding-balance-ctn hidden">
               <label class="control-label">Outstanding Balance</label>
               <div id="outstanding-balance"></div>

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -38,6 +38,10 @@
                               label: 'Referred to clinic',
                               label_class: 'tooltip-header-checkbox',
                               data: { 'tooltip-text': referred_to_clinic_help_text } %>
+              <%= f.check_box :completed_ultrasound,
+                              label: 'Ultrasound completed?',
+                              label_class: 'tooltip-header-checkbox',
+                              data: { 'tooltip-text': mandatory_ultrasound_help_text } %>
             </div>
           </div>
         <% end %>
@@ -65,12 +69,6 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
           <div class="col-sm-6">
             <%= f.number_field :procedure_cost, label: 'Abortion cost', autocomplete: 'off', prepend: '$' %>
-            <div class="form-group">
-              <%= f.check_box :completed_ultrasound,
-                              label: 'Ultrasound completed?',
-                              label_class: 'tooltip-header-checkbox',
-                              data: { 'tooltip-text': mandatory_ultrasound_help_text } %>
-            </div>
             <div class="info-form-left form-group outstanding-balance-ctn hidden">
               <label class="control-label">Outstanding Balance</label>
               <div id="outstanding-balance"></div>

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -122,6 +122,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       select @clinic.name, from: 'patient_clinic_id'
       check 'Resolved without assistance from DCAF'
       check 'Referred to clinic'
+      check 'Ultrasound completed?'
 
       fill_in 'Abortion cost', with: '300'
       fill_in 'Patient contribution', with: '200'
@@ -154,6 +155,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert_equal @clinic.id.to_s, find('#patient_clinic_id').value
         assert has_checked_field?('Resolved without assistance from DCAF')
         assert has_checked_field?('Referred to clinic')
+        assert has_checked_field?('Ultrasound completed?')
 
         assert has_field? 'Abortion cost', with: '300'
         assert has_field? 'Patient contribution', with: '200'
@@ -161,21 +163,6 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'DCAF pledge', with: '25'
         assert has_field? 'Baltimore Abortion Fund pledge', with: '25'
       end
-    end
-
-    it 'should toggle visibility of ultrasound checkbox based on state' do
-      click_link 'Patient Information'
-      select 'MD', from: 'patient_line'
-      click_link 'Abortion Information'
-      assert has_no_css? 'Ultrasound completed?'
-
-      click_link 'Patient Information'
-      select 'VA', from: 'patient_line'
-      click_link 'Abortion Information'
-      assert has_unchecked_field? 'Ultrasound completed?'
-
-      check 'Ultrasound completed?'
-      assert has_checked_field? 'Ultrasound completed?'
     end
   end
 

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -162,6 +162,21 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'Baltimore Abortion Fund pledge', with: '25'
       end
     end
+
+    it 'should toggle visibility of ultrasound checkbox based on state' do
+      click_link 'Patient Information'
+      select 'MD', from: 'patient_line'
+      click_link 'Abortion Information'
+      assert has_no_css? 'Ultrasound completed?'
+
+      click_link 'Patient Information'
+      select 'VA', from: 'patient_line'
+      click_link 'Abortion Information'
+      assert has_unchecked_field? 'Ultrasound completed?'
+
+      check 'Ultrasound completed?'
+      assert has_checked_field? 'Ultrasound completed?'
+    end
   end
 
   describe 'changing patient information' do


### PR DESCRIPTION
This pull request relates to #1497 
- New field `completed_ultrasound` added to patient, as well as the checkbox view and helper text
- updated existing system test case

**Changes in views**  
Now there is a new checkbox for the ultrasound info available. How to see it: 
- click on a patient
- click on Abortion Information tab  
![new_field](https://user-images.githubusercontent.com/23106612/47623426-a68d3880-db11-11e8-9465-0ef8543a40ab.png)


