### PR TITLE
Add procedure_cost to fulfillment model

### DIFF
--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -16,7 +16,6 @@ class Fulfillment
   field :check_number, type: String
   field :date_of_check, type: Date
   field :audited, type: Boolean
-  field :procedure_cost, type: Integer
 
   # Validations
   validates :created_by_id,

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -16,6 +16,7 @@ class Fulfillment
   field :check_number, type: String
   field :date_of_check, type: Date
   field :audited, type: Boolean
+  field :procedure_cost, type: Integer
 
   # Validations
   validates :created_by_id,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -179,7 +179,7 @@ Config.create config_key: :resources_url,
     patient.build_fulfillment(
       created_by_id: User.first.id,
       fulfilled: true,
-      procedure_cost: 4000,
+      fund_payout: 4000,
       procedure_date: 10.days.from_now
     ).save
   end
@@ -357,7 +357,7 @@ end
     fulfilled: true,
     procedure_date: 130.days.ago,
     gestation_at_procedure: "11",
-    procedure_cost: 555,
+    fund_payout: 555,
     check_number: 4563,
     date_of_check: 125.days.ago,
     updated_at: 125.days.ago,


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* adds procedure_cost to Fulfillment model so that rake db:seed does not error out

It relates to the following issue #s: 
* Fixes https://github.com/DCAFEngineering/dcaf_case_management/issues/1540