### PR TITLE
Fix insurance options spanish bug

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -60,13 +60,20 @@ module PatientsHelper
     ]
   end
 
-  def insurance_options
+  def insurance_options(current_value = nil)
     standard_options = [
       [ t('patient.helper.insurance.none'), 'No insurance' ],
       [ t('patient.helper.insurance.unknown'), 'Don\'t know' ],
       [ t('patient.helper.insurance.other'), 'Other (add to notes)' ],
     ]
-    [nil] + Config.find_or_create_by(config_key: 'insurance').options + standard_options
+    full_set = [[nil]] + Config.find_or_create_by(config_key: 'insurance').options + standard_options
+    # if the current value isn't in the list, push it on.
+    # kinda ugly because we're working with a few different datatypes in here.
+    if current_value.present? && full_set.map { |opt| opt.is_a?(Array) ? opt[-1] : opt }.exclude?(current_value)
+      full_set.push current_value
+    end
+
+    full_set.uniq
   end
 
   def practical_support_options

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -66,7 +66,7 @@ module PatientsHelper
       [ t('patient.helper.insurance.unknown'), 'Don\'t know' ],
       [ t('patient.helper.insurance.other'), 'Other (add to notes)' ],
     ]
-    full_set = [[nil]] + Config.find_or_create_by(config_key: 'insurance').options + standard_options
+    full_set = [nil] + Config.find_or_create_by(config_key: 'insurance').options + standard_options
     # if the current value isn't in the list, push it on.
     # kinda ugly because we're working with a few different datatypes in here.
     if current_value.present? && full_set.map { |opt| opt.is_a?(Array) ? opt[-1] : opt }.exclude?(current_value)

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -82,9 +82,9 @@
           </div>
 
           <%= f.select :insurance,
-                       options_for_select(insurance_options.push(patient.insurance).uniq,
+                       options_for_select(insurance_options(patient.insurance),
                                           patient.insurance),
-                                          label: t('patient.information.insurance')%>
+                                          label: t('patient.information.insurance') %>
           <%= f.select :referred_by,
                        options_for_select(referred_by_options,
                                           patient.referred_by),

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -37,6 +37,16 @@ class PatientsHelperTest < ActionView::TestCase
                                     [ 'Other (add to notes)', 'Other (add to notes)'] ]
         assert_same_elements insurance_options, expected_insurance_options_array
       end
+
+      it 'should append any non-nil passed options to the end' do
+        expected_insurance_options_array = [nil, 'DC Medicaid', 'Other state Medicaid', 
+                                    [ 'No insurance', 'No insurance' ],
+                                    [ 'Don\'t know', 'Don\'t know' ],
+                                    [ 'Other (add to notes)', 'Other (add to notes)'],
+                                    'Friendship' ]
+        assert_same_elements expected_insurance_options_array,
+                             insurance_options('Friendship')
+      end
     end
 
     describe 'without a config' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Insurance options has a bug because we're pushing value onto it if not present, so that deprecated values aren't auto-removed on save. We should probably be doing this in more places tbh and I might add it to other option methods. But this gets us out of the doghouse immediately.

To test:

* switch to spanish mode and go to a patient
* change insurance to `no se`
* reload page and observe it being `no se` still
* Change it to nil, reload, observe nil properly observed
* Change it to a custom (nonspanish) option, observe it again

This pull request makes the following changes:
* fix spanish bug around setting insurance options

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Bumps #1648 
