### PR TITLE
Squash sass deprecation warnings -- remove one illegal extend, move the other to a mixin

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -65,7 +65,6 @@ $font-size: 17px;
 }
 
 .btn-primary:hover {
-  @extend .btn-primary:hover;
   background-color: lighten($daria-color,15%);
 }
 
@@ -298,10 +297,9 @@ $daria-color-lt : #825fb9;
     background-color: $daria-color-lt;
     }
   }
-
 }
 
-.btn-success[disabled] {
+@mixin disabled-button {
   color: white;
   background-color: gray;
   border-color: $daria-color;
@@ -317,11 +315,14 @@ $daria-color-lt : #825fb9;
       border-color: $daria-color;
     }
   }
+}
 
+.btn-success[disabled] {
+  @include disabled-button;
 }
 
 .btn-warning[disabled] {
-  @extend .btn-success[disabled];
+  @include disabled-button;
 }
 
 .label-success {


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I'm trying to live my truth in 2019 and squash deprecation warnings. Two of those for sass were happening on bootup about extending compound selectors. 

It turns out that the hover extend wasn't really doing anything and was deleteable; and the other one was just copying some other code over, so I ported it to a mixin.

This pull request makes the following changes:
* delete a compound selector that didn't do anything
* extract a mixin from another compound selector and use that

no view changes!

It relates to the following issue #s: 
* Fixes #1662

