### PR TITLE
Translate Spanish event strings (and move them out of the model) 

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -4,24 +4,28 @@ module EventsHelper
     safe_join [
       tag(:span,
           class: ['glyphicon', "glyphicon-#{event.glyphicon}", 'event-item']),
-      log_entry(event)
+      entry_text(event)
     ], ' '
   end
 
-  def log_entry(event)
-    time = event.created_at.display_time.to_s
-    str = "-- #{event.cm_name} #{event.event_text}"
-    pt_link = link_to(
-      "#{event.patient_name}.",
-      edit_patient_path(event.patient_id)
-    )
-    add_link = link_to(
-      '(Add to call list)',
-      add_patient_path(event.patient_id),
-      method: :patch,
-      remote: true
-    )
+  private
 
-    safe_join [time, str, pt_link, add_link], ' '
+  def entry_text(event)
+    time = event.created_at.display_time.to_s
+    cm = event.cm_name
+    event_text = event_string(event)
+    pt_link = link_to event.patient_name,
+                      edit_patient_path(event.patient_id)
+    call_list_link = link_to "(#{t('events.add_to_call_list')})",
+                             add_patient_path(event.patient_id),
+                             method: :patch,
+                             remote: true
+
+    safe_join [time, '--', cm, event_text, pt_link, call_list_link], ' '
+  end
+
+  def event_string(event)
+    return t('events.pledged', pledge_amount: event.pledge_amount) if event.event_type == 'Pledged'
+    t("events.#{event.underscored_type}")
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,17 +42,9 @@ class Event
     end
   end
 
-  def event_text
-    case event_type
-    when 'Pledged'
-      "sent a $#{pledge_amount} pledge for"
-    when 'Left voicemail'
-      'left a voicemail for'
-    when "Couldn't reach patient"
-      "called, but couldn't reach"
-    when 'Reached patient'
-      'reached'
-    end
+  # remove spaces and punctuation. A sin method because we did this as strs not syms.
+  def underscored_type
+    event_type.gsub(' ', '_').gsub(/\W/, '').downcase
   end
 
   # Clean events older than three weeks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,3 +114,10 @@ en:
         pledge_sent: Pledge Sent
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
+  events:
+    reached_patient: reached
+    couldnt_reach_patient: called, but couldn't reach
+    left_voicemail: left a voicemail for
+    pledged: sent a $%{pledge_amount} pledge for
+    unknown_action: interacted with
+    add_to_call_list: Add to call list

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,13 @@ en:
         password: Password
         password_signin: 'Or, sign in with a password:'
         password_submit: Sign in with password
+  events:
+    add_to_call_list: Add to call list
+    couldnt_reach_patient: called, but couldn't reach
+    left_voicemail: left a voicemail for
+    pledged: sent a $%{pledge_amount} pledge for
+    reached_patient: reached
+    unknown_action: interacted with
   lines:
     new:
       start: Get started
@@ -114,10 +121,3 @@ en:
         pledge_sent: Pledge Sent
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
-  events:
-    reached_patient: reached
-    couldnt_reach_patient: called, but couldn't reach
-    left_voicemail: left a voicemail for
-    pledged: sent a $%{pledge_amount} pledge for
-    unknown_action: interacted with
-    add_to_call_list: Add to call list

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -114,3 +114,10 @@ es:
         pledge_sent: Promesa Enviada
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
+  events:
+    reached_patient: alcanzado
+    couldnt_reach_patient: llamó, pero no pudo llegar
+    left_voicemail: dejó un mensaje de voz para
+    pledged: envió una promesa de $%{pledge_amount} para
+    unknown_action: interactuado con
+    add_to_call_list: Añadir a la lista de llamadas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -48,6 +48,13 @@ es:
         password: Contraseña
         password_signin: 'O, inicie sesión con una contraseña:'
         password_submit: Inicia sesión con contraseña
+  events:
+    add_to_call_list: Añadir a la lista de llamadas
+    couldnt_reach_patient: llamó, pero no pudo llegar
+    left_voicemail: dejó un mensaje de voz para
+    pledged: envió una promesa de $%{pledge_amount} para
+    reached_patient: alcanzado
+    unknown_action: interactuado con
   lines:
     new:
       start: Empezar
@@ -114,10 +121,3 @@ es:
         pledge_sent: Promesa Enviada
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
-  events:
-    reached_patient: alcanzado
-    couldnt_reach_patient: llamó, pero no pudo llegar
-    left_voicemail: dejó un mensaje de voz para
-    pledged: envió una promesa de $%{pledge_amount} para
-    unknown_action: interactuado con
-    add_to_call_list: Añadir a la lista de llamadas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -50,11 +50,11 @@ es:
         password_submit: Inicia sesión con contraseña
   events:
     add_to_call_list: Añadir a la lista de llamadas
-    couldnt_reach_patient: llamó, pero no pudo llegar
-    left_voicemail: dejó un mensaje de voz para
-    pledged: envió una promesa de $%{pledge_amount} para
-    reached_patient: alcanzado
-    unknown_action: interactuado con
+    couldnt_reach_patient: llamó, paciente no contestó
+    left_voicemail: dejó un mensaje de voz
+    pledged: envió una promesa de $%{pledge_amount}
+    reached_patient: alcanzó el paciente
+    unknown_action: habló o interactuó con
   lines:
     new:
       start: Empezar

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class EventsHelperTest< ActionView::TestCase
+  describe 'display_event' do
+    it 'should render an event line - pledged' do
+      event = create :event, event_type: 'Pledged', pledge_amount: 100
+      expected = "<span class=\"glyphicon glyphicon-thumbs-up event-item\" /> " \
+                 "#{event.created_at.display_time} -- #{event.cm_name} sent a " \
+                 "$100 pledge for <a href=\"/patients/#{event.patient_id}/edit\">" \
+                 "#{event.patient_name}</a> <a data-remote=\"true\" rel=\"nofollow\" " \
+                 "data-method=\"patch\" href=\"/call_lists/add_patient/#{event.patient_id}\">" \
+                 "(Add to call list)</a>"
+
+      assert_equal expected, display_event(event)
+    end
+  end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -38,22 +38,28 @@ class EventTest < ActiveSupport::TestCase
   end
 
   describe 'rendering methods' do
-    it 'should render the correct glyphicon' do
-      @event.event_type = "Couldn't reach patient"
-      assert_equal 'earphone', @event.glyphicon
+    describe 'glyphicon' do
+      it 'should render the correct glyphicon' do
+        @event.event_type = "Couldn't reach patient"
+        assert_equal 'earphone', @event.glyphicon
 
-      @event.event_type = 'Reached patient'
-      assert_equal 'comment', @event.glyphicon
+        @event.event_type = 'Reached patient'
+        assert_equal 'comment', @event.glyphicon
 
-      @event.event_type = 'Pledged'
-      assert_equal 'thumbs-up', @event.glyphicon
+        @event.event_type = 'Pledged'
+        assert_equal 'thumbs-up', @event.glyphicon
 
-      @event.event_type = 'Left voicemail'
-      assert_equal 'earphone', @event.glyphicon
+        @event.event_type = 'Left voicemail'
+        assert_equal 'earphone', @event.glyphicon
+      end
     end
 
-    it 'should do something on event text' do
-      assert @event.event_text
+    describe 'underscored_type' do
+      it 'should translate to type without punctuation, with underscores' do
+        assert_equal 'pledged', create(:event, event_type: 'Pledged', pledge_amount: 100).underscored_type
+        assert_equal 'left_voicemail', create(:event, event_type: 'Left voicemail').underscored_type
+        assert_equal 'reached_patient', create(:event, event_type: 'Reached patient').underscored_type
+      end
     end
   end
 
@@ -75,14 +81,6 @@ class EventTest < ActiveSupport::TestCase
       Event.destroy_old_events
 
       assert_equal 3, Event.count
-    end
-  end
-
-  describe 'underscored_type' do
-    it 'should translate to type without punctuation, with underscores' do
-      assert_equal 'pledged', create(:event, event_type: 'Pledged', pledge_amount: 100).underscored_type
-      assert_equal 'left_voicemail', create(:event, event_type: 'Left voicemail').underscored_type
-      assert_equal 'reached_patient', create(:event, event_type: 'Reached patient').underscored_type
     end
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -77,4 +77,12 @@ class EventTest < ActiveSupport::TestCase
       assert_equal 3, Event.count
     end
   end
+
+  describe 'underscored_type' do
+    it 'should translate to type without punctuation, with underscores' do
+      assert_equal 'pledged', create(:event, event_type: 'Pledged', pledge_amount: 100).underscored_type
+      assert_equal 'left_voicemail', create(:event, event_type: 'Left voicemail').underscored_type
+      assert_equal 'reached_patient', create(:event, event_type: 'Reached patient').underscored_type
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This translates the view-facing strings in the Event model and moves them over to the `events_helper`. This was the least intrusive way I could come up with to do this that didn't break the existing Event model.

This pull request makes the following changes:
* adds spanish translations for the event log
* moves the user-facing text out of the model

Note that we can't see the event view because this partial loads async, which can't set locale.

It relates to the following issue #s: 
* Fixes #1578  ~(not done, because we need to move to session)~
