### PR TITLE
add tooltip to budget bar

### DIFF
--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -24,6 +24,14 @@ module TooltipsHelper
     text.strip
   end
 
+  def budget_bar_help_text
+    text = <<-TEXT
+      The budget bar lists money tentatively set aside for a patient
+      (by entering a value in the #{FUND} pledge field) and money sent to a clinic for a patient (by checking the I sent the pledge checkbox) over a given week. It resets on Mondays.
+    TEXT
+    text.strip
+  end
+
   def your_completed_calls_help_text
     text = <<-TEXT
       This is a list of patients you have called within the last 8 hours.

--- a/app/views/dashboards/_overview.html.erb
+++ b/app/views/dashboards/_overview.html.erb
@@ -1,5 +1,6 @@
 <div id="overview" class="margin-bottom">
   <h1 class="border-bottom title">Week of <%= week_range %></h1>
+  <%= dashboard_table_content_tooltip_shell "budget_bar" %>
 
   <div id="budget_bar">
     <%= render_async budget_bar_path, nonce: content_security_policy_script_nonce, 'data-turbolinks-track': 'reload' %>

--- a/app/views/dashboards/_overview.html.erb
+++ b/app/views/dashboards/_overview.html.erb
@@ -1,6 +1,8 @@
 <div id="overview" class="margin-bottom">
-  <h1 class="border-bottom title">Week of <%= week_range %></h1>
-  <%= dashboard_table_content_tooltip_shell "budget_bar" %>
+  <h1 class="border-bottom title">
+    Week of <%= week_range %>
+    <%= dashboard_table_content_tooltip_shell "budget_bar" %>
+  </h1>
 
   <div id="budget_bar">
     <%= render_async budget_bar_path, nonce: content_security_policy_script_nonce, 'data-turbolinks-track': 'reload' %>

--- a/test/helpers/tooltips_helper_test.rb
+++ b/test/helpers/tooltips_helper_test.rb
@@ -30,7 +30,8 @@ class TooltipsHelperTest < ActionView::TestCase
     # Everything's okay alarms -- no need to test contents
     %i[your_call_list_help_text your_completed_calls_help_text
        urgent_cases_help_text record_new_external_pledge_help_text
-       resolved_without_fund_help_text referred_to_clinic_help_text].each do |func|
+       resolved_without_fund_help_text referred_to_clinic_help_text
+        budget_bar_help_text].each do |func|
       it "should return a string - #{func}" do
         assert_operator send(func).length, :>, 10
       end
@@ -44,6 +45,7 @@ class TooltipsHelperTest < ActionView::TestCase
 
     it 'should return a string - status_help_text' do
       assert_match /No Contact Made/, status_help_text(@patient)
+      assert_match /budget bar/, budget_bar_help_text
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

<img width="910" alt="screen shot 2018-12-15 at 12 23 55" src="https://user-images.githubusercontent.com/8662824/50045640-71f32300-0064-11e9-9004-b407280c95c6.png">

Adding the tooltip for budget bar, where should it go?

EDIT: moved tooltip.

This pull request makes the following changes:
* Add tooltip

It relates to the following issue #s: 
* Fixes #1532
