### PR TITLE
Remove redundant budget bar tooltip text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,7 +500,7 @@ en:
         pledge_unfulfilled: Pledge Not Fulfilled
         resolved: Resolved Without %{fund}
   tooltips:
-    budget_bar: The budget bar lists money tentatively set aside for a patient (by entering a value in the %{fund} pledge field) and money sent to a clinic for a patient (by checking the I sent the pledge checkbox) over a given week. It resets on Mondays by default.
+    budget_bar: The budget bar lists money tentatively set aside for a patient (by entering a value in the %{fund} pledge field) and money sent to a clinic for a patient (by checking the I sent the pledge checkbox) over a given week.
     call_list: This sortable list is used to keep track of patients to call back during your shift. Use the search to populate it.
     completed_calls: This is a list of patients you have called within the last 8 hours.
     mandatory_ultrasound: If you are in a state that requires ultrasounds and the patient has completed one, you can log it here.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -500,7 +500,7 @@ es:
         pledge_unfulfilled: Promesa No Cumplida
         resolved: Resuelto Sin %{fund}
   tooltips:
-    budget_bar: La barra de presupuesto indica el dinero provisionalmente reservado para un paciente (cuando ingresa la cantidad de promesa %{fund}) y el dinero enviado a una clínica para un paciente (cuando marca la casilla de verificación "envié la promesa") durante una semana determinada. Se reinicia los lunes.
+    budget_bar: La barra de presupuesto indica el dinero provisionalmente reservado para un paciente (cuando ingresa la cantidad de promesa %{fund}) y el dinero enviado a una clínica para un paciente (cuando marca la casilla de verificación "envié la promesa") durante una semana determinada.
     call_list: Esta lista organiza los pacientes para cuando quiera devolver llamadas durante su turno. Utiliza la búsqueda para rellenar la lista.
     completed_calls: Esta es una lista de pacientes a los que ha llamado en las últimas 8 horas.
     mandatory_ultrasound: Si se encuentra en un estado que requiere ultrasonidos y el paciente ha completado uno, puede indicarlo aquí.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Per conversation in #1709 there's a redundancy in the tooltip. This strips that.

This pull request makes the following changes:
* Remove redundant or possibly irrelevant information about start date for the budget bar

no notable view changes

It relates to the following issue #s: 

* Bumps #1698, sorta
