### PR TITLE
Practical support: Correct spacing/alignment/refresh on create/update/destroy actions

### DIFF
--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -1,4 +1,4 @@
-<section id="abortion_information_content">
+<section id="practical_support_content">
   <div id="patient_fields" class="col-sm-12">
     <div class="row">
       <div class="col-sm-12">

--- a/app/views/practical_supports/_show.html.erb
+++ b/app/views/practical_supports/_show.html.erb
@@ -1,4 +1,4 @@
-<div class="row" class="practical-support-item" id="practical-support-item-<%= practical_support.id %>">
+<div class="row practical-support-item" id="practical-support-item-<%= practical_support.id %>">
   <%= bootstrap_form_for practical_support, url: patient_practical_support_path(patient, practical_support), html: { class: 'edit_practical_support' },  remote: true do |f| %>
     <div class="col-sm-4">
       <%= f.select :support_type, options_for_select(practical_support_options, practical_support.support_type), hide_label: true %>

--- a/app/views/practical_supports/create.js.erb
+++ b/app/views/practical_supports/create.js.erb
@@ -1,4 +1,4 @@
-$('#existing-practical-supports').empty().append('<%= escape_javascript(render partial: "practical_supports/entries", locals: { patient: @patient } ) %>');
+$('#practical-support-entries').empty().append('<%= escape_javascript(render partial: "practical_supports/entries", locals: { patient: @patient } ) %>');
 $('#practical-support-new-form').empty().append('<%= escape_javascript(render partial: "practical_supports/new", locals: { patient: @patient } ) %>');
 
 // flash the result

--- a/app/views/practical_supports/destroy.js.erb
+++ b/app/views/practical_supports/destroy.js.erb
@@ -1,1 +1,6 @@
 $('#practical-support-item-<%= @support.id %>').empty().remove();
+
+// If there aren't any practical support entries left, empty out the list
+if ($('.practical-support-item').length == 0) {
+  $('#practical-support-entries').empty();
+}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I put this together kinda sloppy in terms of alignments/proper element id usage, so this adjusts them and empties out the right partials.

I think this is covered by existing system tests. Also want to note that after this, the partial will start showing up in sandbox for real.

This pull request makes the following changes:
* align everything along the rail
* properly empty out the entries partial if there are no entries

Now left aligned on both create and page load like so:

![image](https://user-images.githubusercontent.com/3866868/60145185-424f7100-9793-11e9-8d0e-e8dca2cc510f.png)

It relates to the following issue #s: 
* Bumps #1493 
