### PR TITLE
User page in Spanish!

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,6 +34,11 @@ class UsersController < ApplicationController
   end
 
   def update
+    # i18n-tasks-use t('mongoid.attributes.user.current_password')
+    # i18n-tasks-use t('mongoid.attributes.user.name')
+    # i18n-tasks-use t('mongoid.attributes.user.password')
+    # i18n-tasks-use t('mongoid.attributes.user.password_confirmation')
+    # i18n-tasks-use t('mongoid.attributes.user.role')
     if @user.update_attributes(user_params)
       flash[:notice] = t('flash.user_update_success')
       redirect_to users_path

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,26 +1,26 @@
 <div class="authform">
-  <h2>User panel for <%= current_user.email %> (<%= current_user.name %>)</h2>
+  <h2> <%= t('user.profile_edit.user_panel', email: current_user.email, name: current_user.name) %></h2>
 
   <%= bootstrap_form_for resource, as: resource_name, url: '/users', html: { method: :put } do |f| %>
     <%= devise_error_messages! %>
 
     <%= f.static_control :email %>
     <%= f.static_control :role %>
-    <%= f.text_field :name, label: 'First and last name' %>
+    <%= f.text_field :name %>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <div><%= t('user.profile_edit.awaiting_confirmation', email: resource.unconfirmed_email) %></div>
     <% end %>
 
-    <h3>Change your password</h3>
+    <h3><%= t('user.profile_edit.change_password') %></h3>
     <%= f.password_field :password, autocomplete: 'off' %>
     <%= f.password_field :password_confirmation, autocomplete: 'off' %>
 
-    <h3>Enter your current password to confirm any changes</h3>
+    <h3><%= t('user.profile_edit.current_password') %></h3>
     <%= f.password_field :current_password, autocomplete: 'off' %>
 
-    <%= f.submit "Update info", class: 'btn btn-primary' %>
+    <%= f.submit t('user.profile_edit.update_info_button'), class: 'btn btn-primary' %>
   <% end %>
   <br>
-  <%= link_to "Back", :back %>
+  <%= link_to t('common.back'), :back %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,7 +201,12 @@ en:
         street_address: Street address
         zip: ZIP
       user:
+        current_password: Current Password
         email: Email
+        name: First and last name
+        password: Password
+        password_confirmation: Password confirmation
+        role: Role
   navigation:
     admin_tools:
       accounting: Accounting
@@ -481,6 +486,12 @@ en:
       user_account_management: User Account Management
     new:
       create_user: Create User
+    profile_edit:
+      awaiting_confirmation: 'Currently waiting for confirmation for: %{email}'
+      change_password: Change your password
+      current_password: Enter your current password to confirm any changes
+      update_info_button: Update info
+      user_panel: User panel for %{email} (%{name})
     search:
       button: Search
       text_field: Name or Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,7 +201,7 @@ en:
         street_address: Street address
         zip: ZIP
       user:
-        current_password: Current Password
+        current_password: Current password
         email: Email
         name: First and last name
         password: Password

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -199,10 +199,10 @@ es:
         phone: Teléfono
         state: Estado
         street_address: Dirección
-        zip: Código postal```
+        zip: Código postal
       user:
         current_password: Contraseña actual
-        email: Email
+        email: Correo Electrónico/Email
         name: Nombre y apellido
         password: Contraseña
         password_confirmation: Confirmación de contraseña

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -201,7 +201,12 @@ es:
         street_address: Dirección
         zip: Código postal```
       user:
+        current_password: Contraseña actual
         email: Email
+        name: Nombre y apellido
+        password: Contraseña
+        password_confirmation: Confirmación de contraseña
+        role: Papel
   navigation:
     admin_tools:
       accounting: Contabilidad
@@ -481,6 +486,12 @@ es:
       user_account_management: Administración de Cuentas de Usuario
     new:
       create_user: Crear Usuario
+    profile_edit:
+      awaiting_confirmation: 'Actualmente en espera de confirmación para: %{email}'
+      change_password: Cambia tu contraseña
+      current_password: Ingrese su contraseña actual para confirmar cualquier cambio
+      update_info_button: Actualizar información
+      user_panel: Panel de usuario para %{email} (%{name})
     search:
       button: Buscar
       text_field: Nombre o Correo Electrónico

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -156,7 +156,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
 
       it 'should flash an error' do
-        assert_equal "Error saving user details - Name can't be blank",
+        assert_equal "Error saving user details - First and last name can't be blank",
                      flash[:alert]
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Not sure how I forgot the user page in the translation list, but shrug! Here it is.

This pull request makes the following changes:
* Translate the user page

![Screenshot from 2019-03-09 12-10-14](https://user-images.githubusercontent.com/6129479/54074870-f91bf580-4265-11e9-9716-c3cc6566d227.png)


It relates to the following issue #s: 
* Bumps #1648 

Ready for spanish review @montanezp
