### PR TITLE
Add ability to edit practical support forms

### DIFF
--- a/app/assets/javascripts/patients.coffee
+++ b/app/assets/javascripts/patients.coffee
@@ -37,6 +37,9 @@ $(document).on 'turbolinks:load', ->
   $(document).on "change", ".edit_patient", ->
     $(this).submit()
 
+  $(document).on "change", ".edit_practical_support", ->
+    $(this).submit()
+
   $(document).on "change", "#pledge_fulfillment_form", ->
     markFulfilledWhenFieldsChecked()
     $(this).submit()

--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -9,6 +9,7 @@ class PracticalSupportsController < ApplicationController
     @support = @patient.practical_supports.new practical_support_params
     @support.created_by = current_user
     if @support.save
+      flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
       @support = @patient.reload.practical_supports.order_by 'created_at desc'
       respond_to { |format| format.js }
     else
@@ -18,6 +19,7 @@ class PracticalSupportsController < ApplicationController
 
   def update
     if @support.update practical_support_params
+      flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
       respond_to { |format| format.js }
     else
       head :bad_request

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -2,10 +2,10 @@
   <ul class="nav nav-pills nav-stacked" id='menu-list'>
     <%= render 'menu_item', link_for: 'patient_information', active: true %>
     <%= render 'menu_item', link_for: 'abortion_information', active: false %>
+    <%= render 'menu_item', link_for: 'practical_support', active: false %>
     <%= render 'menu_item', link_for: 'notes', active: false %>
     <%= render 'menu_item', link_for: 'change_log', active: false %>
     <%= render 'menu_item', link_for: 'call_log', active: false %>
-    <%#= render 'menu_item', link_for: 'practical_support', active: false %>
     
     <% if current_user.allowed_data_access? && patient.pledge_sent? %>
       <%= render 'menu_item', link_for: 'pledge_fulfillment', active: false %>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -2,7 +2,7 @@
   <ul class="nav nav-pills nav-stacked" id='menu-list'>
     <%= render 'menu_item', link_for: 'patient_information', active: true %>
     <%= render 'menu_item', link_for: 'abortion_information', active: false %>
-    <%= render 'menu_item', link_for: 'practical_support', active: false %>
+    <%#= render 'menu_item', link_for: 'practical_support', active: false %>
     <%= render 'menu_item', link_for: 'notes', active: false %>
     <%= render 'menu_item', link_for: 'change_log', active: false %>
     <%= render 'menu_item', link_for: 'call_log', active: false %>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -2,7 +2,7 @@
   <ul class="nav nav-pills nav-stacked" id='menu-list'>
     <%= render 'menu_item', link_for: 'patient_information', active: true %>
     <%= render 'menu_item', link_for: 'abortion_information', active: false %>
-    <%#= render 'menu_item', link_for: 'practical_support', active: false %>
+    <%= render 'menu_item', link_for: 'practical_support', active: false %>
     <%= render 'menu_item', link_for: 'notes', active: false %>
     <%= render 'menu_item', link_for: 'change_log', active: false %>
     <%= render 'menu_item', link_for: 'call_log', active: false %>

--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -7,23 +7,13 @@
     </div>
 
     <div class="row">
-      <div class="col-sm-12 info-form">
-        <div id="existing-practical-supports"> 
-          <%= render 'practical_supports/entries', patient: patient %>
-        </div>
-      </div>
+      <%= render 'practical_supports/entries',
+                 patient: patient %>
     </div>
 
     <div class="row">
-      <div class="col-sm-12 info-form">
-        <h5>Or, record new practical support info: </h5>
-        <%= bootstrap_form_for [patient, patient.practical_supports.new], html: { id: 'new-practical-support' }, remote: true do |f| %>
-          <%= f.select :support_type, practical_support_options %>
-          <%= f.select :source, external_pledge_source_options %>
-          <%= f.check_box :confirmed %>
-          <%= f.submit 'Create new practical support', class: 'btn btn-primary', id: 'create-practical-support' %>
-        <% end %>
-      </div>
+      <%= render 'practical_supports/new',
+                 patient: patient %>
     </div>
   </div>
 </section>

--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -6,12 +6,12 @@
       </div>
     </div>
 
-    <div class="row">
+    <div class="row" id="practical-support-entries">
       <%= render 'practical_supports/entries',
                  patient: patient %>
     </div>
 
-    <div class="row">
+    <div class="row" id="practical-support-new-form">
       <%= render 'practical_supports/new',
                  patient: patient %>
     </div>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -1,6 +1,24 @@
+<div class="row">
+  <div class="col-sm-4"><h5>Category of support</h5></div>
+  <div class="col-sm-4"><h5>Provided by</h5></div>
+  <div class="col-sm-4"></div>
+</div>
+
 <% patient.practical_supports.each do |entry| %>
-    <%= entry.support_type %> -
-    <%= entry.source %> - 
-    <%= entry.confirmed %>
-  <br>   
+  <div class="row">
+    <%= bootstrap_form_for entry, url: patient_practical_support_path(patient, entry), html: { class: 'edit_practical_support' }, layout: :inline, remote: true do |f| %>
+      <div class="col-sm-4">
+        <%= f.select :support_type, options_for_select(practical_support_options, entry.support_type), hide_label: true %>
+      </div>
+      <div class="col-sm-4">
+        <%= f.select :source, options_for_select(external_pledge_source_options, entry.source), hide_label: true %>
+      </div>
+        
+      <div class="col-sm-4">
+        <%= f.check_box :confirmed, id: "practical_support_confirmed_#{entry.id}",label: 'Confirmed?' %>
+      </div>
+      
+    <% end %>
+  </div>
+  <br>
 <% end %>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -1,24 +1,15 @@
-<div class="row">
-  <div class="col-sm-4"><h5>Category of support</h5></div>
-  <div class="col-sm-4"><h5>Provided by</h5></div>
-  <div class="col-sm-4"></div>
-</div>
+<div class="col-sm-12 info-form">
+  <div id="existing-practical-supports"> 
+    <div class="row">
+      <div class="col-sm-4"><h5>Category of support</h5></div>
+      <div class="col-sm-4"><h5>Provided by</h5></div>
+      <div class="col-sm-4"><!-- Where confirmation would go --></div>
+    </div>
 
-<% patient.practical_supports.each do |entry| %>
-  <div class="row">
-    <%= bootstrap_form_for entry, url: patient_practical_support_path(patient, entry), html: { class: 'edit_practical_support' }, layout: :inline, remote: true do |f| %>
-      <div class="col-sm-4">
-        <%= f.select :support_type, options_for_select(practical_support_options, entry.support_type), hide_label: true %>
-      </div>
-      <div class="col-sm-4">
-        <%= f.select :source, options_for_select(external_pledge_source_options, entry.source), hide_label: true %>
-      </div>
-        
-      <div class="col-sm-4">
-        <%= f.check_box :confirmed, id: "practical_support_confirmed_#{entry.id}",label: 'Confirmed?' %>
-      </div>
-      
+    <% patient.practical_supports.each do |entry| %>
+      <%= render 'practical_supports/show',
+                 patient: patient,
+                 practical_support: entry %>
     <% end %>
   </div>
-  <br>
-<% end %>
+</div>

--- a/app/views/practical_supports/_new.html.erb
+++ b/app/views/practical_supports/_new.html.erb
@@ -4,6 +4,7 @@
     <%= f.select :support_type, practical_support_options %>
     <%= f.select :source, external_pledge_source_options %>
     <%= f.check_box :confirmed %>
+    <br>
     <%= f.submit 'Create new practical support', class: 'btn btn-primary', id: 'create-practical-support' %>
   <% end %>
 </div>

--- a/app/views/practical_supports/_new.html.erb
+++ b/app/views/practical_supports/_new.html.erb
@@ -1,0 +1,9 @@
+<div class="col-sm-12 info-form">
+  <h5>Or, record new practical support info: </h5>
+  <%= bootstrap_form_for [patient, patient.practical_supports.new], html: { id: 'new-practical-support' }, remote: true do |f| %>
+    <%= f.select :support_type, practical_support_options %>
+    <%= f.select :source, external_pledge_source_options %>
+    <%= f.check_box :confirmed %>
+    <%= f.submit 'Create new practical support', class: 'btn btn-primary', id: 'create-practical-support' %>
+  <% end %>
+</div>

--- a/app/views/practical_supports/_show.html.erb
+++ b/app/views/practical_supports/_show.html.erb
@@ -1,16 +1,24 @@
-<div class="row">
-  <%= bootstrap_form_for practical_support, url: patient_practical_support_path(patient, practical_support), html: { class: 'edit_practical_support' }, layout: :inline, remote: true do |f| %>
+<div class="row" class="practical-support-item" id="practical-support-item-<%= practical_support.id %>">
+  <%= bootstrap_form_for practical_support, url: patient_practical_support_path(patient, practical_support), html: { class: 'edit_practical_support' },  remote: true do |f| %>
     <div class="col-sm-4">
       <%= f.select :support_type, options_for_select(practical_support_options, practical_support.support_type), hide_label: true %>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
       <%= f.select :source, options_for_select(external_pledge_source_options, practical_support.source), hide_label: true %>
     </div>
       
-    <div class="col-sm-4">
+    <div class="col-sm-3">
       <%= f.check_box :confirmed, id: "practical_support_confirmed_#{practical_support.id}",label: 'Confirmed?' %>
     </div>
-    
   <% end %>
+
+  <div class="col-sm-2">
+    <%= button_to 'Delete',
+                  patient_practical_support_path(patient, practical_support),
+                  remote: true,
+                  method: :delete,
+                  data: { confirm: 'Are you sure you want to delete this practical support entry?' },
+                  class: "btn btn-danger" %>
+  </div>
+  <br>
 </div>
-<br>

--- a/app/views/practical_supports/_show.html.erb
+++ b/app/views/practical_supports/_show.html.erb
@@ -1,0 +1,16 @@
+<div class="row">
+  <%= bootstrap_form_for practical_support, url: patient_practical_support_path(patient, practical_support), html: { class: 'edit_practical_support' }, layout: :inline, remote: true do |f| %>
+    <div class="col-sm-4">
+      <%= f.select :support_type, options_for_select(practical_support_options, practical_support.support_type), hide_label: true %>
+    </div>
+    <div class="col-sm-4">
+      <%= f.select :source, options_for_select(external_pledge_source_options, practical_support.source), hide_label: true %>
+    </div>
+      
+    <div class="col-sm-4">
+      <%= f.check_box :confirmed, id: "practical_support_confirmed_#{practical_support.id}",label: 'Confirmed?' %>
+    </div>
+    
+  <% end %>
+</div>
+<br>

--- a/app/views/practical_supports/create.js.erb
+++ b/app/views/practical_supports/create.js.erb
@@ -1,2 +1,8 @@
-
 $('#existing-practical-supports').empty().append('<%= escape_javascript(render partial: "practical_supports/entries", locals: { patient: @patient } ) %>');
+
+// flash the result
+$('#flash').html('<%= escape_javascript(render partial: "layouts/messages") %>');
+$('#flash').removeClass().hide().fadeIn('slow');
+setTimeout(function() {
+  $('#flash').hide();
+}, 5000);

--- a/app/views/practical_supports/create.js.erb
+++ b/app/views/practical_supports/create.js.erb
@@ -1,4 +1,5 @@
 $('#existing-practical-supports').empty().append('<%= escape_javascript(render partial: "practical_supports/entries", locals: { patient: @patient } ) %>');
+$('#practical-support-new-form').empty().append('<%= escape_javascript(render partial: "practical_supports/new", locals: { patient: @patient } ) %>');
 
 // flash the result
 $('#flash').html('<%= escape_javascript(render partial: "layouts/messages") %>');

--- a/app/views/practical_supports/destroy.js.erb
+++ b/app/views/practical_supports/destroy.js.erb
@@ -1,1 +1,1 @@
-console.log('destroy');
+$('#practical-support-item-<%= @support.id %>').empty().remove();

--- a/app/views/practical_supports/update.js.erb
+++ b/app/views/practical_supports/update.js.erb
@@ -1,1 +1,6 @@
-console.log('update');
+// flash the result
+$('#flash').html('<%= escape_javascript(render partial: "layouts/messages") %>');
+$('#flash').removeClass().hide().fadeIn('slow');
+setTimeout(function() {
+  $('#flash').hide();
+}, 5000);


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Not shipping because there's some additional UI to do, but this sets up update and destroy in the UI. Still not quite primetime ready but materially closer.

This pull request makes the following changes:
* Sets up entry update and destroy (no tests yet)
* some UI cleanup and breaking things into more rest-y routes
* turn on the autosave!

The state of the world:

![image](https://user-images.githubusercontent.com/3866868/59553941-53fe7080-8f6a-11e9-9652-ee2fde8436ba.png)

Still todo are tests and localization and exports at least, and doing a quick UI check with @mlindberg61 .

It relates to the following issue #s: 
* Bumps #1493 
