### PR TITLE
loosen uniqueness restrictions on practical support

### DIFF
--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -14,7 +14,8 @@ class PracticalSupport
 
   # Validations
   validates :created_by_id, :source, :support_type, presence: true
-  validates :support_type, uniqueness: true
+  validates :source,
+            uniqueness: { scope: :support_type, message: 'is already the point of contact for that' }
 
   # History and auditing
   track_history on: fields.keys + [:updated_by_id],

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -42,15 +42,18 @@ class PracticalSupportTest < ActiveSupport::TestCase
       end
     end
 
-    it 'should enforce uniqueness of support_type' do
+    it 'should enforce uniqueness of support_type and source' do
       fields = attributes_for :practical_support
       support1 = @patient.practical_supports.new fields
       assert support1.save
 
       support2 = @patient.practical_supports.new fields
       refute support2.save
-      assert_equal ['is already taken'],
-                   support2.errors.messages[:support_type]
+      assert_equal ['is already the point of contact for that'],
+                   support2.errors.messages[:source]
+
+      support2.support_type = 'cats'
+      assert support2.save
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Per feedback from @harumhelmy  it's possible to have multiple funds investigating practical support (though probably only one should confirmed? idk). So we're loosening that a bit.

This pull request makes the following changes:
* loosens uniqueness scope to source and support type
* bumps tests

It relates to the following issue #s: 
* Bumps #1723 
