### PR TITLE
Colin forgot how booleans work, so fix docker build

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,5 +58,5 @@ Rails.application.configure do
   Mongo::Logger.logger.level = ::Logger::FATAL
 
   # Don't check yarn package integrity in docker
-  config.webpacker.check_yarn_integrity = !!ENV.fetch('DOCKER', true)
+  config.webpacker.check_yarn_integrity = ENV['DOCKER'] ? false : true
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

integrity checks were still going because I forgot how booleans.

This pull request makes the following changes:
* make boolean evaluate properly
