### PR TITLE
Fixing seeds so the CM resources link works

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -150,7 +150,7 @@ Config.create config_key: :pledge_limit_help_text,
 Config.create config_key: :language,
               config_value: { options: ['Spanish', 'French', 'Korean']}
 Config.create config_key: :resources_url,
-              config_value: { options: ['Spanish', 'French', 'Korean']}
+              config_value: { options: ['https://www.petfinder.com/cats/']}
 Config.create config_key: :referred_by,
               config_value: { options: ['Metal band']}
 Config.create config_key: :fax_service,


### PR DESCRIPTION
Super small fix :-). I changed what looks like a typo in the seed file, which was breaking the CM Resources link in the navbar.
