### PR TITLE
add coordinates refresh method to Clinic and port it into nightly_cleanup

### DIFF
--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -1,3 +1,5 @@
 module Exceptions
   class UnauthorizedError < StandardError; end
+
+  class NoGoogleGeoApiKeyError < StandardError; end
 end

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -65,4 +65,9 @@ class Clinic
   def address_changed?
     street_address_changed? || city_changed? || state_changed? || zip_changed?
   end
+
+  def self.update_all_coordinates
+    raise Exceptions::NoGoogleGeoApiKeyError.new unless Geokit::Geocoders::GoogleGeocoder.try(:api_key)
+    all.each { |clinic| clinic.update_coordinates && clinic.save }
+  end
 end

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -1,5 +1,6 @@
-desc 'Clean up call lists, unmark urgent patients, destroy old events'
+desc 'Run nightly cleanup methods on call lists, users, patients, etc.'
 task nightly_cleanup: :environment do
+  # Run these tasks nightly
   User.all.each { |user| user.clean_call_list_between_shifts }
   puts "#{Time.now} -- cleared all recently reached patients from call lists"
 
@@ -14,4 +15,10 @@ task nightly_cleanup: :environment do
 
   ArchivedPatient.archive_eligible_patients!
   puts "#{Time.now} -- archived patients for today"
+
+  if Time.zone.now.monday?
+    # Run these events weekly
+    Clinic.update_all_coordinates
+    puts "#{Time.now} -- refreshed coordinates on all clinics"
+  end
 end

--- a/lib/tasks/update_clinic_coordinates.rake
+++ b/lib/tasks/update_clinic_coordinates.rake
@@ -1,10 +1,6 @@
 namespace :clinics do
   desc "Mass-update all lat-lng coordinates for clinic addresses"
   task update_coordinates: :environment do
-    raise 'Please set an env var GOOGLE_GEO_API_KEY before you do this' unless ENV['GOOGLE_GEO_API_KEY']
-    Clinic.all.each do |clinic|
-      clinic.update_coordinates
-      clinic.save
-    end
+    Clinic.update_all_coordinates
   end
 end

--- a/test/models/clinic_test.rb
+++ b/test/models/clinic_test.rb
@@ -71,6 +71,29 @@ class ClinicTest < ActiveSupport::TestCase
                      '123 Fake Street, Washington, DC 20011'
       end
     end
+
+    describe 'updating all coordinates' do
+      it 'should raise if no geocoder api key is set' do
+        assert_raises Exceptions::NoGoogleGeoApiKeyError do
+          Clinic.update_all_coordinates
+        end
+      end
+
+      describe 'having a key' do
+        before { Geokit::Geocoders::GoogleGeocoder.api_key = '123' }
+        after { Geokit::Geocoders::GoogleGeocoder.api_key = nil }
+
+        it 'should call the update' do
+          fake_coordinates = [23, 23]
+          fake_geo = OpenStruct.new lat: fake_coordinates.first, lng: fake_coordinates.last
+          Geokit::Geocoders::GoogleGeocoder.stub :geocode, fake_geo do
+            Clinic.update_all_coordinates
+          end
+          @clinic.reload
+          assert_equal fake_coordinates, @clinic.coordinates
+        end
+      end
+    end
   end
 
   describe 'callbacks' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We have some ruby that updates coordinates; this pulls it out of a rake task and into an object method, and does some testing around it to confirm it's working properly. 

This pull request makes the following changes:
* pulls `update_all_coordinates` 
* adds it to `nightly_cleanup` task

no view changes

It relates to the following issue #s: 
* Fixes #1525 
