### PR TITLE
Fix system test that is sad about a change to static control

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,8 +4,8 @@
   <%= bootstrap_form_for resource, as: resource_name, url: '/users', html: { method: :put } do |f| %>
     <%= devise_error_messages! %>
 
-    <%= f.static_control :email %>
-    <%= f.static_control :role %>
+    <%= f.text_field :email, disabled: true, readonly: true %>
+    <%= f.text_field :role, disabled: true, readonly: true %>
     <%= f.text_field :name %>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -1,7 +1,7 @@
 // rerack LMP calculation
 $('#patient_appointment_date')
   .parent()
-  .find('span.help-block')
+  .find('small.form-text')
   .text("<%= t('patient.dashboard.approx_gestation', weeks: @patient.last_menstrual_period_at_appt_weeks, days: @patient.last_menstrual_period_at_appt_days) %>");
 
 // rerack status
@@ -10,7 +10,7 @@ $('#patient_status').text('<%= @patient.status %>');
 // rerack current LMP
 $('#patient_last_menstrual_period_weeks')
   .parent()
-  .find('span.help-block')
+  .find('small.form-text')
   .text("<%= t('patient.dashboard.currently', weeks: @patient.last_menstrual_period_now_weeks, days: @patient.last_menstrual_period_now_days) %>");
 
 // refresh changelog


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bootstrap form seems to handle static elements a little differently, so we're changing them to disabled and readonly input fields.

This pull request makes the following changes:
* `static_control` => `text_field, disabled: true, readonly: true`

no view change

no issues