### PR TITLE
Translate the footer to Spanish

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,14 +2,16 @@
 	<hr class="hr_gradient">
 	<div class="row">
 		<div class="col-sm-12 text-center">
-			<small>Please send feedback or ideas for this case management app to <a href="mailto:DCAF.CMapp@gmail.com">DCAF.CMapp@gmail.com</a></small>
+			<small><%= t 'navigation.footer.please_send_feedback' %> <%= link_to 'DCAF.CMapp@gmail.com', mailto: 'DCAF.CMapp@gmail.com' %>.</small>
 		</div>
 	</div><!-- end row -->
 </div><!-- end container -->
 
 <div id="app_footer" class="container text-center margin-bottom-sm">
-  <a href="http://<%= FUND_DOMAIN %>/"><%= FUND_FULL %></a> -- <a href="tel:<%= FUND_PHONE %>"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> <%= FUND_PHONE %></a><br>
-	<a href="https://prochoice.org/">National Abortion Federation</a> -- <a href="tel:800-772-9100"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 800-772-9100</a><br>
+  <a href="http://<%= FUND_DOMAIN %>/"><%= FUND_FULL %></a> --<a href="tel:<%= FUND_PHONE %>"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> <%= FUND_PHONE %></a><br>
+
+  <%= link_to t('navigation.footer.national_abortion_federation'), 'https://prochoice.org' %> -- <a href="tel:800-772-9100"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 800-772-9100</a><br>
+
 	<% if fax_service %>
 		<%= link_to fax_service, fax_service, target: '_blank', rel: 'noopener nofollow' %>
 	<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,9 @@ en:
       sign_in: "Sign In"
       profile: "My Profile"
       sign_out: "Sign Out"
+    footer:
+      national_abortion_federation: "National Abortion Federation"
+      please_send_feedback: "Please send feedback or ideas to the programming team at"
   lines:
     new:
       welcome_to_daria: "Welcome to DARIA (%{fund} edition)!"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -16,6 +16,9 @@ es:
       sign_in: "Registrarse"
       profile: "Mi Perfil"
       sign_out: "Desconectar"
+    footer:
+      national_abortion_federation: "Federación Nacional de Abortos"
+      please_send_feedback: "Por favor envíe sus comentarios o ideas al equipo de programación en"
   lines:
     new:
       welcome_to_daria: "¡Bienvenido a DARIA (edición de %{fund})!"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds il8n keys for the footer like so:

![image](https://user-images.githubusercontent.com/3866868/49701181-04a04780-fbb7-11e8-864b-83631ac73641.png)

In that example, the DC Abortion Fund is set from an env var and so an in-place spanish translation would be a not-easy basket. but the stuff around it is hardset so let's il8n that.

This pull request makes the following changes:
* Translates the footer content

@DarthHater for review on the ruby, @montanezp for review on the spanish

It relates to the following issue #s: 
* Bumps #1382 
