### PR TITLE
Port ajax-produced strings on dashboards

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,11 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+    I18n.locale = if params[:locale].present?
+                    params[:locale]
+                  else
+                    I18n.default_locale
+                  end
   end
 
   def default_url_options

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -22,6 +22,7 @@ class DashboardsController < ApplicationController
   end
 
   def budget_bar
+    # We call these by interpolation in the view; these comments are to let i18n-health know we're using them
     # i18n-tasks-use t('dashboard.budget_bar.pledged_item')
     # i18n-tasks-use t('dashboard.budget_bar.sent_item')
     # i18n-tasks-use t('dashboard.budget_bar.pledged_report')

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -22,6 +22,10 @@ class DashboardsController < ApplicationController
   end
 
   def budget_bar
+    # i18n-tasks-use t('dashboard.budget_bar.pledged_item')
+    # i18n-tasks-use t('dashboard.budget_bar.sent_item')
+    # i18n-tasks-use t('dashboard.budget_bar.pledged_report')
+    # i18n-tasks-use t('dashboard.budget_bar.sent_report')
     render partial: 'dashboards/budget_bar',
            locals: budget_bar_calculations(current_line)
   end

--- a/app/helpers/budget_bar_helper.rb
+++ b/app/helpers/budget_bar_helper.rb
@@ -11,9 +11,11 @@ module BudgetBarHelper
 
   def budget_bar_expenditure_content(patient_hash)
     link = link_to patient_hash[:name], edit_patient_path(patient_hash[:id])
-    appt_text = patient_hash[:appointment_date] ?
-      "appt on #{patient_hash[:appointment_date]&.display_date}" :
-      'no appt date'
+    appt_text = if patient_hash[:appointment_date]
+                  t 'dashboard.budget_bar.pop_content_appt_date', date: patient_hash[:appointment_date]&.display_date
+                else
+                  t 'dashboard.budget_bar.pop_content_no_appt_date'
+                end
     safe_join([link, appt_text], ' - ')
   end
 

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -5,6 +5,8 @@
         <% patient_hashes.each do |patient| %>
           <div class="progress-bar <%= progress_bar_color type %> expenditure-block" style='<%= progress_bar_width patient[:fund_pledge], limit %>' role='progressbar'>
             <div data-toggle='popover' data-content='<%= budget_bar_expenditure_content(patient) %>' data-placement='bottom' data-html='true' class='expenditure-item'>
+              <%= # i18n-tasks-use t('dashboard.budget_bar.pledged_item') %>
+              <%= # i18n-tasks-use t('dashboard.budget_bar.sent_item') %>
               <%= t "dashboard.budget_bar.#{type}_item",
                     amount: number_to_currency(patient[:fund_pledge],
                                                precision: 0,
@@ -19,6 +21,8 @@
     <div class="row" id='budget-report'>
       <% expenditures.each_pair do |type, patient_hashes| %>
         <div class="col-sm-4">
+          <%= # i18n-tasks-use t('dashboard.budget_bar.pledged_report') %>
+          <%= # i18n-tasks-use t('dashboard.budget_bar.sent_report') %>
           <%= t("dashboard.budget_bar.#{type}_report",
                 amount: number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0,
                                            precision: 0,

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -5,8 +5,6 @@
         <% patient_hashes.each do |patient| %>
           <div class="progress-bar <%= progress_bar_color type %> expenditure-block" style='<%= progress_bar_width patient[:fund_pledge], limit %>' role='progressbar'>
             <div data-toggle='popover' data-content='<%= budget_bar_expenditure_content(patient) %>' data-placement='bottom' data-html='true' class='expenditure-item'>
-              <%= # i18n-tasks-use t('dashboard.budget_bar.pledged_item') %>
-              <%= # i18n-tasks-use t('dashboard.budget_bar.sent_item') %>
               <%= t "dashboard.budget_bar.#{type}_item",
                     amount: number_to_currency(patient[:fund_pledge],
                                                precision: 0,
@@ -21,8 +19,6 @@
     <div class="row" id='budget-report'>
       <% expenditures.each_pair do |type, patient_hashes| %>
         <div class="col-sm-4">
-          <%= # i18n-tasks-use t('dashboard.budget_bar.pledged_report') %>
-          <%= # i18n-tasks-use t('dashboard.budget_bar.sent_report') %>
           <%= t("dashboard.budget_bar.#{type}_report",
                 amount: number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0,
                                            precision: 0,

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -15,13 +15,15 @@
     <div class="row" id='budget-report'>
       <% expenditures.each_pair do |type, patient_hashes| %>
         <div class="col-sm-4">
-          <%= number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0, precision: 0)  %> <%= type  %> (<%= expenditures[type].count %> patients)
+          <%= t("dashboard.budget_bar.#{type}",
+                amount: number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0, precision: 0, unit: '$', format: '%u%n'),
+                count: expenditures[type].count) %>
         </div>
       <% end %>
       <%# TODO Commenting out until the config is ready %>
       <!-- 
       <div class="col-sm-4">
-        <%= number_to_currency(budget_bar_remaining(expenditures, limit), precision: 0) %> remaining
+        <%#= number_to_currency(budget_bar_remaining(expenditures, limit), precision: 0) %> remaining
       </div>
       -->
     </div>

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -5,7 +5,11 @@
         <% patient_hashes.each do |patient| %>
           <div class="progress-bar <%= progress_bar_color type %> expenditure-block" style='<%= progress_bar_width patient[:fund_pledge], limit %>' role='progressbar'>
             <div data-toggle='popover' data-content='<%= budget_bar_expenditure_content(patient) %>' data-placement='bottom' data-html='true' class='expenditure-item'>
-              <%= number_to_currency patient[:fund_pledge], precision: 0 %> <%= type %>
+              <%= t "dashboard.budget_bar.#{type}_item",
+                    amount: number_to_currency(patient[:fund_pledge],
+                                               precision: 0,
+                                               unit: '$',
+                                               format: '%u%n') %>
             </div>
           </div>
         <% end %>
@@ -15,8 +19,11 @@
     <div class="row" id='budget-report'>
       <% expenditures.each_pair do |type, patient_hashes| %>
         <div class="col-sm-4">
-          <%= t("dashboard.budget_bar.#{type}",
-                amount: number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0, precision: 0, unit: '$', format: '%u%n'),
+          <%= t("dashboard.budget_bar.#{type}_report",
+                amount: number_to_currency(expenditures[type].map { |h| h[:fund_pledge] }.inject(:+) || 0,
+                                           precision: 0,
+                                           unit: '$',
+                                           format: '%u%n'),
                 count: expenditures[type].count) %>
         </div>
       <% end %>

--- a/app/views/dashboards/_search_form.html.erb
+++ b/app/views/dashboards/_search_form.html.erb
@@ -4,6 +4,8 @@
   </h1>
 
   <%= bootstrap_form_tag url: '/search', remote: true, layout: :inline do |p| %>
+    <%= p.hidden_field :locale, value: params[:locale] %>
+
     <%= p.text_field :search, placeholder: t('dashboard.search.input_placeholder'), hide_label: true, class: 'search_form_input' %>
     <%= p.button class: 'btn btn-primary', title: t('common.search') do %>
       <i class="glyphicon glyphicon-search"></i>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,12 +20,12 @@ en:
     activity_log:
       label: "%{current_line} Line Activity Log"
     budget_bar:
+      pledged_item: "%{amount} pledged"
+      pledged_report: "%{amount} pledged (%{count} patients)"
       pop_content_appt_date: appt on %{date}
       pop_content_no_appt_date: no appt date
       sent_item: "%{amount} sent"
-      pledged_item: "%{amount} pledged"
       sent_report: "%{amount} sent (%{count} patients)"
-      pledged_report: "%{amount} pledged (%{count} patients)"
     helpers:
       voicemail_options:
         'no': Do not leave a voicemail

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,8 +20,12 @@ en:
     activity_log:
       label: "%{current_line} Line Activity Log"
     budget_bar:
-      sent: "%{amount} sent (%{count} patients)"
-      pledged: "%{amount} sent (%{count} patients)"
+      pop_content_appt_date: appt on %{date}
+      pop_content_no_appt_date: no appt date
+      sent_item: "%{amount} sent"
+      pledged_item: "%{amount} pledged"
+      sent_report: "%{amount} sent (%{count} patients)"
+      pledged_report: "%{amount} pledged (%{count} patients)"
     helpers:
       voicemail_options:
         'no': Do not leave a voicemail

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,9 @@ en:
   dashboard:
     activity_log:
       label: "%{current_line} Line Activity Log"
+    budget_bar:
+      sent: "%{amount} sent (%{count} patients)"
+      pledged: "%{amount} sent (%{count} patients)"
     helpers:
       voicemail_options:
         'no': Do not leave a voicemail

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -251,7 +251,7 @@ es:
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
   tooltips:
-    budget_bar: La barra de presupuesto indica el dinero provisionalmente reservado para un paciente (cuando ingresa la cantidad de compromiso %{FUND}) y el dinero enviado a una clínica para un paciente (cuando marca la casilla de verificación “enviaré la promesa”) durante una semana determinada. Se reinicia los lunes.
+    budget_bar: La barra de presupuesto indica el dinero provisionalmente reservado para un paciente (cuando ingresa la cantidad de compromiso %{fund}) y el dinero enviado a una clínica para un paciente (cuando marca la casilla de verificación “enviaré la promesa”) durante una semana determinada. Se reinicia los lunes.
     call_list: Esta lista organiza los pacientes para cuando quiera devolver llamadas durante su turno. Utiliza la búsqueda para rellenar la lista.
     completed_calls: Esta es una lista de pacientes a los que ha llamado en las últimas 8 horas.
     mandatory_ultrasound: Si se encuentra en un estado que requiere ultrasonidos y el paciente ha completado uno, puede indicarlo aquí.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -20,12 +20,12 @@ es:
     activity_log:
       label: Actividad de línea de llamadas %{current_line}
     budget_bar:
+      pledged_item: "%{amount} prometido"
+      pledged_report: "%{amount} prometido (%{count} pacientes)"
       pop_content_appt_date: cita en %{date}
       pop_content_no_appt_date: sin cita
       sent_item: "%{amount} expedido"
-      pledged_item: "%{amount} prometido"
       sent_report: "%{amount} expedido (%{count} pacientes)"
-      pledged_report: "%{amount} prometido (%{count} pacientes)"
     helpers:
       voicemail_options:
         'no': No dejen mensajes de voz

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -24,8 +24,8 @@ es:
       pledged_report: "%{amount} prometido (%{count} pacientes)"
       pop_content_appt_date: cita en %{date}
       pop_content_no_appt_date: sin cita
-      sent_item: "%{amount} expedido"
-      sent_report: "%{amount} expedido (%{count} pacientes)"
+      sent_item: "%{amount} enviado"
+      sent_report: "%{amount} enviado (%{count} pacientes)"
     helpers:
       voicemail_options:
         'no': No dejen mensajes de voz

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -20,8 +20,12 @@ es:
     activity_log:
       label: Actividad de línea de llamadas %{current_line}
     budget_bar:
-      sent: "%{amount} expedido (%{count} pacientes)"
-      pledged: "%{amount} prometido (%{count} pacientes)"
+      pop_content_appt_date: cita en %{date}
+      pop_content_no_appt_date: sin cita
+      sent_item: "%{amount} expedido"
+      pledged_item: "%{amount} prometido"
+      sent_report: "%{amount} expedido (%{count} pacientes)"
+      pledged_report: "%{amount} prometido (%{count} pacientes)"
     helpers:
       voicemail_options:
         'no': No dejen mensajes de voz

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,6 +19,9 @@ es:
   dashboard:
     activity_log:
       label: Actividad de línea de llamadas %{current_line}
+    budget_bar:
+      sent: "%{amount} expedido (%{count} pacientes)"
+      pledged: "%{amount} prometido (%{count} pacientes)"
     helpers:
       voicemail_options:
         'no': No dejen mensajes de voz


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Translates the budget bar courtesy of some great work by @DarthHater in #1597 . Also translates the `render_async` stuff in the budget bar.

This leaves the tooltips alone, as they are a LOT of spanish. But that's the remaining part.

This pull request makes the following changes:
* Translates search results partial and budget bar

It relates to the following issue #s: 
* Bumps #1575 
