### PR TITLE
WIP Clinic views translations

### DIFF
--- a/app/views/clinics/index.html.erb
+++ b/app/views/clinics/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Clinics</h1>
+<h1><%=t'clinics.index.header'%></h1>
 <p><%= link_to 'Add a new clinic', new_clinic_path %></p>
 
 <table class="table table-hover" id='clinics_table'>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,3 +114,19 @@ en:
         pledge_sent: Pledge Sent
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
+    clinics:
+      index:
+        header: Clinics
+        add_new: Add a new clinic
+        th:
+          name: Clinic name
+          address: Address
+          city: City
+          state: State
+          zip: ZIP
+          naf: NAF
+          medicaid: Medicaid
+          gest: Gestational Limit (Days)
+        td:
+          yes: Yes
+          no: No


### PR DESCRIPTION
I added keys and values for views/clinics/index.html in en.yml and input `t'clinics.index.header'` into the `h1` tag on that page. Instead of getting 'Clinics', as expected, I got 'Header' as you can see below:

![screen shot 2019-02-13 at 9 53 39 pm](https://user-images.githubusercontent.com/7850267/52759436-e05b4f80-2fd9-11e9-9ff6-996db052f19d.png)

I will continue to plug away at this when I can, but let me know if someone knows what's causing the unexpected result. 
