### PR TITLE
Remove --no-rdoc in favor of --no-document (fixes builds)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
             - dcaf_case_management-{{ checksum "Gemfile.lock" }}
             - dcaf_case_management-{{ checksum ".circleci/config.yml" }}
       - run: bundle check || bundle install
-      - run: gem install --no-rdoc brakeman
-      - run: gem install --no-rdoc ruby_audit
-      - run: gem install --no-rdoc bundler-audit
+      - run: gem install --no-document brakeman
+      - run: gem install --no-document ruby_audit
+      - run: gem install --no-document bundler-audit
       - save_cache:
           key: dcaf_case_management-{{ checksum "Gemfile.lock" }}
           paths:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

```
#!/bin/bash -eo pipefail
gem install --no-rdoc brakeman
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
Exited with code 1
```
FROM: https://circleci.com/gh/DCAFEngineering/dcaf_case_management/4460?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

One of my PR's was failing as a result of `gem install` removing `--no-rdoc` as an option. I've replaced it with `--no-document` as mentioned here: https://github.com/bundler/heroku-buildpack-bundler2/pull/1#issuecomment-451654992

This pull request makes the following changes:
* Small change to `.circleci/config.yml`

