### PR TITLE
Remove filters from ClinicFinder in favor of Mongoid/ActiveRecord#where

### DIFF
--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -5,6 +5,10 @@ class Clinic
   include Mongoid::History::Trackable
   include Mongoid::Userstamp
 
+  # Clinics intentionally excluded from ClinicFinder are assigned the zip 99999.
+  # e.g. so a fund can have an 'OTHER CLINIC' catchall.
+  EXCLUDED_ZIP = '99999'
+
   # Relationships
   has_many :patients
   has_many :archived_patients

--- a/app/services/clinic_finder/locator.rb
+++ b/app/services/clinic_finder/locator.rb
@@ -4,12 +4,7 @@ require 'ostruct'
 
 # Use as follows:
 # pt = Patient.find('123');
-# finder = ClinicFinder::Locator.new(
-#   Clinic.all,
-#   gestational_age: pt.gestational_age, # in days
-#   naf_only: true, # Limit results to NAF clinics
-#   medicaid_only: true # Limit results to Medicaid clinics
-# )
+# finder = ClinicFinder::Locator.new(Clinic.all)
 # finder.locate_nearest_clinics pt.zip, limit: 5
 # finder.locate_cheapest_clinics limit: 5
 module ClinicFinder
@@ -19,19 +14,12 @@ module ClinicFinder
   class Locator
     include ClinicFinder::Modules::Geocoder
 
-    attr_accessor :clinics
     attr_accessor :clinic_structs
     attr_accessor :patient_context # no reason to not assign this to an obj lvl
     attr_accessor :geocoder
 
-    def initialize(clinics, gestational_age: 0,
-                   naf_only: false, medicaid_only: false)
-      @clinics = filter_by_params clinics,
-                                  gestational_age,
-                                  naf_only,
-                                  medicaid_only
-
-      @clinic_structs = @clinics.map { |clinic| OpenStruct.new clinic.attributes }
+    def initialize(clinics)
+      @clinic_structs = clinics.map { |clinic| OpenStruct.new clinic.attributes }
       @patient_context = OpenStruct.new
       @geocoder = Geokit::Geocoders::GoogleGeocoder
     end
@@ -54,19 +42,6 @@ module ClinicFinder
 
       # @gestational_tier = @helper.gestational_tier
       # decorate_data(available_clinics)
-    end
-
-    private
-
-    # Based on initialization fields, narrow the list of clinics to
-    # just what we need.
-    def filter_by_params(clinics, gestational_age, naf_only, medicaid_only)
-      filtered_clinics = clinics.keep_if do |clinic|
-        gestational_age < (clinic.gestational_limit || 1000) &&
-          (naf_only ? clinic.accepts_naf : true) &&
-          (medicaid_only ? clinic.accepts_medicaid : true)
-      end
-      filtered_clinics
     end
   end
 end

--- a/test/services/clinic_finder/clinic_finder_test.rb
+++ b/test/services/clinic_finder/clinic_finder_test.rb
@@ -54,18 +54,18 @@ class ClinicFinderTest < ActiveSupport::TestCase
 
   describe 'initialization with clinics' do
     before do
+      @clinics = Clinic.all
       @abortron = ClinicFinder::Locator.new Clinic.all
     end
 
     it 'should initialize with clinics' do
-      assert(@abortron.clinics.find { |c| c.name == 'PP SF' })
-      assert_equal Clinic.all.count, @abortron.clinics.count
-      assert_equal @abortron.clinics.count, @abortron.clinic_structs.count
+      assert @abortron.clinic_structs.find { |c| c.name == 'PP SF' }
+      assert_equal Clinic.all.count, @abortron.clinic_structs.count
     end
 
     it 'should have mirroring clinic and clinic_structs on init' do
       @abortron.clinic_structs.each do |clinic_struct|
-        clinic = @abortron.clinics.find { |c| c._id == clinic_struct._id }
+        clinic = @clinics.find clinic_struct._id
         clinic.attributes.each_pair do |k, _v|
           attr_value = clinic.instance_variable_get("@#{k}")
           assert_equal attr_value, clinic_struct[k] if attr_value
@@ -77,26 +77,6 @@ class ClinicFinderTest < ActiveSupport::TestCase
       assert @abortron.respond_to? :patient_context
       @abortron.patient_context.yolo = 'goat'
       assert_equal 'goat', @abortron.patient_context.yolo
-    end
-  end
-
-  describe 'initializing with filters' do
-    it 'should filter clinics based on patients gestational age' do
-      @abortron = ClinicFinder::Locator.new Clinic.all,
-                                            gestational_age: 150
-      @abortron.clinics.each { |clinic| assert clinic.gestational_limit >= 150 }
-    end
-
-    it 'should filter clinics based on medicaid preference' do
-      @abortron = ClinicFinder::Locator.new Clinic.all,
-                                            medicaid_only: true
-      @abortron.clinics.each { |clinic| assert clinic.accepts_medicaid }
-    end
-
-    it 'should filter clinics based on naf preference' do
-      @abortron = ClinicFinder::Locator.new Clinic.all,
-                                            naf_only: true
-      @abortron.clinics.each { |clinic| assert clinic.accepts_naf }
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

While working thru #1595 it kinda became apparent that we were just reimplementing activerecord filters in the clinic finder code. This strips out those filters in favor of activerecord. I separated this change out because it's sort of independent of the larger work of setting up gestation limit filtering.

This pull request makes the following changes:
* deletes filter methods from clinicfinder
* moves it all to the controller (for now)

no view changes

It relates to the following issue #s: 
* Bumps #1365 
