### PR TITLE
Spanish view refres

### DIFF
--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -2,7 +2,7 @@
 $('#patient_appointment_date')
   .parent()
   .find('span.help-block')
-  .text('Approx gestation at appt: <%= @patient.last_menstrual_period_at_appt %>');
+  .text("<%= t('patient.dashboard.approx_gestation', gest: @patient.last_menstrual_period_at_appt) %>");
 
 // rerack status
 $('#patient_status').text('<%= @patient.status %>');
@@ -11,7 +11,7 @@ $('#patient_status').text('<%= @patient.status %>');
 $('#patient_last_menstrual_period_weeks')
   .parent()
   .find('span.help-block')
-  .text('Currently: <%= @patient.last_menstrual_period_display_short %>');
+  .text("<%= t('patient.dashboard.currently', LMP: @patient.last_menstrual_period_display_short) %>");
 
 // refresh changelog
 $('#change_log').html(
@@ -57,7 +57,7 @@ $('#patient_fulfillment_audited')
   .parent()
   .parent()
   .find('p.archive-note')
-  .text('Patient will be archived on <%= @patient.archive_date %>');
+  .text("<%= t('patient.pledge_fulfillment.audit.archive_note', date: l(@patient.archive_date, format: :medium)) %>");
 
 // flash the result
 $('#flash').html('<%= escape_javascript(render partial: "layouts/messages") %>');


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We missed a spot in the patient edit view when updating fields. This adds the i18n keys to the translations.

This pull request makes the following changes:
* Use i18n instead of hardset strings in app/views/patients/update.js.erb

![image](https://user-images.githubusercontent.com/3866868/53777392-34659f80-3ec7-11e9-88e4-ce8976a0c31c.png)


It relates to the following issue #s: 
* Bumps #1633 
