### PR TITLE
Fixer upper on textable and clinic coordinate setting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.1)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-attack (5.4.1)
       rack (>= 1.0, < 3)
     rack-test (0.6.3)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -110,8 +110,8 @@ class PatientsController < ApplicationController
   ].freeze
 
   PATIENT_INFORMATION_PARAMS = [
-    :line, :age, :race_ethnicity, :language,
-    :voicemail_preference, :city, :state, :county, :zip, :other_contact, :other_phone,
+    :line, :age, :race_ethnicity, :language, :voicemail_preference, :textable,
+    :city, :state, :county, :zip, :other_contact, :other_phone,
     :other_contact_relationship, :employment_status, :income,
     :household_size_adults, :household_size_children, :insurance, :referred_by,
     special_circumstances: []

--- a/lib/tasks/update_clinic_coordinates.rake
+++ b/lib/tasks/update_clinic_coordinates.rake
@@ -4,6 +4,7 @@ namespace :clinics do
     raise 'Please set an env var GOOGLE_GEO_API_KEY before you do this' unless ENV['GOOGLE_GEO_API_KEY']
     Clinic.all.each do |clinic|
       clinic.update_coordinates
+      clinic.save
     end
   end
 end

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -182,6 +182,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       fill_in 'State', with: 'DC'
       fill_in 'County', with: 'Wash'
       select 'Voicemail OK', from: 'patient_voicemail_preference'
+      check 'Textable?'
       wait_for_ajax
 
       select 'Spanish', from: 'patient_language'
@@ -215,6 +216,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'State', with: 'DC'
         assert has_field? 'County', with: 'Wash'
         assert_equal 'yes', find('#patient_voicemail_preference').value
+        assert has_checked_field?('Textable?')
         assert_equal 'Spanish', find('#patient_language').value
 
         assert_equal 'Part-time', find('#patient_employment_status').value


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

A few small fixes in advance of deployment for corners that got cut during hacktoberfest sprinting.

This pull request makes the following changes:
* Adds a systemtest for textable
* Controller whitelists textable
* Actually save coordinates after getting them
