### PR TITLE
Turn on spanish link in production

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -8,13 +8,11 @@ module NavbarHelper
   end
 
   def spanish_or_english_link
-    if !Rails.env.production?
-      content_tag :li do
-        if I18n.locale == I18n.default_locale 
-          link_to "Español", { :locale=>'es' }
-        else
-          link_to "English", { :locale=>'en' }
-        end
+    content_tag :li do
+      if I18n.locale == I18n.default_locale 
+        link_to "Español", { :locale=>'es' }
+      else
+        link_to "English", { :locale=>'en' }
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Remove a conditional to turn spanish on in production mode. Merge when it's showtime!

This pull request makes the following changes:
* remove a conditional to turn on spanish language mode

It relates to the following issue #s: 
* Fixes #1382 
