### PR TITLE
upgrade nokogiri to squelch a vuln

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'puma' # roar
 gem 'turbolinks', '~> 5.2.0'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 1.0.0', group: :doc
-gem 'nokogiri', '>= 1.8.5'
+gem 'nokogiri', '>= 1.10.3'
 gem 'tzinfo-data', require: false
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
@@ -448,7 +448,7 @@ DEPENDENCIES
   mongoid-history (< 1.0)
   mongoid_rails_migrations
   mongoid_userstamp!
-  nokogiri (>= 1.8.5)
+  nokogiri (>= 1.10.3)
   omniauth-google-oauth2 (~> 0.6.0)
   pdf-inspector
   prawn


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

It's Nokogiri season.

This pull request makes the following changes:
* bump nokogiri to >= 1.10.3 to squelch a CVE

no views or issues