### PR TITLE
Translate tooltip helper text

### DIFF
--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -21,7 +21,7 @@ module TooltipsHelper
   end
 
   def budget_bar_help_text
-    t('tooltips.completed_calls', fund: FUND).strip
+    t('tooltips.budget_bar', fund: FUND).strip
   end
 
   def completed_calls_help_text

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -17,36 +17,19 @@ module TooltipsHelper
   end
 
   def call_list_help_text
-    text = <<-TEXT
-      This sortable list is used to keep track of patients to call back
-      during your shift. Use the search to populate it.
-    TEXT
-    text.strip
+    t('tooltips.call_list').strip
   end
 
   def budget_bar_help_text
-    text = <<-TEXT
-      The budget bar lists money tentatively set aside for a patient
-      (by entering a value in the #{FUND} pledge field) and money sent to a clinic for a patient (by checking the I sent the pledge checkbox) over a given week. It resets on Mondays.
-    TEXT
-    text.strip
+    t('tooltips.completed_calls', fund: FUND).strip
   end
 
   def completed_calls_help_text
-    text = <<-TEXT
-      This is a list of patients you have called within the last 8 hours.
-    TEXT
-    text.strip
+    t('tooltips.completed_calls').strip
   end
 
   def urgent_cases_help_text
-    text = <<-TEXT
-      These are patients who require a little more attention. This list is
-      shared across all case managers working on a single line. Patients are
-      removed from this list automatically after they are marked as having
-      a sent pledge, or marked as resolved without assistance.
-    TEXT
-    text.strip
+    t('tooltips.urgent_cases').strip
   end
 
   def status_help_text(patient)
@@ -55,34 +38,22 @@ module TooltipsHelper
 
     status_def = "#{status[:key]}: #{status[:help_text]}"
 
-    safe_join(['Status definition:'].concat([status_def]), tag('br'))
+    safe_join(["#{t('tooltips.status_definition')}:"].concat([status_def]), tag('br'))
   end
 
   def record_new_external_pledge_help_text
-    text = <<-TEXT
-      External pledges is our term for pledges by other abortion funds also
-      working with a patient.
-    TEXT
-    text.strip
+    t('tooltips.record_new_external_pledge').strip
   end
 
   def resolved_without_fund_help_text
-    text = <<-TEXT
-      This is used to indicate that a patient does not require or want
-      our services any longer.
-    TEXT
-    text.strip
+    t('tooltips.resolved_without_fund').strip
   end
 
   def referred_to_clinic_help_text
-    text = <<-TEXT
-      Check this box if you as a case manager referred the patient to a
-      particular clinic.
-    TEXT
-    text.strip
+    t('tooltips.referred_to_clinic').strip
   end
 
   def mandatory_ultrasound_help_text
-    'If you are in a state that requires ultrasounds and the patient has completed one, you can log it here.'
+    t('tooltips.mandatory_ultrasound').strip
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,3 +114,31 @@ en:
         pledge_sent: Pledge Sent
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
+  tooltips:
+    call_list: >-
+      This sortable list is used to keep track of patients to call back
+      during your shift. Use the search to populate it.
+    budget_bar: >-
+      The budget bar lists money tentatively set aside for a patient
+      (by entering a value in the #{FUND} pledge field) and money sent
+      to a clinic for a patient (by checking the I sent the pledge checkbox)
+      over a given week. It resets on Mondays.
+    completed_calls: >-
+      This is a list of patients you have called within the last 8 hours.
+    urgent_cases: >-
+      These are patients who require a little more attention. This list is
+      shared across all case managers working on a single line. Patients are
+      removed from this list automatically after they are marked as having
+      a sent pledge, or marked as resolved without assistance.
+    record_new_external_pledge: >-
+      External pledges is our term for pledges by other abortion funds also
+      working with a patient.
+    resolved_without_fund: >-
+      This is used to indicate that a patient does not require or want
+      our services any longer.
+    referred_to_clinic: >-
+      Check this box if you as a case manager referred the patient to a
+      particular clinic.
+    mandatory_ultrasound: >-
+      If you are in a state that requires ultrasounds and the patient
+      has completed one, you can log it here.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,3 +142,4 @@ en:
     mandatory_ultrasound: >-
       If you are in a state that requires ultrasounds and the patient
       has completed one, you can log it here.
+    status_definition: Status definition

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,31 +115,12 @@ en:
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
   tooltips:
-    call_list: >-
-      This sortable list is used to keep track of patients to call back
-      during your shift. Use the search to populate it.
-    budget_bar: >-
-      The budget bar lists money tentatively set aside for a patient
-      (by entering a value in the #{FUND} pledge field) and money sent
-      to a clinic for a patient (by checking the I sent the pledge checkbox)
-      over a given week. It resets on Mondays.
-    completed_calls: >-
-      This is a list of patients you have called within the last 8 hours.
-    urgent_cases: >-
-      These are patients who require a little more attention. This list is
-      shared across all case managers working on a single line. Patients are
-      removed from this list automatically after they are marked as having
-      a sent pledge, or marked as resolved without assistance.
-    record_new_external_pledge: >-
-      External pledges is our term for pledges by other abortion funds also
-      working with a patient.
-    resolved_without_fund: >-
-      This is used to indicate that a patient does not require or want
-      our services any longer.
-    referred_to_clinic: >-
-      Check this box if you as a case manager referred the patient to a
-      particular clinic.
-    mandatory_ultrasound: >-
-      If you are in a state that requires ultrasounds and the patient
-      has completed one, you can log it here.
+    budget_bar: The budget bar lists money tentatively set aside for a patient (by entering a value in the %{fund} pledge field) and money sent to a clinic for a patient (by checking the I sent the pledge checkbox) over a given week. It resets on Mondays.
+    call_list: This sortable list is used to keep track of patients to call back during your shift. Use the search to populate it.
+    completed_calls: This is a list of patients you have called within the last 8 hours.
+    mandatory_ultrasound: If you are in a state that requires ultrasounds and the patient has completed one, you can log it here.
+    record_new_external_pledge: External pledges is our term for pledges by other abortion funds also working with a patient.
+    referred_to_clinic: Check this box if you as a case manager referred the patient to a particular clinic.
+    resolved_without_fund: This is used to indicate that a patient does not require or want our services any longer.
     status_definition: Status definition
+    urgent_cases: These are patients who require a little more attention. This list is shared across all case managers working on a single line. Patients are removed from this list automatically after they are marked as having a sent pledge, or marked as resolved without assistance.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -115,34 +115,12 @@ es:
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
   tooltips:
-    call_list: >-
-      Esta lista clasificable se usa para hacer un seguimiento de los
-      pacientes para devolver la llamada durante su turno. Utiliza la
-      búsqueda para rellenarla.
-    budget_bar: >-
-      La barra de presupuesto enumera dinero provisionalmente reservado
-      para un paciente (ingresando un valor en el campo de compromiso %{FUND})
-      y el dinero enviado a una clínica para un paciente (marcando la casilla
-      de verificación Enviaré la promesa) durante una semana determinada.
-      Se reinicia los lunes.
-    completed_calls: >-
-      Esta es una lista de pacientes a los que ha llamado en las últimas 8 horas.
-    urgent_cases: >-
-      Estos son pacientes que requieren un poco más de atención. Esta lista es
-      compartido entre todos los administradores de casos que trabajan en una
-      sola línea. Los pacientes son eliminados de esta lista automáticamente
-      después de que estén marcados como que tienen. Un compromiso enviado,
-      o marcado como resuelto sin ayuda.
-    record_new_external_pledge: >-
-      Promesas externas es nuestro término para promesas hechas por otros
-      fondos de aborto también trabajando con un paciente.
-    resolved_without_fund: >-
-      Esto se utiliza para indicar que un paciente no requiere o quiere
-      nuestros servicios por más tiempo.
-    referred_to_clinic: >-
-      Marque esta casilla si usted, como administrador de casos, refirió al
-      paciente a un clínica particular.
-    mandatory_ultrasound: >-
-      Si se encuentra en un estado que requiere ultrasonidos y el paciente
-      ha completado uno, puede iniciar sesión aquí.
+    budget_bar: La barra de presupuesto enumera dinero provisionalmente reservado para un paciente (ingresando un valor en el campo de compromiso %{fund}) y el dinero enviado a una clínica para un paciente (marcando la casilla de verificación Enviaré la promesa) durante una semana determinada. Se reinicia los lunes.
+    call_list: Esta lista clasificable se usa para hacer un seguimiento de los pacientes para devolver la llamada durante su turno. Utiliza la búsqueda para rellenarla.
+    completed_calls: Esta es una lista de pacientes a los que ha llamado en las últimas 8 horas.
+    mandatory_ultrasound: Si se encuentra en un estado que requiere ultrasonidos y el paciente ha completado uno, puede iniciar sesión aquí.
+    record_new_external_pledge: Promesas externas es nuestro término para promesas hechas por otros fondos de aborto también trabajando con un paciente.
+    referred_to_clinic: Marque esta casilla si usted, como administrador de casos, refirió al paciente a un clínica particular.
+    resolved_without_fund: Esto se utiliza para indicar que un paciente no requiere o quiere nuestros servicios por más tiempo.
     status_definition: Definición de estado
+    urgent_cases: Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados como que tienen. Un compromiso enviado, o marcado como resuelto sin ayuda.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -114,6 +114,7 @@ es:
         pledge_sent: Promesa Enviada
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
+  tooltips:
     call_list: >-
       Esta lista clasificable se usa para hacer un seguimiento de los
       pacientes para devolver la llamada durante su turno. Utiliza la
@@ -144,3 +145,4 @@ es:
     mandatory_ultrasound: >-
       Si se encuentra en un estado que requiere ultrasonidos y el paciente
       ha completado uno, puede iniciar sesión aquí.
+    status_definition: Definición de estado

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -115,12 +115,12 @@ es:
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
   tooltips:
-    budget_bar: La barra de presupuesto enumera dinero provisionalmente reservado para un paciente (ingresando un valor en el campo de compromiso %{fund}) y el dinero enviado a una clínica para un paciente (marcando la casilla de verificación Enviaré la promesa) durante una semana determinada. Se reinicia los lunes.
-    call_list: Esta lista clasificable se usa para hacer un seguimiento de los pacientes para devolver la llamada durante su turno. Utiliza la búsqueda para rellenarla.
+    budget_bar: La barra de presupuesto indica el dinero provisionalmente reservado para un paciente (cuando ingresa la cantidad de compromiso %{FUND}) y el dinero enviado a una clínica para un paciente (cuando marca la casilla de verificación “enviaré la promesa”) durante una semana determinada. Se reinicia los lunes.
+    call_list: Esta lista organiza los pacientes para cuando quiera devolver llamadas durante su turno. Utiliza la búsqueda para rellenar la lista.
     completed_calls: Esta es una lista de pacientes a los que ha llamado en las últimas 8 horas.
-    mandatory_ultrasound: Si se encuentra en un estado que requiere ultrasonidos y el paciente ha completado uno, puede iniciar sesión aquí.
-    record_new_external_pledge: Promesas externas es nuestro término para promesas hechas por otros fondos de aborto también trabajando con un paciente.
+    mandatory_ultrasound: Si se encuentra en un estado que requiere ultrasonidos y el paciente ha completado uno, puede indicarlo aquí.
+    record_new_external_pledge: "“Promesas externas” significa las promesas hechas por otros fondos de aborto también trabajando con un paciente."
     referred_to_clinic: Marque esta casilla si usted, como administrador de casos, refirió al paciente a un clínica particular.
-    resolved_without_fund: Esto se utiliza para indicar que un paciente no requiere o quiere nuestros servicios por más tiempo.
+    resolved_without_fund: Esto se utiliza para indicar que un paciente ya no necesita o quiere nuestros servicios.
     status_definition: Definición de estado
-    urgent_cases: Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados como que tienen. Un compromiso enviado, o marcado como resuelto sin ayuda.
+    urgent_cases: Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados con “compromiso enviado”, o marcado como “resuelto sin ayuda”.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -114,3 +114,33 @@ es:
         pledge_sent: Promesa Enviada
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
+    call_list: >-
+      Esta lista clasificable se usa para hacer un seguimiento de los
+      pacientes para devolver la llamada durante su turno. Utiliza la
+      búsqueda para rellenarla.
+    budget_bar: >-
+      La barra de presupuesto enumera dinero provisionalmente reservado
+      para un paciente (ingresando un valor en el campo de compromiso %{FUND})
+      y el dinero enviado a una clínica para un paciente (marcando la casilla
+      de verificación Enviaré la promesa) durante una semana determinada.
+      Se reinicia los lunes.
+    completed_calls: >-
+      Esta es una lista de pacientes a los que ha llamado en las últimas 8 horas.
+    urgent_cases: >-
+      Estos son pacientes que requieren un poco más de atención. Esta lista es
+      compartido entre todos los administradores de casos que trabajan en una
+      sola línea. Los pacientes son eliminados de esta lista automáticamente
+      después de que estén marcados como que tienen. Un compromiso enviado,
+      o marcado como resuelto sin ayuda.
+    record_new_external_pledge: >-
+      Promesas externas es nuestro término para promesas hechas por otros
+      fondos de aborto también trabajando con un paciente.
+    resolved_without_fund: >-
+      Esto se utiliza para indicar que un paciente no requiere o quiere
+      nuestros servicios por más tiempo.
+    referred_to_clinic: >-
+      Marque esta casilla si usted, como administrador de casos, refirió al
+      paciente a un clínica particular.
+    mandatory_ultrasound: >-
+      Si se encuentra en un estado que requiere ultrasonidos y el paciente
+      ha completado uno, puede iniciar sesión aquí.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR adds i18n to the tooltips in tooltips_helper. These are spread out over a few views but were all trivial to port.

This pull request makes the following changes:
* Ports tooltips_helper to use i18n

![image](https://user-images.githubusercontent.com/3866868/52763440-b3169d80-2fe9-11e9-899c-29705d7505f0.png)

It relates to the following issue #s: 
* Fixes #1575 (I think!)
