### PR TITLE
add other/wildcard options to support source and type options

### DIFF
--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -9,14 +9,14 @@ module PracticalSupportsHelper
     full_set = [nil] +
       standard_options +
       Config.find_or_create_by(config_key: 'practical_support').options +
-      [current_value]
+      ['Other (see notes)', current_value]
     full_set.uniq
   end
 
   def practical_support_source_options(current_value = nil)
     full_set = [nil, FUND_FULL] +
       Config.find_or_create_by(config_key: 'external_pledge_source').options +
-      ['Clinic', 'Other (see notes)', current_value]
+      ['Patient', 'Clinic', 'Other (see notes)', 'Not sure yet (see notes)', current_value]
     full_set.uniq
   end
 end

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -13,7 +13,8 @@ class PracticalSupportsHelperTest < ActionView::TestCase
           "Travel to the region",
           "Travel inside the region",
           "Lodging",
-          "Companion"
+          "Companion",
+          'Other (see notes)'
         ]
         assert_same_elements expected, practical_support_options
       end
@@ -30,7 +31,8 @@ class PracticalSupportsHelperTest < ActionView::TestCase
           "Travel to the region",
           "Travel inside the region",
           "Lodging",
-          "Companion"
+          "Companion",
+          'Other (see notes)'
         ]
         assert_same_elements expected, @options
         assert Config.find_by(config_key: 'practical_support')
@@ -45,6 +47,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
           "Travel inside the region",
           "Lodging",
           "Companion",
+          'Other (see notes)',
           'bandmates'
         ]
         assert_same_elements expected, practical_support_options('bandmates')
@@ -63,8 +66,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
           'Baltimore Abortion Fund',
           'Tiller Fund (NNAF)',
           'NYAAF (New York)',
+          'Patient',
           'Clinic',
-          'Other (see notes)'
+          'Other (see notes)',
+          'Not sure yet (see notes)'
         ]
         assert_same_elements expected, practical_support_source_options
       end
@@ -79,8 +84,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
         expected = [
           nil,
           'DC Abortion Fund',
+          'Patient',
           'Clinic',
-          'Other (see notes)'
+          'Other (see notes)',
+          'Not sure yet (see notes)'
         ]
         assert_same_elements expected, @options
         assert Config.find_by(config_key: 'external_pledge_source')
@@ -92,8 +99,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
         expected = [
           nil,
           'DC Abortion Fund',
+          'Patient',
           'Clinic',
           'Other (see notes)',
+          'Not sure yet (see notes)',
           'yolo'
         ]
         assert_same_elements expected, practical_support_source_options('yolo')


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Had an open question about how to handle more than one active request out -- I think we're trying to actively discourage the possibility that it won't be clear who's quarterbacking a practical support supply effort, and that need supersedes what we lose on reporting here by not knowing 'we asked this fund but they went in a diff direction'.

This pull request makes the following changes:
* adds new wildcard options and patient as practical support source
* keeps current validation of only one source type the way it is now

It relates to the following issue #s: 
* Bumps #1723 
