### PR TITLE
Translate string constants in dashboards

### DIFF
--- a/app/views/dashboards/_activity_log.html.erb
+++ b/app/views/dashboards/_activity_log.html.erb
@@ -1,5 +1,7 @@
 <div id='activity_log' class='margin-bottom'>
-  <h1 class='border-bottom title'><%= current_line %> Call Line Activity Log</h1>
+  <h1 class='border-bottom title'>
+    <%= t 'dashboard.activity_log.label', current_line: current_line %>
+  </h1>
 
   <div id="activity_log_content">
     <%= render_async events_path, nonce: content_security_policy_script_nonce, 'data-turbolinks-track': 'reload' %>

--- a/app/views/dashboards/_overview.html.erb
+++ b/app/views/dashboards/_overview.html.erb
@@ -1,6 +1,6 @@
 <div id="overview" class="margin-bottom">
   <h1 class="border-bottom title">
-    Week of <%= week_range %>
+    <%= t 'dashboard.overview.week_of', week_range: week_range %>
     <%= dashboard_table_content_tooltip_shell "budget_bar" %>
   </h1>
 

--- a/app/views/dashboards/_search_form.html.erb
+++ b/app/views/dashboards/_search_form.html.erb
@@ -1,9 +1,11 @@
 <div id="search_form" class="margin-bottom">
-  <h1 class="border-bottom title">Build your call list</h1>
+  <h1 class="border-bottom title">
+    <%= t 'dashboard.search.header' %>
+  </h1>
 
   <%= bootstrap_form_tag url: '/search', remote: true, layout: :inline do |p| %>
-    <%= p.text_field :search, placeholder: 'Name (Susan Smith) or Phone (555-555-5555)', hide_label: true, class: 'search_form_input' %>
-    <%= p.button :class => "btn btn-primary", title: "Search" do %>
+    <%= p.text_field :search, placeholder: t('dashboard.search.input_placeholder'), hide_label: true, class: 'search_form_input' %>
+    <%= p.button class: 'btn btn-primary', title: t('common.search') do %>
       <i class="glyphicon glyphicon-search"></i>
     <% end %>
   <% end %>

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -12,12 +12,12 @@
         <% if local_assigns[:sortable] %>
           <th><!-- handle --></th>
         <% end %>
-        <th>Phone</th>
-        <th>Name</th>
-        <th>Weeks Along</th>
-        <%= th_autosortable 'Status', 'string', local_assigns %>
-        <%= th_autosortable 'Appt date', 'string', local_assigns %>
-        <th>Notes</th>
+        <th><%= t 'common.phone' %></th>
+        <th><%= t 'common.name' %></th>
+        <th><%= t 'common.weeks_along_short' %></th>
+        <%= th_autosortable t('common.status'), 'string', local_assigns %>
+        <%= th_autosortable t('common.appointment_date_short'), 'string', local_assigns %>
+        <th><%= t 'common.notes' %></th>
         <th></th>
         <th></th>
       </tr>
@@ -38,18 +38,28 @@
             <td class="blank-td"></td>
           <% else %>
             <% if current_user.patient_ids.include?(patient.id) %>
-              <td><%= link_to remove_from_call_list_glyphicon, remove_patient_path(patient), method: :patch, data: { confirm: "Are you sure you want to remove #{patient.name} from your call list?" },  remote: true %></td>
+              <td><%= link_to remove_from_call_list_glyphicon, remove_patient_path(patient), method: :patch, data: { confirm: t('dashboard.table_content.remove_from_call_list_confirm', name: patient.name) },  remote: true %></td>
             <% else %>
-              <td><%= link_to "Add", add_patient_path(patient), method: :patch, remote: true %></td>
+              <td><%= link_to t('common.add'), add_patient_path(patient), method: :patch, remote: true %></td>
             <% end %>
           <% end %>
-          <td><%= link_to call_glyphicon, new_patient_call_path(patient), class:"call_button call-#{patient.primary_phone_display}", remote: true %> </td>
-
+          <td>
+            <%= link_to call_glyphicon,
+                        new_patient_call_path(patient),
+                        class: "call_button call-#{patient.primary_phone_display}",
+                        remote: true %>
+          </td>
         </tr>
       <% end %>
     </tbody>
   </table>
+
   <% if table_type == 'call_list' && current_user.patients.count.nonzero? %>
-    <%= link_to "Clear your call list", clear_current_user_call_list_path, class: "pull-right text-danger", data: { confirm: "Are you sure you want to clear your current call list? This will also clear completed calls." }, method: :patch, remote: true %>
+    <%= link_to t('dashboard.table_content.clear_call_list'),
+                clear_current_user_call_list_path,
+                class: "pull-right text-danger",
+                data: { confirm: t('dashboard.table_content.clear_call_list_confirm') },
+                method: :patch,
+                remote: true %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,19 @@ en:
       profile: My Profile
       sign_in: Sign In
       sign_out: Sign Out
+  dashboard:
+    activity_log:
+      label: "%{current_line} Line Activity Log"
+    overview:
+      week_of: Week of %{week_range}
+    search:
+      header: Build your call list
+      input_placeholder: Name (Susan Smith) or Phone (555-555-5555)
+      button_text: Search
+    table_content:
+      remove_from_call_list_confirm: "Are you sure you want to remove %{name} from your call list?"
+      clear_call_list: Clear your call list
+      clear_call_list_confirm: Are you sure you want to clear your current call list? This will also clear completed calls.
   patient:
     dashboard:
       approx_gestation: 'Approx gestation at appt: %{gest}'
@@ -83,3 +96,11 @@ en:
         pledge_sent: Pledge Sent
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
+  common:
+    phone: Phone
+    name: Name
+    weeks_along_short: Weeks along
+    status: Status
+    appointment_date_short: Appt date
+    notes: Notes
+    add: Add

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
     name: Name
     notes: Notes
     phone: Phone
+    search: Search
     status: Status
     weeks_along_short: Weeks along
   configs:
@@ -21,7 +22,6 @@ en:
     overview:
       week_of: Week of %{week_range}
     search:
-      button_text: Search
       header: Build your call list
       input_placeholder: Name (Susan Smith) or Phone (555-555-5555)
     table_content:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,13 @@
 ---
 en:
+  common:
+    add: Add
+    appointment_date_short: Appt date
+    name: Name
+    notes: Notes
+    phone: Phone
+    status: Status
+    weeks_along_short: Weeks along
   configs:
     config:
       current_options: 'Current options are:'
@@ -7,6 +15,19 @@ en:
     index:
       sub_text: Use this to set custom insurance, language, external pledge options, and help text for pledge limits.
       title: Configs
+  dashboard:
+    activity_log:
+      label: "%{current_line} Line Activity Log"
+    overview:
+      week_of: Week of %{week_range}
+    search:
+      button_text: Search
+      header: Build your call list
+      input_placeholder: Name (Susan Smith) or Phone (555-555-5555)
+    table_content:
+      clear_call_list: Clear your call list
+      clear_call_list_confirm: Are you sure you want to clear your current call list? This will also clear completed calls.
+      remove_from_call_list_confirm: Are you sure you want to remove %{name} from your call list?
   devise:
     omniauth_callbacks:
       success: Successfully logged in with %{kind}
@@ -42,19 +63,6 @@ en:
       profile: My Profile
       sign_in: Sign In
       sign_out: Sign Out
-  dashboard:
-    activity_log:
-      label: "%{current_line} Line Activity Log"
-    overview:
-      week_of: Week of %{week_range}
-    search:
-      header: Build your call list
-      input_placeholder: Name (Susan Smith) or Phone (555-555-5555)
-      button_text: Search
-    table_content:
-      remove_from_call_list_confirm: "Are you sure you want to remove %{name} from your call list?"
-      clear_call_list: Clear your call list
-      clear_call_list_confirm: Are you sure you want to clear your current call list? This will also clear completed calls.
   patient:
     dashboard:
       approx_gestation: 'Approx gestation at appt: %{gest}'
@@ -96,11 +104,3 @@ en:
         pledge_sent: Pledge Sent
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
-  common:
-    phone: Phone
-    name: Name
-    weeks_along_short: Weeks along
-    status: Status
-    appointment_date_short: Appt date
-    notes: Notes
-    add: Add

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,14 @@
 ---
 es:
+  common:
+    add: Añadir
+    appointment_date_short: Día de la cita
+    name: Nombre
+    notes: Notas
+    phone: Teléfono
+    search: Buscar
+    status: Estado
+    weeks_along_short: Semanas a lo largo
   configs:
     config:
       current_options: 'Las opciones actuales son:'
@@ -7,6 +16,18 @@ es:
     index:
       sub_text: Use esto para configurar el seguro medico, el idioma, las opciones de compromiso externo y los límites de compromiso
       title: Configuraciones
+  dashboard:
+    activity_log:
+      label: Actividad de línea de llamada %{current_line}
+    overview:
+      week_of: Semana de %{week_range}
+    search:
+      header: Construye tu lista de llamadas
+      input_placeholder: Nombre (Susan Smith) o teléfono (555-555-5555)
+    table_content:
+      clear_call_list: Borrar su lista de llamadas
+      clear_call_list_confirm: "¿Está seguro de que desea borrar su lista de llamadas actual? Esto también borrará las llamadas completadas."
+      remove_from_call_list_confirm: "¿Estás seguro de que deseas eliminar a %{name} de tu lista de llamadas?"
   devise:
     omniauth_callbacks:
       success: Iniciar sesión con éxito con %{kind}
@@ -42,18 +63,6 @@ es:
       profile: Mi Perfil
       sign_in: Registrarse
       sign_out: Desconectar
-  dashboard:
-    activity_log:
-      label: Actividad de línea de llamada %{current_line}
-    overview:
-      week_of: Semana de %{week_range}
-    search:
-      header: Construye tu lista de llamadas
-      input_placeholder: Nombre (Susan Smith) o teléfono (555-555-5555)
-    table_content:
-      remove_from_call_list_confirm: "¿Estás seguro de que deseas eliminar a %{name} de tu lista de llamadas?"
-      clear_call_list: Borrar su lista de llamadas
-      clear_call_list_confirm: ¿Está seguro de que desea borrar su lista de llamadas actual? Esto también borrará las llamadas completadas.
   patient:
     dashboard:
       approx_gestation: 'Aprox la gestación en la cita: %{gest}'
@@ -95,12 +104,3 @@ es:
         pledge_sent: Promesa Enviada
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
-  common:
-    phone: Teléfono
-    name: Nombre
-    weeks_along_short: Semanas a lo largo
-    status: Estado
-    appointment_date_short: Día de la cita
-    notes: Notas
-    add: Añadir
-    search: Buscar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -42,6 +42,18 @@ es:
       profile: Mi Perfil
       sign_in: Registrarse
       sign_out: Desconectar
+  dashboard:
+    activity_log:
+      label: Actividad de línea de llamada %{current_line}
+    overview:
+      week_of: Semana de %{week_range}
+    search:
+      header: Construye tu lista de llamadas
+      input_placeholder: Nombre (Susan Smith) o teléfono (555-555-5555)
+    table_content:
+      remove_from_call_list_confirm: "¿Estás seguro de que deseas eliminar a %{name} de tu lista de llamadas?"
+      clear_call_list: Borrar su lista de llamadas
+      clear_call_list_confirm: ¿Está seguro de que desea borrar su lista de llamadas actual? Esto también borrará las llamadas completadas.
   patient:
     dashboard:
       approx_gestation: 'Aprox la gestación en la cita: %{gest}'
@@ -83,3 +95,12 @@ es:
         pledge_sent: Promesa Enviada
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
+  common:
+    phone: Teléfono
+    name: Nombre
+    weeks_along_short: Semanas a lo largo
+    status: Estado
+    appointment_date_short: Día de la cita
+    notes: Notas
+    add: Añadir
+    search: Buscar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,7 +7,7 @@ es:
     notes: Notas
     phone: Teléfono
     search: Buscar
-    status: Estado
+    status: Estatus
     weeks_along_short: Semanas a lo largo
   configs:
     config:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Tackles some of the translation on dashboards, specifically strings contained in partials. Strings that are inferred or produced from helper methods are tk.

It felt weird to pull single simple words into their own nested namespaces, so this PR also stands up the top level namespace `common`, which I stuck a bunch of one word things into like Add, Phone, etc.

This doesn't touch the slightly more complex stuff (in helpers, for example). But I am committing to doing that here.

This pull request makes the following changes:
* translate strings defined in the dashboard partials
* a little bit of view cleanup while I'm rooting around in there
![image](https://user-images.githubusercontent.com/3866868/52179455-df8c1780-27a8-11e9-9c28-0815c96bce82.png)

cc @montanezp can you pop in here and review the translations?

It relates to the following issue #s: 
* Bumps #1575 

ps s/o @lomky for the good directions and the reminder to run `il8n-tasks health`!