### PR TITLE
Filter patients which resolved it without funds

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -143,6 +143,7 @@ class Patient
     where(:fund_pledge.nin => [0, nil, ''])
       .where(:resolved_without_fund.in => [0, nil, ''])
       .where(:fund_pledged_at.gte => Time.zone.today.beginning_of_week(:monday))
+      .order_by(fund_pledged_at: :asc)
       .in(line: line)
   end
 

--- a/test/factories/patient.rb
+++ b/test/factories/patient.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :patient do
-    name { 'New Patient' }
+    name { Faker::Name.name }
     sequence(:primary_phone, 100) { |n| "127-#{n}-1111" }
     line { 'DC' }
     created_by { FactoryBot.create(:user) }

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -135,6 +135,9 @@ class PatientTest < ActiveSupport::TestCase
       @patient.update appointment_date: 2.days.from_now, fund_pledge: 300
       @patient2.update appointment_date: 4.days.from_now, fund_pledge: 500,
                        pledge_sent: true, clinic: create(:clinic)
+      @patient3 = create :patient, appointment_date: 3.days.from_now,
+                         fund_pledge: 400, resolved_without_fund: true
+
       shaped_patient = patient_to_hash @patient
       shaped_patient2 = patient_to_hash @patient2
 
@@ -143,6 +146,9 @@ class PatientTest < ActiveSupport::TestCase
                    Patient.pledged_status_summary(:DC)[:pledged][0][:name]
       assert_equal shaped_patient2[:name],
                    Patient.pledged_status_summary(:DC)[:sent][0][:name]
+
+      assert_equal 1, Patient.pledged_status_summary(:DC)[:pledged].count
+      assert_equal 1, Patient.pledged_status_summary(:DC)[:sent].count
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
It filters out patients which have resolved the case without funds.
I decided to simplify the method by extracting it to a scope, and updated the test so that such patients are not included in the summary. 
Also the factory has been updated, since the tests were testing patient names, but the name appeared to be hard-coded in the factory

It relates to the following issue #s: 
* Fixes #1534 
* Fixes #1533 
