### PR TITLE
Change verbiage of practical support columns and add indicator

### DIFF
--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -3,12 +3,17 @@
     <div class="row">
       <div class="col-sm-12">
         <h2><%= t('patient.abortion_information.title') %></h2>
+
+        <% if patient.practical_supports.any? %>
+          <h5 class="text-danger">This patient requires practical support. See Practical Support tab.</h5>
+        <% end %>
       </div>
     </div>
 
     <div class="row">
       <div class="col-sm-12 info-form">
         <h3><%= t('patient.abortion_information.clinic_section.title') %></h3>
+
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form-1' }, remote: true do |f| %>
           <div class="col-sm-6">
             <div class="info-form-left">
@@ -68,6 +73,7 @@
         <%= bootstrap_form_for patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
           <div class="col-sm-6">
             <%= f.number_field :procedure_cost, label: t('patient.abortion_information.cost_section.abortion_cost'), autocomplete: 'off', prepend: '$' %>
+
             <div class="info-form-left form-group outstanding-balance-ctn hidden">
               <label class="control-label"><%= t('patient.abortion_information.cost_section.outstanding_balance') %></label>
               <div id="outstanding-balance"></div>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -2,8 +2,8 @@
   <div id="existing-practical-supports"> 
     <% if patient.practical_supports.present? %>
       <div class="row">
-        <div class="col-sm-4"><h5>Category of support</h5></div>
-        <div class="col-sm-4"><h5>Provided by</h5></div>
+        <div class="col-sm-4"><h5>Support needed</h5></div>
+        <div class="col-sm-4"><h5>Point of contact</h5></div>
         <div class="col-sm-4"><!-- Where confirmation would go --></div>
       </div>
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

#1723 noted that the verbiage was kinda confusing, so we clarify it to `Support needed` and `Point of contact`.

We also add an indicator to abortion information to make a note when a patient has practical support entries. This seems so straightforward and noncritical that I don't think we need to ajax changes in or test for it. Open to other opinions.

This pull request makes the following changes:
* change verbiage
* add indicator to abortion information when a patient has practical supports

![image](https://user-images.githubusercontent.com/3866868/61176779-fffca100-a594-11e9-8ddc-75d5234b16df.png)

It relates to the following issue #s: 
* Bumps #1723 
