### PR TITLE
Translate remove call alert

### DIFF
--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -24,7 +24,12 @@
             <td><%= call.created_by.name %></td>
             <td>
               <% if call.created_by == current_user && call.recent? %>
-                <%= button_to t('patient.call_log.table.remove_button'), patient_call_path(@patient, call), remote: true, method: :delete, data: { confirm: "Are you sure you want to remove this call from the call log?" }, class: "btn btn-danger" %>
+                <%= button_to t('patient.call_log.table.remove_button'),
+                              patient_call_path(@patient, call), 
+                              remote: true,
+                              method: :delete,
+                              data: { confirm: t('patient.call_log.delete_confirm') },
+                              class: "btn btn-danger" %>
               <% end %>
             </td>
           </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,6 +240,7 @@ en:
         result: RESULT
         time: TIME
       title: Call Log
+      delete_confirm: "Are you sure you want to remove this call from the call log?"
     change_log:
       table:
         case_manager: CM

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,7 @@ en:
         title: Cost details
       title: Abortion information
     call_log:
+      delete_confirm: Are you sure you want to remove this call from the call log?
       record_new_call: Record new call
       table:
         actions: ACTIONS
@@ -240,7 +241,6 @@ en:
         result: RESULT
         time: TIME
       title: Call Log
-      delete_confirm: "Are you sure you want to remove this call from the call log?"
     change_log:
       table:
         case_manager: CM

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -240,6 +240,7 @@ es:
         result: RESULTADO
         time: HORA
       title: Registro de Llamadas
+      delete_confirm: "¿Está seguro de que desea eliminar esta llamada del registro de llamadas?"
     change_log:
       table:
         case_manager: CM

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -231,6 +231,7 @@ es:
         title: Detalles del costo
       title: Informacion de aborto
     call_log:
+      delete_confirm: "¿Está seguro de que desea eliminar esta llamada del registro de llamadas?"
       record_new_call: Grabar nueva llamada
       table:
         actions: ACCIONES
@@ -240,7 +241,6 @@ es:
         result: RESULTADO
         time: HORA
       title: Registro de Llamadas
-      delete_confirm: "¿Está seguro de que desea eliminar esta llamada del registro de llamadas?"
     change_log:
       table:
         case_manager: CM


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Translate the i18n key for call delete.

This pull request makes the following changes:
* Translate the sneaky i18n key for call delete

![image](https://user-images.githubusercontent.com/3866868/53777895-de91f700-3ec8-11e9-9628-cb956f0a8190.png)


It relates to the following issue #s: 
* Bumps #1633 
