### PR TITLE
Translate most changelog fields, use model keys for translations in patient information form items

### DIFF
--- a/app/helpers/change_log_helper.rb
+++ b/app/helpers/change_log_helper.rb
@@ -10,7 +10,8 @@ module ChangeLogHelper
   # Map changelog entries to a html string
   def changelog_entry_display(shaped_changes)
     shaped_changes.map do |entry|
-      field = content_tag('strong') { "#{entry[0].humanize}:" }.freeze
+      field = t("mongoid.attributes.patient.#{entry[0]}")
+      field = content_tag('strong') { "#{field}:" }.freeze
       orig = entry[1][:original]
       separator = '->'.freeze
       mod = entry[1][:modified]

--- a/app/views/patients/_new_patient.html.erb
+++ b/app/views/patients/_new_patient.html.erb
@@ -41,7 +41,7 @@
       </div>
 
       <div class="col-sm-2">
-        <%= f.select :line, options_for_select(lines, current_line), label: t('patient.information.line') %>
+        <%= f.select :line, options_for_select(lines, current_line) %>
       </div>
 
       <div class="col-sm-2 btn-space">

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -12,14 +12,12 @@
           <% if current_user.admin? %>
             <%= f.select :line,
                        options_for_select(lines,
-                                          patient.line),
-                                          label: t('patient.information.line') %>
+                                          patient.line) %>
           <% end %>
-          <%= f.number_field :age, label: t('patient.information.age'), autocomplete: 'off' %>
+          <%= f.number_field :age, autocomplete: 'off' %>
           <%= f.select :race_ethnicity,
                        options_for_select(race_ethnicity_options,
                                           patient.race_ethnicity),
-                                          label: t('patient.information.race_ethnicity'),
                                           autocomplete: 'off' %>
 
           <%= f.form_group :language do %>
@@ -38,14 +36,14 @@
 
           <div class="row">
             <div class="col-sm-8">
-              <%= f.text_field :city, label: t('patient.information.city'), autocomplete: 'off' %>
+              <%= f.text_field :city, autocomplete: 'off' %>
             </div>
             <div class="col-sm-4">
-              <%= f.text_field :state, label: t('patient.information.state'), autocomplete: 'off' %>
+              <%= f.text_field :state, autocomplete: 'off' %>
             </div>
           </div>
 
-          <%= f.text_field :county, label: t('patient.information.county'), autocomplete: 'off' %>
+          <%= f.text_field :county, autocomplete: 'off' %>
 
           <h3><%= t 'patient.information.other_contact.title' %></h3>
             <%= f.text_field :other_contact, autocomplete: 'off', label: t('patient.information.other_contact.name') %>
@@ -57,27 +55,23 @@
           <%= f.select :employment_status,
                        options_for_select(employment_status_options,
                                           patient.employment_status),
-                                          autocomplete: 'off',
-                                          label: t('patient.information.employment_status')%>
+                                          autocomplete: 'off' %>
           <%= f.select :income,
                        options_for_select(income_options,
                                           patient.income),
                                           help: t('patient.information.income_help'),
-                                          autocomplete: 'off',
-                                          label: t('patient.information.income')%>
+                                          autocomplete: 'off' %>
           <div class="row">
             <div class="col-sm-6">
               <%= f.select :household_size_adults,
                             options_for_select(household_size_options,
                                                patient.household_size_adults),
-                                               label: t('patient.information.household_adults'),
                                                help: t('patient.information.household_help') %>
             </div>
             <div class="col-sm-6">
               <%= f.select :household_size_children,
                             options_for_select(household_size_options,
-                                               patient.household_size_children),
-                                               label: t('patient.information.household_minors') %>
+                                               patient.household_size_children) %>
             </div>
           </div>
 

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -3,7 +3,7 @@
 <h1><%= t('patient.data_entry.patient_entry') %></h1>
 
 <%= bootstrap_form_for @patient, url: data_entry_create_path, html: { class: 'mass_entry_form' } do |f| %>
-  <%= f.select :line, options_for_select(lines, current_line), label: t('patient.information.line') %>
+  <%= f.select :line, options_for_select(lines, current_line) %>
 
   <%= f.date_field :initial_call_date, label: t('patient.new.initial_call_date') %>
 
@@ -24,9 +24,9 @@
     </div>
   </div>
 
-  <%= f.text_field :city,  label: t('patient.information.city'), autocomplete: 'off' %>
-  <%= f.text_field :state, label: t('patient.information.state'), autocomplete: 'off' %>
-  <%= f.text_field :county, label: t('patient.information.county'), autocomplete: 'off' %>
+  <%= f.text_field :city, autocomplete: 'off' %>
+  <%= f.text_field :state, autocomplete: 'off' %>
+  <%= f.text_field :county, autocomplete: 'off' %>
 
   <!-- Notes doesn't work because strong params :( -->
   <%#= f.fields_for @patient.notes.new do |notes| %>
@@ -35,8 +35,8 @@
 
   <%= f.number_field :fund_pledge, label: t('patient.abortion_information.cost_section.fund_pledge', fund: "#{FUND}"), autocomplete: 'off' %>
 
-  <%= f.number_field :age, label: t('patient.information.age'), autocomplete: 'off' %>
-  <%= f.select :race_ethnicity, options_for_select(race_ethnicity_options), label: t('patient.information.race_ethnicity'), autocomplete: 'off' %>
+  <%= f.number_field :age, autocomplete: 'off' %>
+  <%= f.select :race_ethnicity, options_for_select(race_ethnicity_options), autocomplete: 'off' %>
   <%= f.select :clinic_id, options_for_select(clinic_options), label: t('patient.pledge_fulfillment.confirmation.clinic') %>
 
   <%= f.date_field :appointment_date, label: t('patient.shared.appt_date'), autocomplete: 'off' %>
@@ -49,29 +49,25 @@
     <div class="col-sm-6">
       <%= f.select :household_size_adults,
                     options_for_select(household_size_options),
-                                       label: t('patient.information.household_adults'),
-                                       help: t('patient.information.household_help') %>
+                    help: t('patient.information.household_help') %>
     </div>
     <div class="col-sm-6">
       <%= f.select :household_size_children,
-                    options_for_select(household_size_options),
-                                       label: t('patient.information.household_minors') %>
+                    options_for_select(household_size_options) %>
     </div>
   </div>
 
   <%= f.select :employment_status,
                options_for_select(employment_status_options),
-               label: t('patient.information.employment_status'),
-                                  autocomplete: 'off' %>
+               autocomplete: 'off' %>
   <%= f.select :income,
                options_for_select(income_options),
-               label: t('patient.information.income'),
-                                  autocomplete: 'off' %>
+               autocomplete: 'off' %>
 
   <%= f.select :referred_by,
                options_for_select(referred_by_options),
                label: t('patient.helper.referred_by.title'),
-                                  autocomplete: 'off' %>
+               autocomplete: 'off' %>
 
     <%= f.number_field :procedure_cost, label: t('patient.pledge_fulfillment.form.procedure_cost') %>
     <%= f.number_field :patient_contribution, label: t('patient.abortion_information.cost_section.patient_contribution'), autocomplete: 'off', prepend: '$' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,44 @@ en:
         password: Password
         password_confirmation: Password confirmation
         role: Role
+      patient:
+        name: Name
+        primary_phone: Primary phone
+        other_contact: Other contact
+        other_phone: Other phone
+        other_contact_relationship: Other contact relationship
+        voicemail_preference: Voicemail preference
+        line: Line
+        language: Language
+        initial_call_date: Initial call date 
+        urgent_flag: Urgent flag
+        last_menstrual_period_weeks: Last menstrual period weeks
+        last_menstrual_period_days: Last menstrual period days
+        age: Age
+        city: City
+        state: State
+        county: County
+        race_ethnicity: Race / Ethnicity
+        employment_status: Employment status
+        household_size_children: Minors in household
+        household_size_adults: Adults in household
+        insurance: Insurance
+        income: Income
+        special_circumstances: Special circumstances
+        referred_by: Referred by
+        referred_to_clinic: Referred to clinic
+        completed_ultrasound: Completed ultrasound?
+        appointment_date: Appointment date
+        procedure_cost: Procedure cost
+        patient_contribution: Patient contribution
+        naf_pledge: NAF pledge
+        fund_pledge: Fund pledge
+        fund_pledged_at: Fund pledged at
+        pledge_sent: Pledge sent
+        resolved_without_fund: Resolved without fund
+        pledge_generated_at: Pledge generated at
+        pledge_sent_at: Pledge sent at
+        textable: Textable
   navigation:
     admin_tools:
       accounting: Accounting
@@ -344,24 +382,15 @@ en:
         one: "%{count} week"
         other: "%{count} weeks"
     information:
-      age: Age
-      city: City
-      county: County
-      employment_status: Employment Status
-      household_adults: Adults in household
       household_help: "(including patient)"
-      household_minors: Minors in household
-      income: Income
       income_help: Employment, Food Stamps, SS, TANF, etc.
       insurance: Patient insurance
       language: Preferred Language
-      line: Line
       other_contact:
         name: Other contact name
         phone: Other phone
         relationship: Relationship to other contact
         title: Other Contact
-      race_ethnicity: Race / Ethnicity
       referred_by: How patient heard about %{fund}
       special_circumstances:
         domestic_violence: Domestic violence
@@ -372,10 +401,9 @@ en:
         prison: Prison
         rape: Rape
         title: Special Circumstances
-      state: State
       textable: Textable?
       title: Patient information
-      voicemail_preference: Voicemail Preference
+      voicemail_preference: Voicemail preference
     menu:
       abortion_information: Abortion Information
       call_log: Call Log

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,44 @@ en:
         state: State
         street_address: Street address
         zip: ZIP
+      patient:
+        age: Age
+        appointment_date: Appointment date
+        city: City
+        completed_ultrasound: Completed ultrasound?
+        county: County
+        employment_status: Employment status
+        fund_pledge: Fund pledge
+        fund_pledged_at: Fund pledged at
+        household_size_adults: Adults in household
+        household_size_children: Minors in household
+        income: Income
+        initial_call_date: Initial call date
+        insurance: Insurance
+        language: Language
+        last_menstrual_period_days: Last menstrual period days
+        last_menstrual_period_weeks: Last menstrual period weeks
+        line: Line
+        naf_pledge: NAF pledge
+        name: Name
+        other_contact: Other contact
+        other_contact_relationship: Other contact relationship
+        other_phone: Other phone
+        patient_contribution: Patient contribution
+        pledge_generated_at: Pledge generated at
+        pledge_sent: Pledge sent
+        pledge_sent_at: Pledge sent at
+        primary_phone: Primary phone
+        procedure_cost: Procedure cost
+        race_ethnicity: Race / Ethnicity
+        referred_by: Referred by
+        referred_to_clinic: Referred to clinic
+        resolved_without_fund: Resolved without fund
+        special_circumstances: Special circumstances
+        state: State
+        textable: Textable
+        urgent_flag: Urgent flag
+        voicemail_preference: Voicemail preference
       user:
         current_password: Current password
         email: Email
@@ -209,44 +247,6 @@ en:
         password: Password
         password_confirmation: Password confirmation
         role: Role
-      patient:
-        name: Name
-        primary_phone: Primary phone
-        other_contact: Other contact
-        other_phone: Other phone
-        other_contact_relationship: Other contact relationship
-        voicemail_preference: Voicemail preference
-        line: Line
-        language: Language
-        initial_call_date: Initial call date 
-        urgent_flag: Urgent flag
-        last_menstrual_period_weeks: Last menstrual period weeks
-        last_menstrual_period_days: Last menstrual period days
-        age: Age
-        city: City
-        state: State
-        county: County
-        race_ethnicity: Race / Ethnicity
-        employment_status: Employment status
-        household_size_children: Minors in household
-        household_size_adults: Adults in household
-        insurance: Insurance
-        income: Income
-        special_circumstances: Special circumstances
-        referred_by: Referred by
-        referred_to_clinic: Referred to clinic
-        completed_ultrasound: Completed ultrasound?
-        appointment_date: Appointment date
-        procedure_cost: Procedure cost
-        patient_contribution: Patient contribution
-        naf_pledge: NAF pledge
-        fund_pledge: Fund pledge
-        fund_pledged_at: Fund pledged at
-        pledge_sent: Pledge sent
-        resolved_without_fund: Resolved without fund
-        pledge_generated_at: Pledge generated at
-        pledge_sent_at: Pledge sent at
-        textable: Textable
   navigation:
     admin_tools:
       accounting: Accounting

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -202,6 +202,44 @@ es:
         state: Estado
         street_address: Dirección
         zip: Código postal
+      patient:
+        age: Edad
+        appointment_date: Día de la cita
+        city: Ciudad
+        completed_ultrasound: Ultrasonido completado
+        county: Condado
+        employment_status: Estatus de empleo
+        fund_pledge: Promesa de fondos
+        fund_pledged_at: Fondo prometido en
+        household_size_adults: Adultos en el Hogar
+        household_size_children: Menores en el Hogar
+        income: Ingresos
+        initial_call_date: Fecha de llamada inicial
+        insurance: Seguro médico
+        language: Idioma
+        last_menstrual_period_days: Últimos días del período menstrual
+        last_menstrual_period_weeks: Últimas semanas del período menstrual
+        line: Línea
+        naf_pledge: Promesa de la NAF
+        name: Nombre
+        other_contact: Otro contacto
+        other_contact_relationship: Otra relacion de contacto
+        other_phone: Otro teléfono
+        patient_contribution: Contribución del paciente
+        pledge_generated_at: Promesa generada en
+        pledge_sent: Promeso enviada
+        pledge_sent_at: Promesa enviada en
+        primary_phone: Número de teléfono principal
+        procedure_cost: Costo del procedimiento
+        race_ethnicity: Raza / Etnicidad
+        referred_by: Referido por
+        referred_to_clinic: Referido a la clínica
+        resolved_without_fund: Resuelto sin ayuda de fondo
+        special_circumstances: Circunstancias Especiales
+        state: Estado
+        textable: Textable
+        urgent_flag: Bandera urgente
+        voicemail_preference: Preferencia de correo de voz
       user:
         current_password: Contraseña actual
         email: Correo Electrónico/Email
@@ -209,44 +247,6 @@ es:
         password: Contraseña
         password_confirmation: Confirmación de contraseña
         role: Papel
-      patient:
-        name: Nombre
-        line: Línea
-        primary_phone: Número de teléfono principal
-        other_contact: Otro contacto
-        other_phone: Otro teléfono
-        other_contact_relationship: Otra relacion de contacto
-        voicemail_preference: Preferencia de correo de voz
-        language: Idioma
-        initial_call_date: Fecha de llamada inicial
-        urgent_flag: Bandera urgente
-        last_menstrual_period_weeks: Últimas semanas del período menstrual
-        last_menstrual_period_days: Últimos días del período menstrual
-        age: Edad
-        city: Ciudad
-        state: Estado
-        county: Condado
-        race_ethnicity: Raza / Etnicidad
-        employment_status: Estatus de empleo
-        household_size_children: Menores en el Hogar
-        household_size_adults: Adultos en el Hogar
-        insurance: Seguro médico
-        income: Ingresos
-        special_circumstances: Circunstancias Especiales
-        referred_by: Referido por
-        referred_to_clinic: Referido a la clínica
-        completed_ultrasound: Ultrasonido completado
-        appointment_date: Día de la cita
-        procedure_cost: Costo del procedimiento
-        patient_contribution: Contribución del paciente
-        naf_pledge: Promesa de la NAF
-        fund_pledge: Promesa de fondos
-        fund_pledged_at: Fondo prometido en
-        pledge_sent: Promeso enviada
-        resolved_without_fund: Resuelto sin ayuda de fondo
-        pledge_generated_at: Promesa generada en
-        pledge_sent_at: Promesa enviada en
-        textable: Textable
   navigation:
     admin_tools:
       accounting: Contabilidad
@@ -384,8 +384,8 @@ es:
     information:
       household_help: "(incluyendo paciente)"
       income_help: Empleo, Cupones de Alimentos, SS, TANF, etc.
-      language: Idioma preferido
       insurance: Seguro médico del patiente
+      language: Idioma preferido
       other_contact:
         name: Nombre de Otro Contacto
         phone: Otro teléfono

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -209,6 +209,44 @@ es:
         password: Contraseña
         password_confirmation: Confirmación de contraseña
         role: Papel
+      patient:
+        name: Nombre
+        line: Línea
+        primary_phone: Número de teléfono principal
+        other_contact: Otro contacto
+        other_phone: Otro teléfono
+        other_contact_relationship: Otra relacion de contacto
+        voicemail_preference: Preferencia de correo de voz
+        language: Idioma
+        initial_call_date: Fecha de llamada inicial
+        urgent_flag: Bandera urgente
+        last_menstrual_period_weeks: Últimas semanas del período menstrual
+        last_menstrual_period_days: Últimos días del período menstrual
+        age: Edad
+        city: Ciudad
+        state: Estado
+        county: Condado
+        race_ethnicity: Raza / Etnicidad
+        employment_status: Estatus de empleo
+        household_size_children: Menores en el Hogar
+        household_size_adults: Adultos en el Hogar
+        insurance: Seguro médico
+        income: Ingresos
+        special_circumstances: Circunstancias Especiales
+        referred_by: Referido por
+        referred_to_clinic: Referido a la clínica
+        completed_ultrasound: Ultrasonido completado
+        appointment_date: Appointment date
+        procedure_cost: Procedure cost
+        patient_contribution: Patient contribution
+        naf_pledge: NAF pledge
+        fund_pledge: Fund pledge
+        fund_pledged_at: Fund pledged at
+        pledge_sent: Pledge sent
+        resolved_without_fund: Resolved without fund
+        pledge_generated_at: Pledge generated at
+        pledge_sent_at: Pledge sent at
+        textable: Textable
   navigation:
     admin_tools:
       accounting: Contabilidad
@@ -344,24 +382,15 @@ es:
         one: "%{count} semana"
         other: "%{count} semanas"
     information:
-      age: Edad
-      city: Ciudad
-      county: Condado
-      employment_status: Estatus de Empleo
-      household_adults: Adultos en el Hogar
       household_help: "(incluyendo paciente)"
-      household_minors: Menores en el Hogar
-      income: Ingresos
       income_help: Empleo, Cupones de Alimentos, SS, TANF, etc.
-      insurance: Seguro Médico del Paciente
-      language: Idioma Preferido
-      line: Linea
+      language: Idioma preferido
+      insurance: Seguro médico del patiente
       other_contact:
         name: Nombre de Otro Contacto
         phone: Otro teléfono
         relationship: Relación con Otro Contacto
         title: Otro Contacto
-      race_ethnicity: Raza / Etnicidad
       referred_by: Cómo escuchó el paciente sobre %{fund}
       special_circumstances:
         domestic_violence: Violencia doméstica
@@ -372,7 +401,6 @@ es:
         prison: Prisión
         rape: Violación
         title: Circunstancias Especiales
-      state: Estado
       textable: Se permite enviar mensajes de texto?
       title: Información del Paciente
       voicemail_preference: Preferencias de Mensaje de Voz

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -236,16 +236,16 @@ es:
         referred_by: Referido por
         referred_to_clinic: Referido a la clínica
         completed_ultrasound: Ultrasonido completado
-        appointment_date: Appointment date
-        procedure_cost: Procedure cost
-        patient_contribution: Patient contribution
-        naf_pledge: NAF pledge
-        fund_pledge: Fund pledge
-        fund_pledged_at: Fund pledged at
-        pledge_sent: Pledge sent
-        resolved_without_fund: Resolved without fund
-        pledge_generated_at: Pledge generated at
-        pledge_sent_at: Pledge sent at
+        appointment_date: Día de la cita
+        procedure_cost: Costo del procedimiento
+        patient_contribution: Contribución del paciente
+        naf_pledge: Promesa de la NAF
+        fund_pledge: Promesa de fondos
+        fund_pledged_at: Fondo prometido en
+        pledge_sent: Promeso enviada
+        resolved_without_fund: Resuelto sin ayuda de fondo
+        pledge_generated_at: Promesa generada en
+        pledge_sent_at: Promesa enviada en
         textable: Textable
   navigation:
     admin_tools:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

So two things here:

* This dumps model fields into i18n
* I wanted to see if they got automagically read by bootstrap_forms and turns out they do! So I changed some of the stuff in patient information over to be in the business of only setting keys in one place as much as possible.
* There are a few entries we infer (`Clinic` for example) which are not really Patient fields per se, so we'll have to handle those ever so slightly differently in a way that isn't clear to me here. But this handles 90% of it and reduces this down to a few simpler next steps, so we can probably merge as is and put a nail in the coffin

This pull request makes the following changes:
* Add patient attributes on mongoid i18n something something
* Changes some of the patient information form input titles to rely on mongoid, to prove it works

This one probably does need a translation review. @montanezp if you'd be so kind?

Note that the ugly TRANSLATION MISSING thing will just show up as `Clinic` in prod:

![image](https://user-images.githubusercontent.com/3866868/56095404-8d532b00-5eaa-11e9-9a5a-72f9b22ba039.png)

It relates to the following issue #s: 
* Bumps #1658 
