### PR TITLE
Most recent note translate

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -3,7 +3,7 @@ module NotesHelper
   def plus_sign_glyphicon(note)
     return nil unless note && note.try(:full_text).length > 31
     note = tag(:span, class: 'glyphicon glyphicon-plus-sign',
-                      title: 'Most recent note',
+                      title: t('note.most_recent_no_user'),
                       aria: { hidden: true },
                       data: { toggle: 'popover', placement: 'bottom',
                               content: note.full_text })

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -22,6 +22,7 @@
         <th></th>
       </tr>
     </thead>
+
     <tbody id="<%= table_type %>_content">
       <% patients.each do |patient| %>
         <tr class="patient-data" id="<%= patient.id %>">
@@ -34,6 +35,7 @@
           <td><%= patient.status %></td>
           <td><%= patient.appointment_date_display %></td>
           <td><%= patient.most_recent_note_display_text %> <%= plus_sign_glyphicon(patient.most_recent_note) %></td>
+
           <% if table_type == 'completed_calls' || table_type == 'urgent_cases' %>
             <td class="blank-td"></td>
           <% else %>
@@ -43,6 +45,7 @@
               <td><%= link_to t('common.add'), add_patient_path(patient), method: :patch, remote: true %></td>
             <% end %>
           <% end %>
+
           <td>
             <%= link_to call_glyphicon,
                         new_patient_call_path(patient),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,8 +211,8 @@ en:
       sign_in: Sign In
       sign_out: Sign Out
   note:
-    most_recent_no_user: Most recent note
     most_recent: 'Most recent note from %{by} at %{at}:'
+    most_recent_no_user: Most recent note
   patient:
     abortion_information:
       clinic_section:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
       sign_in: Sign In
       sign_out: Sign Out
   note:
+    most_recent_no_user: Most recent note
     most_recent: 'Most recent note from %{by} at %{at}:'
   patient:
     abortion_information:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -211,8 +211,8 @@ es:
       sign_in: Registrarse
       sign_out: Desconectar
   note:
-    most_recent_no_user: "La nota más reciente"
     most_recent: 'La nota más reciente de %{by} en %{at}:'
+    most_recent_no_user: La nota más reciente
   patient:
     abortion_information:
       clinic_section:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -211,6 +211,7 @@ es:
       sign_in: Registrarse
       sign_out: Desconectar
   note:
+    most_recent_no_user: "La nota más reciente"
     most_recent: 'La nota más reciente de %{by} en %{at}:'
   patient:
     abortion_information:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Missed a spot on the dashboard.

This pull request makes the following changes:
* Translates Most Recent Note, an i18n key I missed on the dashboard

![image](https://user-images.githubusercontent.com/3866868/53778406-94aa1080-3eca-11e9-8a66-c238d4ccaa4b.png)


It relates to the following issue #s: 
* Bumps #1633 
