### PR TITLE
squelch the accountants n+1 join and a duplicate fax query

### DIFF
--- a/app/controllers/accountants_controller.rb
+++ b/app/controllers/accountants_controller.rb
@@ -5,7 +5,7 @@ class AccountantsController < ApplicationController
   before_action :find_patient, only: [:edit]
 
   def index
-    patients = pledged_patients
+    patients = pledged_patients.includes(:clinic)
     @patients = paginate_results(patients)
   end
 

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -1,6 +1,7 @@
 # Functions primarily related to populating funds at the footer.
 module FooterHelper
   def fax_service
-    Config.find_or_create_by(config_key: 'fax_service').options.try :first
+    fax = Config.find_or_create_by(config_key: 'fax_service').options.try :first
+    link_to fax, fax, target: '_blank', rel: 'noopener nofollow' if fax
   end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,9 +10,7 @@
 <div id="app_footer" class="container text-center margin-bottom-sm">
   <a href="http://<%= FUND_DOMAIN %>/"><%= FUND_FULL %></a> -- <a href="tel:<%= FUND_PHONE %>"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> <%= FUND_PHONE %></a><br>
 	<a href="https://prochoice.org/">National Abortion Federation</a> -- <a href="tel:800-772-9100"><span class="glyphicon glyphicon-earphone" aria-hidden="true"></span> 800-772-9100</a><br>
-	<% if fax_service %>
-		<%= link_to fax_service, fax_service, target: '_blank', rel: 'noopener nofollow' %>
-	<% end %>
+	<%= fax_service %>
 </div><!-- end container -->
 
 <div class="container text-center margin-bottom-sm">

--- a/test/helpers/footer_helper_test.rb
+++ b/test/helpers/footer_helper_test.rb
@@ -5,7 +5,9 @@ class FooterHelperTest < ActionView::TestCase
 
   describe 'fax service' do
     it 'should return the config' do
-      assert_equal 'http://www.yolofax.com', fax_service
+      fax_link_html = fax_service
+      assert_match 'href="http://www.yolofax.com"', fax_link_html
+      assert_match '>http://www.yolofax.com</a>', fax_link_html
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* squelches an n+1 join in the accountants controller
* `fax_service` was making three queries, so we're getting ahead of it here by just setting the var in the helper, and moving the html generation out of the view into the helper

It relates to the following issue #s: 
* Fixes #1551
