### PR TITLE
Bump ruby to 2.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     parallelism: 4
     working_directory: ~/abortioneering
     docker:
-      - image: circleci/ruby:2.5.3-node-browsers
+      - image: circleci/ruby:2.6.0-node-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -40,7 +40,7 @@ jobs:
   predeploy:
     working_directory: ~/abortioneering
     docker:
-      - image: circleci/ruby:2.5.3-node-browsers
+      - image: circleci/ruby:2.6.0-node-browsers
     steps:
       - checkout
       # - restore_cache:
@@ -59,7 +59,7 @@ jobs:
   deploy:
     working_directory: ~/abortioneering
     docker:
-      - image: circleci/ruby:2.5.3-node-browsers
+      - image: circleci/ruby:2.6.0-node-browsers
     steps:
       - checkout
       - setup_remote_docker:

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3-alpine
+FROM ruby:2.6.0-alpine
 MAINTAINER Colin Fleming <c3flemin@gmail.com>
 
 # configure environment variable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Bundler/OrderedGems:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.5.3
+  TargetRubyVersion: 2.6.0
   Exclude: 
     - db/**/*
     - bin/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.3'
+ruby '2.6.0'
 
 # Standard rails
 gem 'rails', '~> 5.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,7 +457,7 @@ DEPENDENCIES
   uglifier (~> 4.1)
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.6.0p0
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Does it build?

This pull request makes the following changes:
* bump 2.5.3 to 2.6.0 in a bunch of places

no views
no issues
