### PR TITLE
move api key to an initializer, simplify clinicfinder code

### DIFF
--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -54,10 +54,9 @@ class Clinic
   end
 
   def update_coordinates
-    return unless ENV['GOOGLE_GEO_API_KEY']
-
     geocoder = Geokit::Geocoders::GoogleGeocoder
-    geocoder.api_key = ENV['GOOGLE_GEO_API_KEY'] if ENV['GOOGLE_GEO_API_KEY']
+    return unless geocoder.try :api_key
+
     location = geocoder.geocode full_address
     coordinates = [location.lat, location.lng]
     self.coordinates = coordinates

--- a/app/services/clinic_finder/locator.rb
+++ b/app/services/clinic_finder/locator.rb
@@ -33,7 +33,7 @@ module ClinicFinder
 
       @clinic_structs = @clinics.map { |clinic| OpenStruct.new clinic.attributes }
       @patient_context = OpenStruct.new
-      @geocoder = set_geocoder
+      @geocoder = Geokit::Geocoders::GoogleGeocoder
     end
 
     # Return a set of the closest clinics as structs and their attributes,
@@ -67,13 +67,6 @@ module ClinicFinder
           (medicaid_only ? clinic.accepts_medicaid : true)
       end
       filtered_clinics
-    end
-
-    def set_geocoder
-      geocoder = Geokit::Geocoders::GoogleGeocoder
-      geocoder.api_key = ENV['GOOGLE_GEO_API_KEY'] if ENV['GOOGLE_GEO_API_KEY']
-
-      geocoder
     end
   end
 end

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,0 +1,100 @@
+# These defaults are used in Geokit::Mappable.distance_to and acts_as_mappable
+Geokit::default_units = :miles # others :kms, :nms, :meters
+Geokit::default_formula = :sphere
+
+# This is the timeout value in seconds to be used for calls to the geocoder web
+# services.  For no timeout at all, comment out the setting.  The timeout unit
+# is in seconds.
+Geokit::Geocoders::request_timeout = 3
+
+# This setting can be used if web service calls must be routed through a proxy.
+# These setting can be nil if not needed, otherwise, a valid URI must be
+# filled in at a minimum.  If the proxy requires authentication, the username
+# and password can be provided as well.
+# Geokit::Geocoders::proxy = 'https://user:password@host:port'
+
+# This is your yahoo application key for the Yahoo Geocoder.
+# See http://developer.yahoo.com/faq/index.html#appid
+# and http://developer.yahoo.com/maps/rest/V1/geocode.html
+# Geokit::Geocoders::YahooGeocoder.key = 'REPLACE_WITH_YOUR_YAHOO_KEY'
+# Geokit::Geocoders::YahooGeocoder.secret = 'REPLACE_WITH_YOUR_YAHOO_SECRET'
+
+# This is your Google Maps geocoder keys (all optional).
+# See http://www.google.com/apis/maps/signup.html
+# and http://www.google.com/apis/maps/documentation/#Geocoding_Examples
+# Geokit::Geocoders::GoogleGeocoder.client_id = ''
+# Geokit::Geocoders::GoogleGeocoder.cryptographic_key = ''
+# Geokit::Geocoders::GoogleGeocoder.channel = ''
+
+# You can also use the free API key instead of signed requests
+# See https://developers.google.com/maps/documentation/geocoding/#api_key
+Geokit::Geocoders::GoogleGeocoder.api_key = ENV['GOOGLE_GEO_API_KEY'] if ENV['GOOGLE_GEO_API_KEY']
+
+# You can also set multiple API KEYS for different domains that may be directed
+# to this same application.
+# The domain from which the current user is being directed will automatically
+# be updated for Geokit via
+# the GeocoderControl class, which gets it's begin filter mixed
+# into the ActionController.
+# You define these keys with a Hash as follows:
+# Geokit::Geocoders::google = {
+# 'rubyonrails.org' => 'RUBY_ON_RAILS_API_KEY',
+# ' ruby-docs.org' => 'RUBY_DOCS_API_KEY' }
+
+# This is your username and password for geocoder.us.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, the value should be set to username:password.
+# See http://geocoder.us
+# and http://geocoder.us/user/signup
+# Geokit::Geocoders::UsGeocoder.key = 'username:password'
+
+# This is your authorization key for geocoder.ca.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, set the value to the key obtained from
+# Geocoder.ca.
+# See http://geocoder.ca
+# and http://geocoder.ca/?register=1
+# Geokit::Geocoders::CaGeocoder.key = 'KEY'
+
+# This is your username key for geonames.
+# To use this service either free or premium, you must register a key.
+# See http://www.geonames.org
+# Geokit::Geocoders::GeonamesGeocoder.key = 'KEY'
+
+# Most other geocoders need either no setup or a key
+# Geokit::Geocoders::BingGeocoder.key = ''
+# Geokit::Geocoders::MapQuestGeocoder.key = ''
+# Geokit::Geocoders::YandexGeocoder.key = ''
+# Geokit::Geocoders::MapboxGeocoder.key = 'ACCESS_TOKEN'
+# Geokit::Geocoders::OpencageGeocoder.key = 'some_api_key'
+
+# Geonames has a free service and a premium service, each using a different URL
+# GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)
+# GeonamesGeocoder.premium = false will use http://api.geonames.org (free)
+# Geokit::Geocoders::GeonamesGeocoder.premium = false
+
+# require "external_geocoder.rb"
+# Please see the section "writing your own geocoders" for more information.
+# Geokit::Geocoders::external_key = 'REPLACE_WITH_YOUR_API_KEY'
+
+# This is the order in which the geocoders are called in a failover scenario
+# If you only want to use a single geocoder, put a single symbol in the array.
+# Valid symbols are :google, :yahoo, :us, and :ca.
+# Be aware that there are Terms of Use restrictions on how you can use the
+# various geocoders.  Make sure you read up on relevant Terms of Use for each
+# geocoder you are going to use.
+# Geokit::Geocoders::provider_order = [:google,:us]
+
+# The IP provider order. Valid symbols are :ip,:geo_plugin.
+# As before, make sure you read up on relevant Terms of Use for each.
+# Geokit::Geocoders::ip_provider_order = [:external,:geo_plugin,:ip]
+
+# Disable HTTPS globally.  This option can also be set on individual
+# geocoder classes.
+# Geokit::Geocoders::secure = false
+
+# Control verification of the server certificate for geocoders using HTTPS
+# Geokit::Geocoders::ssl_verify_mode = OpenSSL::SSL::VERIFY_(PEER/NONE)
+# Setting this to VERIFY_NONE may be needed on systems that don't have
+# a complete or up to date root certificate store. Only applies to
+# the Net::HTTP adapter.

--- a/test/models/clinic_test.rb
+++ b/test/models/clinic_test.rb
@@ -75,11 +75,10 @@ class ClinicTest < ActiveSupport::TestCase
 
   describe 'callbacks' do
     describe 'updating coordinates when address changes' do
-      before { @cached_api_key = ENV['GOOGLE_GEO_API_KEY'] }
-      after { ENV['GOOGLE_GEO_API_KEY'] = @cached_api_key }
+      before { Geokit::Geocoders::GoogleGeocoder.api_key = '123' }
+      after { Geokit::Geocoders::GoogleGeocoder.api_key = nil }
 
       it 'should update coordinates on address change' do
-        ENV['GOOGLE_GEO_API_KEY'] = '123'
         fake_geo = OpenStruct.new lat: 38.8976633, lng: 77.0365739
         Geokit::Geocoders::GoogleGeocoder.stub :geocode, fake_geo do
           @clinic.update city: 'Arlington'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

As pointed out by @dismantl in #1337 , the way we're handling google geo api keys is a little weird and not super railsy. We addressed the initial problem of not having the key anywhere in the codebase when we brought in the clinic finder code, but there's still some awkwardness and redundancy in how we're handling the key; this addresses most of it.

This pull request makes the following changes:
* set up geokit initializer
* move env var hits to the initializer

no view changes

It relates to the following issue #s: 
* Fixes #1337 
