### PR TITLE
Make entries line up by being clearer about what nil is

### DIFF
--- a/app/helpers/change_log_helper.rb
+++ b/app/helpers/change_log_helper.rb
@@ -3,4 +3,9 @@ module ChangeLogHelper
   def safe_join_fields(fields)
     safe_join fields, tag('br')
   end
+
+  def change_or_nil(field)
+    return field if field.present?
+    '(empty)'
+  end
 end

--- a/app/helpers/change_log_helper.rb
+++ b/app/helpers/change_log_helper.rb
@@ -1,7 +1,21 @@
 # Functions for cleanly displaying rows in an audit log.
 module ChangeLogHelper
-  def safe_join_fields(fields)
-    Rails.logger.debug fields
-    safe_join fields, tag('br')
+  # Separate changelog fields with breaks
+  def safe_join_fields(shaped_changes)
+    safe_join changelog_entry_display(shaped_changes), tag('br')
+  end
+
+  private
+
+  # Map changelog entries to a html string
+  def changelog_entry_display(shaped_changes)
+    shaped_changes.map do |entry|
+      field = content_tag('strong') { "#{entry[0]}:" }.freeze
+      orig = entry[1][:original]
+      separator = '->'.freeze
+      mod = entry[1][:modified]
+
+      safe_join([field, orig, separator, mod], ' ').freeze
+    end
   end
 end

--- a/app/helpers/change_log_helper.rb
+++ b/app/helpers/change_log_helper.rb
@@ -4,9 +4,4 @@ module ChangeLogHelper
     Rails.logger.debug fields
     safe_join fields, tag('br')
   end
-
-  def change_or_nil(field)
-    return field if field.present?
-    '(empty)'
-  end
 end

--- a/app/helpers/change_log_helper.rb
+++ b/app/helpers/change_log_helper.rb
@@ -10,7 +10,7 @@ module ChangeLogHelper
   # Map changelog entries to a html string
   def changelog_entry_display(shaped_changes)
     shaped_changes.map do |entry|
-      field = content_tag('strong') { "#{entry[0]}:" }.freeze
+      field = content_tag('strong') { "#{entry[0].humanize}:" }.freeze
       orig = entry[1][:original]
       separator = '->'.freeze
       mod = entry[1][:modified]

--- a/app/helpers/change_log_helper.rb
+++ b/app/helpers/change_log_helper.rb
@@ -1,6 +1,7 @@
 # Functions for cleanly displaying rows in an audit log.
 module ChangeLogHelper
   def safe_join_fields(fields)
+    Rails.logger.debug fields
     safe_join fields, tag('br')
   end
 

--- a/app/models/audit_trail.rb
+++ b/app/models/audit_trail.rb
@@ -5,7 +5,7 @@ class AuditTrail
   include Mongoid::Userstamp
   mongoid_userstamp user_model: 'User'
 
-  IRRELEVANT_FIELDS = %w[user_ids updated_by_id pledge_sent_by_id last_edited_by_id].freeze
+  IRRELEVANT_FIELDS = %w[user_ids updated_by_id pledge_sent_by_id last_edited_by_id identifier].freeze
   DATE_FIELDS = %w[appointment_date initial_call_date pledge_generated_at pledge_sent_at fund_pledged_at].freeze
 
   # convenience methods for clean view display
@@ -39,7 +39,7 @@ class AuditTrail
     all_fields = orig.keys | mod.keys
     changeset = {}
     all_fields.each do |key|
-      changeset[key.humanize] = { original: format_fieldchange(key, orig[key]),
+      changeset[key] = { original: format_fieldchange(key, orig[key]),
                                   modified: format_fieldchange(key, modified[key]) }
     end
     changeset
@@ -48,8 +48,9 @@ class AuditTrail
   private
 
   def format_fieldchange(key, value)
-    return '(empty)' unless value.present?
-    shaped_value = if DATE_FIELDS.include? key
+    shaped_value = if value.blank?
+                     '(empty)'
+                   elsif DATE_FIELDS.include? key
                      value.display_date
                    elsif value.is_a? Array # special circumstances, for example
                      value.reject(&:blank?).join(', ')
@@ -58,7 +59,6 @@ class AuditTrail
                    else
                      value
                    end
-    return '(empty)' unless shaped_value.present?
     shaped_value 
   end
 end

--- a/app/models/audit_trail.rb
+++ b/app/models/audit_trail.rb
@@ -42,7 +42,6 @@ class AuditTrail
       changeset[key] = { original: format_fieldchange(key, orig[key]),
                                   modified: format_fieldchange(key, modified[key]) }
     end
-    puts(changeset)
     changeset
   end
 

--- a/app/models/audit_trail.rb
+++ b/app/models/audit_trail.rb
@@ -42,6 +42,7 @@ class AuditTrail
       changeset[key] = { original: format_fieldchange(key, orig[key]),
                                   modified: format_fieldchange(key, modified[key]) }
     end
+    puts(changeset)
     changeset
   end
 
@@ -55,7 +56,9 @@ class AuditTrail
                    elsif value.is_a? Array # special circumstances, for example
                      value.reject(&:blank?).join(', ')
                    elsif key == 'clinic_id'
-                     Clinic.find(value).name if value.present?
+                     Clinic.find(value).name
+                   elsif key == 'pledge_generated_by_id'
+                     ::User.find(value).name # Use the User model instead of the Userstamp namespace
                    else
                      value
                    end

--- a/app/models/audit_trail.rb
+++ b/app/models/audit_trail.rb
@@ -33,8 +33,6 @@ class AuditTrail
     modified.include?('urgent_flag') && modified['urgent_flag'] == true
   end
 
-  private
-
   def shaped_changes
     orig = original.reject { |field| AuditTrail::IRRELEVANT_FIELDS.include? field }
     mod = modified.reject { |field| AuditTrail::IRRELEVANT_FIELDS.include? field }
@@ -46,6 +44,8 @@ class AuditTrail
     end
     changeset
   end
+
+  private
 
   def format_fieldchange(key, value)
     return '(empty)' unless value.present?

--- a/app/models/audit_trail.rb
+++ b/app/models/audit_trail.rb
@@ -17,14 +17,6 @@ class AuditTrail
     modified.reject { |x| IRRELEVANT_FIELDS.include? x }.present?
   end
 
-  def changed_from
-    shaped_changes.values.map { |field| field[:original] }
-  end
-
-  def changed_to
-    shaped_changes.values.map { |field| field[:modified] }
-  end
-
   def changed_by_user
     created_by ? created_by.name : 'System'
   end

--- a/app/views/patients/_change_log.html.erb
+++ b/app/views/patients/_change_log.html.erb
@@ -5,9 +5,7 @@
       <thead>
         <tr>
           <th>Modified Date</th>
-          <th>Field</th>
-          <th>Changed From</th>
-          <th>Changed To</th>
+          <th>Change (from -> to)</th>
           <th>CM</th>
         </tr>
       </thead>

--- a/app/views/patients/_change_log_entry.html.erb
+++ b/app/views/patients/_change_log_entry.html.erb
@@ -1,9 +1,7 @@
 <% if revision.has_changed_fields? %>
   <tr>
     <td><%= revision.date_of_change %></td>
-    <td><%= safe_join_fields revision.shaped_changes.keys %></td>
-    <td><%= safe_join_fields revision.changed_from %></td>
-    <td><%= safe_join_fields revision.changed_to %></td>
+    <td><%= safe_join_fields revision.shaped_changes %></td>
     <td><%= revision.changed_by_user %></td>
   </tr>
 <% end %>

--- a/app/views/patients/_change_log_entry.html.erb
+++ b/app/views/patients/_change_log_entry.html.erb
@@ -1,9 +1,11 @@
 <% if revision.changed_fields.present? %>
   <tr>
     <td><%= revision.date_of_change %></td>
-    <td><%= safe_join_fields revision.changed_fields %></td>
-    <td><%= safe_join_fields revision.changed_from.map { |str| change_or_nil(str) } %></td>
-    <td><%= safe_join_fields revision.changed_to.map { |str| change_or_nil(str) } %></td>
+    <% revision.shaped_changes.each_pair do |key, value| %>
+      <td><%= key %></td>
+      <td><%= value[:original] %></td>
+      <td><%= value[:modified] %></td>
+    <% end %>
     <td><%= revision.changed_by_user %></td>
   </tr>
 <% end %>

--- a/app/views/patients/_change_log_entry.html.erb
+++ b/app/views/patients/_change_log_entry.html.erb
@@ -1,11 +1,9 @@
-<% if revision.changed_fields.present? %>
+<% if revision.has_changed_fields? %>
   <tr>
     <td><%= revision.date_of_change %></td>
-    <% revision.shaped_changes.each_pair do |key, value| %>
-      <td><%= key %></td>
-      <td><%= value[:original] %></td>
-      <td><%= value[:modified] %></td>
-    <% end %>
+    <td><%= safe_join_fields revision.shaped_changes.keys %></td>
+    <td><%= safe_join_fields revision.changed_from %></td>
+    <td><%= safe_join_fields revision.changed_to %></td>
     <td><%= revision.changed_by_user %></td>
   </tr>
 <% end %>

--- a/app/views/patients/_change_log_entry.html.erb
+++ b/app/views/patients/_change_log_entry.html.erb
@@ -1,9 +1,9 @@
 <% if revision.changed_fields.present? %>
   <tr>
     <td><%= revision.date_of_change %></td>
-    <td><%= safe_join_fields(revision.changed_fields) %></td>
-    <td><%= safe_join_fields(revision.changed_from) %></td>
-    <td><%= safe_join_fields(revision.changed_to) %></td>
+    <td><%= safe_join_fields revision.changed_fields %></td>
+    <td><%= safe_join_fields revision.changed_from.map(&:change_or_nil) %></td>
+    <td><%= safe_join_fields revision.changed_to.map(&:change_or_nil) %></td>
     <td><%= revision.changed_by_user %></td>
   </tr>
 <% end %>

--- a/app/views/patients/_change_log_entry.html.erb
+++ b/app/views/patients/_change_log_entry.html.erb
@@ -2,8 +2,8 @@
   <tr>
     <td><%= revision.date_of_change %></td>
     <td><%= safe_join_fields revision.changed_fields %></td>
-    <td><%= safe_join_fields revision.changed_from.map(&:change_or_nil) %></td>
-    <td><%= safe_join_fields revision.changed_to.map(&:change_or_nil) %></td>
+    <td><%= safe_join_fields revision.changed_from.map { |str| change_or_nil(str) } %></td>
+    <td><%= safe_join_fields revision.changed_to.map { |str| change_or_nil(str) } %></td>
     <td><%= revision.changed_by_user %></td>
   </tr>
 <% end %>

--- a/test/helpers/change_log_helper_test.rb
+++ b/test/helpers/change_log_helper_test.rb
@@ -7,15 +7,4 @@ class ChangeLogHelperTest < ActionView::TestCase
                    'yolo<br />goat'
     end
   end
-
-  describe 'change_or_nil' do
-    it 'should return field if field' do
-      assert_equal 'yolo', change_or_nil('yolo')
-    end
-
-    it 'should return empty if nothing' do
-      assert_equal 'empty', change_or_nil('')
-      assert_equal 'empty', change_or_nil(nil)
-    end
-  end
 end

--- a/test/helpers/change_log_helper_test.rb
+++ b/test/helpers/change_log_helper_test.rb
@@ -1,10 +1,17 @@
 require 'test_helper'
 
 class ChangeLogHelperTest < ActionView::TestCase
-  describe 'safe join convenience method' do
+  describe 'safe_join_fields convenience method' do
+    before do
+      pt = create :patient, name: 'Old name'
+      pt.update name: 'New name', city: 'Canada'
+      @changeset = pt.history_tracks.last
+    end
+
     it 'should work' do
-      assert_equal safe_join_fields(%w(yolo goat)),
-                   'yolo<br />goat'
+      assert_equal safe_join_fields(@changeset.shaped_changes),
+                   '<strong>Name:</strong> Old name -&gt; New name<br />' \
+                   '<strong>City:</strong> (empty) -&gt; Canada'
     end
   end
 end

--- a/test/helpers/change_log_helper_test.rb
+++ b/test/helpers/change_log_helper_test.rb
@@ -7,4 +7,15 @@ class ChangeLogHelperTest < ActionView::TestCase
                    'yolo<br />goat'
     end
   end
+
+  describe 'change_or_nil' do
+    it 'should return field if field' do
+      assert_equal 'yolo', change_or_nil('yolo')
+    end
+
+    it 'should return empty if nothing' do
+      assert_equal 'empty', change_or_nil('')
+      assert_equal 'empty', change_or_nil(nil)
+    end
+  end
 end

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -35,34 +35,6 @@ class AuditTrailTest < ActiveSupport::TestCase
                    @track.date_of_change
     end
 
-
-    it 'should indicate whether a revision has relevant changed fields' do
-      assert @track.has_changed_fields?
-
-      # A revision with only changes to fields we don't care about should be false
-      @patient.update last_edited_by: create(:user)
-      last_track = @patient.reload.history_tracks.last
-      refute last_track.has_changed_fields?
-    end
-
-    it 'should conveniently render what they were before' do
-      assert_equal @track.changed_from,
-                   ["Susie Everyteen",
-                     "1112223333",
-                     (Time.zone.now + 5.days).display_date,
-                     (Time.zone.now + 3.days).display_date,
-                     "D2-3333"]
-    end
-
-    it 'should conveniently render what they are now' do
-      assert_equal @track.changed_to,
-                  ["Yolo",
-                    "1234569999",
-                    (Time.zone.now + 10.days).display_date,
-                    (Time.zone.now + 4.days).display_date,
-                    "D6-9999"]
-    end
-
     it 'should default to System if it cannot find a user' do
       assert_equal @track.changed_by_user, 'System'
     end

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -23,10 +23,13 @@ class AuditTrailTest < ActiveSupport::TestCase
 
   describe 'methods' do
     before do
+      @clinic = create :clinic
       @patient.update_attributes name: 'Yolo',
                                  primary_phone: '123-456-9999',
                                  appointment_date: Time.zone.now + 10.days,
-                                 initial_call_date: Time.zone.now + 4.days
+                                 city: 'Canada',
+                                 clinic: @clinic,
+                                 special_circumstances: ['A', '', 'C', '']
       @track = @patient.history_tracks.second
     end
 
@@ -39,6 +42,16 @@ class AuditTrailTest < ActiveSupport::TestCase
       assert_equal @track.changed_by_user, 'System'
     end
 
+    it 'should return shaped changes as a single dict' do
+      assert_equal @track.shaped_changes,
+                   { 'name' => { original: 'Susie Everyteen', modified: 'Yolo' },
+                     'primary_phone' => { original: '1112223333', modified: '1234569999' },
+                     'appointment_date' =>{ original: (Time.zone.now + 5.days).display_date, modified: (Time.zone.now + 10.days).display_date },
+                     'special_circumstances' =>{ original: '(empty)', modified: 'A, C' },
+                     'city' =>{ original: '(empty)', modified: 'Canada' },
+                     'clinic_id' =>{ original: '(empty)', modified: @clinic.name },
+                   }
+    end
   end
 
   describe 'marked urgent' do

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -30,6 +30,15 @@ class AuditTrailTest < ActiveSupport::TestCase
       @track = @patient.history_tracks.second
     end
 
+    # date_of_change
+    # has_changed_fields
+    # shaped_changes
+    # changed_from
+    # changed_to
+    # format_fieldchange
+    # changed_by_user
+    # marked_urgent?
+
     it 'should conveniently render the date' do
       assert_equal Time.zone.now.display_date,
                    @track.date_of_change

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -30,24 +30,19 @@ class AuditTrailTest < ActiveSupport::TestCase
       @track = @patient.history_tracks.second
     end
 
-    # date_of_change
-    # has_changed_fields
-    # shaped_changes
-    # changed_from
-    # changed_to
-    # format_fieldchange
-    # changed_by_user
-    # marked_urgent?
-
     it 'should conveniently render the date' do
       assert_equal Time.zone.now.display_date,
                    @track.date_of_change
     end
 
 
-    it 'should conveniently render changed fields' do
-      assert_equal @track.changed_fields,
-                   ["Name", "Primary phone", "Appointment date", "Initial call date", "Identifier"]
+    it 'should indicate whether a revision has relevant changed fields' do
+      assert @track.has_changed_fields?
+
+      # A revision with only changes to fields we don't care about should be false
+      @patient.update last_edited_by: create(:user)
+      last_track = @patient.reload.history_tracks.last
+      refute last_track.has_changed_fields?
     end
 
     it 'should conveniently render what they were before' do

--- a/test/system/change_log_test.rb
+++ b/test/system/change_log_test.rb
@@ -24,8 +24,7 @@ class ChangeLogTest < ApplicationSystemTestCase
 
       within :css, '#change_log' do
         assert has_text? Time.zone.now.display_date
-        assert has_text? 'City'
-        assert has_text? 'Canada'
+        assert has_text? 'City: (empty) -> Canada'
         assert has_text? @user.name
       end
     end

--- a/test/system/change_log_test.rb
+++ b/test/system/change_log_test.rb
@@ -24,7 +24,7 @@ class ChangeLogTest < ApplicationSystemTestCase
 
       within :css, '#change_log' do
         assert has_text? Time.zone.now.display_date
-        assert has_text? 'City: (empty) -> Canada'
+        assert has_text? 'City: Washington -> Canada'
         assert has_text? @user.name
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

a quick NITE PR -- I think this should resolve the problem described in #1338 . Screenshots in the morning. I'm getting old.

This pull request makes the following changes:
* `blank` changelog entries now show up as `(empty)`
* remix the view so breaks between individual field changes are always clear
* tests for same

![image](https://user-images.githubusercontent.com/3866868/52172347-8cc84680-273b-11e9-9642-366001e7169e.png)


It relates to the following issue #s: 
* Fixes #1338 
