### PR TITLE
Add clinic finder gestation filter

### DIFF
--- a/app/controllers/clinicfinders_controller.rb
+++ b/app/controllers/clinicfinders_controller.rb
@@ -4,15 +4,15 @@ class ClinicfindersController < ApplicationController
   def search
     return head :bad_request if params[:zip].blank?
 
-    # Clinics intentionally excluded from ClinicFinder are assigned the zip 99999.
-    # e.g. so a fund can have an 'OTHER CLINIC' catchall.
-    excluded_zip = '99999'
+    gestation = calculate_gestation params
+    clinics = Clinic.with_zip_and_gestational_limit_above gestation
+                    .where(accepts_naf: )
+                    .where(:accepts_naf.in =>  true)
 
-    clinics = Clinic.where(:zip.nin => [nil, '', excluded_zip])
     # Get all clinics except those with invalid zip codes.
     clinic_finder = ClinicFinder::Locator.new(
       clinics,
-      gestational_age: (params[:gestation].to_i || 0),
+      gestational_age: gestation_limit,
       naf_only: params[:naf_only] == '1',
       medicaid_only: params[:medicaid_only] == '1'
     )
@@ -20,5 +20,13 @@ class ClinicfindersController < ApplicationController
     @nearest = clinic_finder.locate_nearest_clinics params[:zip]
     @cheapest = nil # clinic_finder.locate_cheapest_clinic
     respond_to { |format| format.js }
+  end
+
+  private
+
+  def calculate_gestation(params)
+    weeks = params[:gestation_weeks].present? ? params[:gestation_weeks].to_i * 7 : 0
+    days = params[:gestation_days].present? ? params[:gestation_days].to_i : 0
+    (weeks + days).to_i
   end
 end

--- a/app/controllers/clinicfinders_controller.rb
+++ b/app/controllers/clinicfinders_controller.rb
@@ -6,6 +6,7 @@ class ClinicfindersController < ApplicationController
 
     gestation = calculate_gestation params
     filtered_clinics = Clinic.where(:zip.nin => [nil, '', Clinic::EXCLUDED_ZIP])
+                             .gestational_limit_above(gestation)
                              .where(:accepts_naf.in => [true, params[:naf_only] == '1'])
                              .where(:accepts_medicaid.in => [true, params[:medicaid_only] == '1'])
 

--- a/app/controllers/clinicfinders_controller.rb
+++ b/app/controllers/clinicfinders_controller.rb
@@ -8,9 +8,10 @@ class ClinicfindersController < ApplicationController
     # e.g. so a fund can have an 'OTHER CLINIC' catchall.
     excluded_zip = '99999'
 
+    clinics = Clinic.where(:zip.nin => [nil, '', excluded_zip])
     # Get all clinics except those with invalid zip codes.
     clinic_finder = ClinicFinder::Locator.new(
-      Clinic.where(:zip.nin => [nil, '', excluded_zip]),
+      clinics,
       gestational_age: (params[:gestation].to_i || 0),
       naf_only: params[:naf_only] == '1',
       medicaid_only: params[:medicaid_only] == '1'

--- a/app/helpers/clinicfinders_helper.rb
+++ b/app/helpers/clinicfinders_helper.rb
@@ -9,7 +9,9 @@ module ClinicfindersHelper
     when :cost
       number_to_currency clinic[field], precision: 0
     when :gestational_limit
-      clinic.gestational_limit.present? ? "Goes to #{(clinic.gestational_limit / 7).to_i}w" : 'Not specified'
+      weeks = (clinic.gestational_limit / 7).to_i
+      days = (clinic.gestational_limit % 7).to_i
+      clinic.gestational_limit.present? ? "Goes to #{weeks}w#{days}d" : 'Not specified'
     else
       clinic[field]
     end

--- a/app/helpers/clinicfinders_helper.rb
+++ b/app/helpers/clinicfinders_helper.rb
@@ -8,8 +8,8 @@ module ClinicfindersHelper
       "#{clinic[field].round(2)} miles"
     when :cost
       number_to_currency clinic[field], precision: 0
-    when :gestation_limit
-      "Goes to #{(gestation_limit / 7).to_i}w"
+    when :gestational_limit
+      clinic.gestational_limit.present? ? "Goes to #{(clinic.gestational_limit / 7).to_i}w" : 'Not specified'
     else
       clinic[field]
     end

--- a/app/helpers/clinicfinders_helper.rb
+++ b/app/helpers/clinicfinders_helper.rb
@@ -8,6 +8,8 @@ module ClinicfindersHelper
       "#{clinic[field].round(2)} miles"
     when :cost
       number_to_currency clinic[field], precision: 0
+    when :gestation_limit
+      "Goes to #{(gestation_limit / 7).to_i}w"
     else
       clinic[field]
     end

--- a/app/helpers/clinicfinders_helper.rb
+++ b/app/helpers/clinicfinders_helper.rb
@@ -9,9 +9,10 @@ module ClinicfindersHelper
     when :cost
       number_to_currency clinic[field], precision: 0
     when :gestational_limit
+      return 'Not specified' unless clinic.gestational_limit.present?
       weeks = (clinic.gestational_limit / 7).to_i
       days = (clinic.gestational_limit % 7).to_i
-      clinic.gestational_limit.present? ? "Goes to #{weeks}w#{days}d" : 'Not specified'
+      "Goes to #{weeks}w#{days}d"
     else
       clinic[field]
     end

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -5,6 +5,10 @@ class Clinic
   include Mongoid::History::Trackable
   include Mongoid::Userstamp
 
+  # Clinics intentionally excluded from ClinicFinder are assigned the zip 99999.
+  # e.g. so a fund can have an 'OTHER CLINIC' catchall.
+  EXCLUDED_ZIP = '99999'
+
   # Relationships
   has_many :patients
   has_many :archived_patients
@@ -64,6 +68,12 @@ class Clinic
 
   def address_changed?
     street_address_changed? || city_changed? || state_changed? || zip_changed?
+  end
+
+  def self.with_zip_and_gestational_limit_above(gestational_limit:, naf_only:, medicaid_only:)
+    where(:zip.nin => [nil, '', EXCLUDED_ZIP])
+      .or({:gestational_limit.in => [nil, '']},
+          {:gestational_limit.gte => gestational_limit})
   end
 
   def self.update_all_coordinates

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -13,6 +13,11 @@ class Clinic
   has_many :patients
   has_many :archived_patients
 
+  # Scopes
+  # Is gestatiional_limit either nil or above x?
+  scope :gestational_limit_above, ->(gestation){ any_of({:gestational_limit.in => [nil]},
+                                                        {:gestational_limit.gte => gestation})}
+
   # Callbacks
   before_save :update_coordinates, if: :address_changed?
 
@@ -47,13 +52,11 @@ class Clinic
   # Methods
   def display_location
     return nil if city.blank? || state.blank?
-
     "#{city}, #{state}"
   end
 
   def full_address
     return nil if display_location.blank? || street_address.blank? || zip.blank?
-
     "#{street_address}, #{display_location} #{zip}"
   end
 
@@ -68,12 +71,6 @@ class Clinic
 
   def address_changed?
     street_address_changed? || city_changed? || state_changed? || zip_changed?
-  end
-
-  def self.with_zip_and_gestational_limit_above(gestational_limit:, naf_only:, medicaid_only:)
-    where(:zip.nin => [nil, '', EXCLUDED_ZIP])
-      .or({:gestational_limit.in => [nil, '']},
-          {:gestational_limit.gte => gestational_limit})
   end
 
   def self.update_all_coordinates

--- a/app/models/concerns/last_menstrual_period_measureable.rb
+++ b/app/models/concerns/last_menstrual_period_measureable.rb
@@ -18,6 +18,16 @@ module LastMenstrualPeriodMeasureable
     _display_as_weeks lmp
   end
 
+  def last_menstrual_period_now_weeks
+    return nil unless _last_menstrual_period_now
+    (_last_menstrual_period_now / 7).to_i
+  end
+
+  def last_menstrual_period_now_days
+    return nil unless _last_menstrual_period_now
+    (_last_menstrual_period_now % 7).to_i
+  end
+
   def _last_menstrual_period_now
     if appointment_date && appointment_date < Time.zone.today
       _last_menstrual_period_on_date appointment_date

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -1,11 +1,14 @@
 <div class='col-sm-12'>
   <h5 class='clinic-finder-expand'>
     Clinic Locator Assistant
+    <small>This is an experimental feature.</small>
     <span class='glyphicon glyphicon-plus-sign pull-right'></span>
   </h5>
 
   <div class='col-sm-12 hide' id='clinic-finder-search-form'>
-    <h6>A tool for sorting clinics by cost and distance.</h6>
+    <h6>
+      A tool for sorting clinics by cost and distance.
+    </h6>
 
     <%= bootstrap_form_tag url: clinicfinder_search_path, remote: true do |f| %>
       <div class="row">
@@ -15,9 +18,12 @@
           <%= f.check_box :medicaid_only, label: 'Show only Medicaid clinics' %>
         </div>
 
-        <div class="col-sm-6 info-form-right">
-          This is an experimental feature.
-          <%#= f.select :gestation, weeks_options, label: "Patient's approx. gestation at appt" %>
+        <div class="col-sm-3 info-form-right">
+          <%= f.select :gestation_weeks, options_for_select(weeks_options, patient.last_menstrual_period_now_weeks), label: 'Weeks along', autocomplete: 'off', help: t('patient.dashboard.currently', LMP: patient.last_menstrual_period_display_short) %>
+        </div>
+
+        <div class="col-sm-3 info-form-right hide-label">
+          <%= f.select :gestation_days, options_for_select(days_options, patient.last_menstrual_period_now_days), label: '.' %>
         </div>
       </div>
 

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -1,14 +1,15 @@
 <div class='col-sm-12'>
-  <h5 class='clinic-finder-expand'>
+  <h4 class='clinic-finder-expand'>
     Clinic Locator Assistant
     <small>This is an experimental feature.</small>
     <span class='glyphicon glyphicon-plus-sign pull-right'></span>
-  </h5>
+  </h4>
+
 
   <div class='col-sm-12 hide' id='clinic-finder-search-form'>
-    <h6>
-      A tool for sorting clinics by cost and distance.
-    </h6>
+    <h5>
+      Filters
+    </h5>
 
     <%= bootstrap_form_tag url: clinicfinder_search_path, remote: true do |f| %>
       <div class="row">
@@ -21,10 +22,8 @@
         <div class="col-sm-3 info-form-right">
           <%= f.select :gestation_weeks,
                        options_for_select(weeks_options, patient.last_menstrual_period_now_weeks),
-                       label: 'Gestation cap',
-                       autocomplete: 'off',
-                       help: t('patient.dashboard.currently',
-                               LMP: patient.last_menstrual_period_display_short) %>
+                       label: 'Gestation above',
+                       autocomplete: 'off' %>
         </div>
 
         <div class="col-sm-3 info-form-right hide-label">

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -8,7 +8,7 @@
 
   <div class='col-sm-12 hide' id='clinic-finder-search-form'>
     <h5>
-      Filters
+      Filter out clinics according to accepting NAF/NNAF and their gestation limits; sort by proximity to a ZIP code.
     </h5>
 
     <%= bootstrap_form_tag url: clinicfinder_search_path, remote: true do |f| %>

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -19,11 +19,19 @@
         </div>
 
         <div class="col-sm-3 info-form-right">
-          <%= f.select :gestation_weeks, options_for_select(weeks_options, patient.last_menstrual_period_now_weeks), label: 'Weeks along', autocomplete: 'off', help: t('patient.dashboard.currently', LMP: patient.last_menstrual_period_display_short) %>
+          <%= f.select :gestation_weeks,
+                       options_for_select(weeks_options, patient.last_menstrual_period_now_weeks),
+                       label: 'Gestation cap',
+                       autocomplete: 'off',
+                       help: t('patient.dashboard.currently',
+                               LMP: patient.last_menstrual_period_display_short) %>
         </div>
 
         <div class="col-sm-3 info-form-right hide-label">
-          <%= f.select :gestation_days, options_for_select(days_options, patient.last_menstrual_period_now_days), label: '.' %>
+          <%= f.select :gestation_days,
+                       options_for_select(days_options, patient.last_menstrual_period_now_days),
+                       label: '.',
+                       autocomplete: 'off' %>
         </div>
       </div>
 

--- a/app/views/clinicfinders/search.js.erb
+++ b/app/views/clinicfinders/search.js.erb
@@ -1,7 +1,7 @@
 $('#clinic-finder-results').empty().hide();
 
 <% if @nearest&.any? %>
-  $("#clinic-finder-results").append("<%= escape_javascript(render partial: 'clinicfinders/result_table', locals: { title: 'Nearest Clinics', clinic_fields: [:name, :location, :accepts_naf, :distance], clinics: @nearest }) %>");
+  $("#clinic-finder-results").append("<%= escape_javascript(render partial: 'clinicfinders/result_table', locals: { title: 'Nearest Clinics', clinic_fields: [:name, :location, :accepts_naf, :distance, :gestational_limit], clinics: @nearest }) %>");
 <% end %>
 
 <% if @cheapest&.any? %>

--- a/app/views/clinicfinders/search.js.erb
+++ b/app/views/clinicfinders/search.js.erb
@@ -1,11 +1,21 @@
 $('#clinic-finder-results').empty().hide();
 
 <% if @nearest&.any? %>
-  $("#clinic-finder-results").append("<%= escape_javascript(render partial: 'clinicfinders/result_table', locals: { title: 'Nearest Clinics', clinic_fields: [:name, :location, :accepts_naf, :distance, :gestational_limit], clinics: @nearest }) %>");
+  $("#clinic-finder-results").append(
+    "<%= escape_javascript(render partial: 'clinicfinders/result_table',
+                           locals: { title: 'Nearest Clinics',
+                                     clinic_fields: [:name, :location, :accepts_naf, :distance, :gestational_limit],
+                                     clinics: @nearest }) %>"
+  );
 <% end %>
 
 <% if @cheapest&.any? %>
-  $("#clinic-finder-results").append("<%= escape_javascript(render partial: 'clinicfinders/result_table', locals: { title: 'Most Affordable Clinics', clinic_fields: [:name, :cost], clinics: @cheapest }) %>");
+  $("#clinic-finder-results").append(
+    "<%= escape_javascript(render partial: 'clinicfinders/result_table',
+                                  locals: { title: 'Most Affordable Clinics',
+                                            clinic_fields: [:name, :cost],
+                                            clinics: @cheapest }) %>"
+  );
 <% end %>
 
 $("#clinic-finder-results").slideDown('fast');

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -49,7 +49,8 @@
     </div>
 
     <div class="row col-md-12 clinic_finder_container">
-      <%= render 'clinicfinders/search_form' %>
+      <%= render partial: 'clinicfinders/search_form',
+                 locals: { patient: patient } %>
     </div>
   </div>
 

--- a/test/helpers/clinicfinders_helper_test.rb
+++ b/test/helpers/clinicfinders_helper_test.rb
@@ -28,7 +28,7 @@ class ClinicfindersHelperTest < ActionView::TestCase
 
     it 'should parse gestational_limit specially' do
       @clinic_struct.gestational_limit = 50
-      assert_equal 'Goes to 7w',
+      assert_equal 'Goes to 7w1d',
                    parse_clinicfinder_field(@clinic_struct, :gestational_limit)
 
       @clinic_struct.gestational_limit = nil

--- a/test/helpers/clinicfinders_helper_test.rb
+++ b/test/helpers/clinicfinders_helper_test.rb
@@ -26,6 +26,16 @@ class ClinicfindersHelperTest < ActionView::TestCase
                    parse_clinicfinder_field(@clinic_struct, :cost)
     end
 
+    it 'should parse gestational_limit specially' do
+      @clinic_struct.gestational_limit = 50
+      assert_equal 'Goes to 7w',
+                   parse_clinicfinder_field(@clinic_struct, :gestational_limit)
+
+      @clinic_struct.gestational_limit = nil
+      assert_equal 'Not specified',
+                   parse_clinicfinder_field(@clinic_struct, :gestational_limit)
+    end
+
     it 'parses other fields too' do
       assert_equal @clinic.name,
                    parse_clinicfinder_field(@clinic_struct, :name)

--- a/test/models/clinic_test.rb
+++ b/test/models/clinic_test.rb
@@ -112,4 +112,23 @@ class ClinicTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'scopes' do
+    describe 'gestational_limit_above' do
+      before { Clinic.destroy_all }
+
+      it 'should filter out clinics unless the gestational_limit is above the cutoff in days' do
+        no_gl_clinic = create :clinic
+        gl_filtered_clinic = create :clinic, gestational_limit: 100
+        gl_kept_clinic = create :clinic, gestational_limit: 240
+        # Should return the clinics with no specified GL and a GL above 150
+        gl_above_clinics = Clinic.gestational_limit_above 150
+
+        assert_equal 2, gl_above_clinics.count
+        assert_includes gl_above_clinics, no_gl_clinic
+        assert_includes gl_above_clinics, gl_kept_clinic
+        assert_not_includes gl_above_clinics, gl_filtered_clinic
+      end
+    end
+  end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds gestation filter as a parameter you can filter down in clinic finder. If, for example, you are a CM working with someone who's 18w, clinics that don't go that far are unhelpful at best and misdirecting at worst. This pops those out early via some filtering in the controller.

Tests TK

This pull request makes the following changes:
* Adds gestation filter as a thing you can filter clinics by in clinic finder
* Adds gestation filter to the clinic finder results table
* includes #1596 

Getting a little cramped, but it works!

![image](https://user-images.githubusercontent.com/3866868/52530534-7e4ad380-2cd5-11e9-9f5a-e713e7712ec4.png)

It relates to the following issue #s: 
* Fixes #1365 
