### PR TITLE
Switch to Spanish Link

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,11 @@ class ApplicationController < ActionController::Base
     I18n.locale = params[:locale] || I18n.default_locale
   end
 
+  def default_url_options
+    return { :locale => I18n.locale } if I18n.locale != I18n.default_locale
+    {}
+  end
+
   private
 
   # Prevents app from caching pages as a security measure

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -6,4 +6,16 @@ module NavbarHelper
       link_to t('navigation.cm_resources.label'), url, target: '_blank'
     end if url.present?
   end
+
+  def spanish_or_english_link
+    if !Rails.env.production?
+      content_tag :li do
+        if I18n.locale == I18n.default_locale 
+          link_to "Español", { :locale=>'es' }
+        else
+          link_to "English", { :locale=>'en' }
+        end
+      end
+    end
+  end
 end

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -4,6 +4,7 @@
       <li class="navbar-text-alt"><%= current_line_display %></li>
     <% end %>
     <%= cm_resources_link %>
+    <%= spanish_or_english_link %>
   <% end %>
 </ul>
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I borked #1527 so here's a new cleaner PR

This adds a link to switch from Spanish and English for the app, as well as enables default url options to include the locale.

This pull request makes the following changes:
* Tiny changes to the application controller
* A helper for outputting the spanish/english link
* Adding the helper into the navbar view