### PR TITLE
Do i18n translations for practical support

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -54,6 +54,9 @@ class PatientsController < ApplicationController
   end
 
   def edit
+    # i18n-tasks-use t('mongoid.attributes.practical_support.confirmed')
+    # i18n-tasks-use t('mongoid.attributes.practical_support.source')
+    # i18n-tasks-use t('mongoid.attributes.practical_support.support_type')
     @note = @patient.notes.new
     @external_pledge = @patient.external_pledges.new
   end

--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -1,22 +1,39 @@
 module PracticalSupportsHelper
   def practical_support_options(current_value = nil)
-    standard_options = [
-      t('patient.helper.practical_support.travel_to_area'),
-      t('patient.helper.practical_support.travel_inside_area'),
-      t('patient.helper.practical_support.lodging'),
-      t('patient.helper.practical_support.companion'),
-    ]
-    full_set = [nil] +
-      standard_options +
-      Config.find_or_create_by(config_key: 'practical_support').options +
-      ['Other (see notes)', current_value]
-    full_set.uniq
+    options = [
+      nil,
+      [ t('patient.helper.practical_support.travel_to_region'), 'Travel to region' ],
+      [ t('patient.helper.practical_support.travel_inside_region'), 'Travel inside region' ],
+      [ t('patient.helper.practical_support.lodging'), 'Lodging' ],
+      [ t('patient.helper.practical_support.companion'), 'Companion' ],
+    ] + Config.find_or_create_by(config_key: 'practical_support').options +
+      [
+        [ t('patient.helper.practical_support.other'), 'Other (see notes)' ]
+      ]
+
+    options.push(current_value) if current_value_not_present?(options, current_value)
+    options
   end
 
   def practical_support_source_options(current_value = nil)
-    full_set = [nil, FUND_FULL] +
+    options = [nil, FUND_FULL] +
       Config.find_or_create_by(config_key: 'external_pledge_source').options +
-      ['Patient', 'Clinic', 'Other (see notes)', 'Not sure yet (see notes)', current_value]
-    full_set.uniq
+      [
+        [ t('common.patient'), 'Patient' ],
+        [ t('common.clinic'), 'Clinic' ],
+        [ t('patient.helper.practical_support.other'), 'Other (see notes)' ],
+        [ t('patient.helper.practical_support.not_sure_yet'), 'Not sure yet (see notes)' ]
+      ]
+
+    options.push(current_value) if current_value_not_present?(options, current_value)
+    options
+  end
+
+  private
+
+  def current_value_not_present?(options, current_value)
+    # Return true if current value is present in the values of options.
+    return false if current_value.blank?
+    options.map { |option| option.is_a?(Array) ? option[-1] : option }.exclude? current_value
   end
 end

--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -2,8 +2,8 @@ module PracticalSupportsHelper
   def practical_support_options(current_value = nil)
     options = [
       nil,
-      [ t('patient.helper.practical_support.travel_to_region'), 'Travel to region' ],
-      [ t('patient.helper.practical_support.travel_inside_region'), 'Travel inside region' ],
+      [ t('patient.helper.practical_support.travel_to_region'), 'Travel to the region' ],
+      [ t('patient.helper.practical_support.travel_inside_region'), 'Travel inside the region' ],
       [ t('patient.helper.practical_support.lodging'), 'Lodging' ],
       [ t('patient.helper.practical_support.companion'), 'Companion' ],
     ] + Config.find_or_create_by(config_key: 'practical_support').options +

--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -2,7 +2,7 @@
   <div id="patient_fields" class="col-sm-12">
     <div class="row">
       <div class="col-sm-12">
-        <h2>Practical Support</h2>
+        <h2><%= t 'patient.practical_support.title' %></h2>
       </div>
     </div>
 

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -16,17 +16,16 @@
       
     <div class="col-sm-3">
       <%= f.check_box :confirmed,
-                      id: "practical_support_confirmed_#{practical_support.id}",
-                      label: 'Confirmed?' %>
+                      id: "practical_support_confirmed_#{practical_support.id}" %>
     </div>
   <% end %>
 
   <div class="col-sm-2">
-    <%= button_to 'Delete',
+    <%= button_to t('patient.practical_support.remove'),
                   patient_practical_support_path(patient, practical_support),
                   remote: true,
                   method: :delete,
-                  data: { confirm: 'Are you sure you want to delete this practical support entry?' },
+                  data: { confirm: t('patient.practical_support.delete_confirm') },
                   class: "btn btn-danger" %>
   </div>
   <br />

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -2,8 +2,8 @@
   <div id="existing-practical-supports"> 
     <% if patient.practical_supports.present? %>
       <div class="row">
-        <div class="col-sm-4"><h5>Support needed</h5></div>
-        <div class="col-sm-4"><h5>Point of contact</h5></div>
+        <div class="col-sm-4"><h5><%= t 'patient.practical_support.support_needed' %></h5></div>
+        <div class="col-sm-4"><h5><%= t 'patient.practical_support.point_of_contact' %></h5></div>
         <div class="col-sm-4"><!-- Where confirmation would go --></div>
       </div>
 

--- a/app/views/practical_supports/_new.html.erb
+++ b/app/views/practical_supports/_new.html.erb
@@ -1,10 +1,10 @@
 <div class="col-sm-12 info-form">
-  <h5>Record new practical support info: </h5>
+  <h5><%= t 'patient.practical_support.new' %></h5>
   <%= bootstrap_form_for [patient, patient.practical_supports.new], html: { id: 'new-practical-support' }, remote: true do |f| %>
     <%= f.select :support_type, practical_support_options %>
     <%= f.select :source, practical_support_source_options %>
     <%= f.check_box :confirmed %>
     <br>
-    <%= f.submit 'Create new practical support', class: 'btn btn-primary', id: 'create-practical-support' %>
+    <%= f.submit t('patient.practical_support.create'), class: 'btn btn-primary', id: 'create-practical-support' %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,6 +248,10 @@ en:
         password: Password
         password_confirmation: Password confirmation
         role: Role
+      practical_support:
+        confirmed: Confirmed
+        support_type: Support type
+        source: Source
   navigation:
     admin_tools:
       accounting: Accounting
@@ -413,6 +417,7 @@ en:
       notes: Notes
       patient_information: Patient Information
       pledge_fulfillment: Pledge Fulfillment
+      practical_support: Practical Support
       submit_pledge: Submit pledge
     new:
       add_button: Add new patient
@@ -474,6 +479,14 @@ en:
         procedure_date: Procedure date
         weeks_along_at_procedure: Weeks along at procedure
       title: Pledge Fulfillment
+    practical_support:
+      delete_confirm: "Are you sure you want to delete this practical support entry?"
+      support_needed: Support needed
+      point_of_contact: Point of contact
+      create: Create new practical support entry
+      title: Practical support
+      remove: Remove
+      new: 'Record new practical support info:'
     shared:
       appt_date: Appointment date
       name: First and last name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     add: Add
     appointment_date_short: Appt date
     back: Back
+    clinic: Clinic
     days_along: Days along at intake
     email: Email
     medicaid: Medicaid
@@ -72,6 +73,7 @@ en:
     name: Name
     'no': 'No'
     notes: Notes
+    patient: Patient
     phone: Phone
     save: Save
     search: Search
@@ -356,6 +358,8 @@ en:
         lodging: Lodging
         travel_inside_area: Travel inside the region
         travel_to_area: Travel to the region
+        other: Other (see notes)
+        not_sure_yet: Not sure yet (see notes)
       race:
         asian_south_asian: Asian or South Asian
         black_african_american: Black/African-American

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,8 +356,8 @@ en:
       practical_support:
         companion: Companion
         lodging: Lodging
-        travel_inside_area: Travel inside the region
-        travel_to_area: Travel to the region
+        travel_inside_region: Travel inside the region
+        travel_to_region: Travel to the region
         other: Other (see notes)
         not_sure_yet: Not sure yet (see notes)
       race:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,6 +243,10 @@ en:
         textable: Textable
         urgent_flag: Urgent flag
         voicemail_preference: Voicemail preference
+      practical_support:
+        confirmed: Confirmed
+        source: Source
+        support_type: Support type
       user:
         current_password: Current password
         email: Email
@@ -250,10 +254,6 @@ en:
         password: Password
         password_confirmation: Password confirmation
         role: Role
-      practical_support:
-        confirmed: Confirmed
-        support_type: Support type
-        source: Source
   navigation:
     admin_tools:
       accounting: Accounting
@@ -356,10 +356,10 @@ en:
       practical_support:
         companion: Companion
         lodging: Lodging
+        not_sure_yet: Not sure yet (see notes)
+        other: Other (see notes)
         travel_inside_region: Travel inside the region
         travel_to_region: Travel to the region
-        other: Other (see notes)
-        not_sure_yet: Not sure yet (see notes)
       race:
         asian_south_asian: Asian or South Asian
         black_african_american: Black/African-American
@@ -484,13 +484,13 @@ en:
         weeks_along_at_procedure: Weeks along at procedure
       title: Pledge Fulfillment
     practical_support:
-      delete_confirm: "Are you sure you want to delete this practical support entry?"
-      support_needed: Support needed
-      point_of_contact: Point of contact
       create: Create new practical support entry
-      title: Practical support
-      remove: Remove
+      delete_confirm: Are you sure you want to delete this practical support entry?
       new: 'Record new practical support info:'
+      point_of_contact: Point of contact
+      remove: Remove
+      support_needed: Support needed
+      title: Practical support
     shared:
       appt_date: Appointment date
       name: First and last name

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -65,6 +65,7 @@ es:
     add: Añadir
     appointment_date_short: Día de la cita
     back: Atrás
+    clinic: Clínica
     days_along: Días de embarazo al inicio
     email: Email
     medicaid: Medicaid
@@ -72,6 +73,7 @@ es:
     name: Nombre
     'no': 'No'
     notes: Notas
+    patient: Patiente
     phone: Teléfono
     save: Guardar
     search: Buscar
@@ -354,8 +356,10 @@ es:
       practical_support:
         companion: Acompañante
         lodging: Hospedaje
-        travel_inside_area: Viajar dentro de la región
-        travel_to_area: Viajar a la región
+        travel_inside_region: Viajar dentro de la región
+        travel_to_region: Viajar a la región
+        other: Otro (ver notas)
+        not_sure_yet: No estamos seguro (ver notas)
       race:
         asian_south_asian: Asiática o Sur de Asia
         black_african_american: Negra/Afroamericana

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -488,7 +488,7 @@ es:
       delete_confirm: "¿Está seguro de que desea eliminar esta entrada de soporte práctico?"
       new: 'Grabar nueva información de soporte práctico:'
       point_of_contact: Punto de contacto
-      remove: Quita
+      remove: Elimina
       support_needed: Soporte Necesarios
       title: Apoyo practico
     shared:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -243,6 +243,10 @@ es:
         textable: Textable
         urgent_flag: Bandera urgente
         voicemail_preference: Preferencia de correo de voz
+      practical_support:
+        confirmed: Confirmado
+        source: Fuente
+        support_type: Tipo de apoyo
       user:
         current_password: Contraseña actual
         email: Correo Electrónico/Email
@@ -250,10 +254,6 @@ es:
         password: Contraseña
         password_confirmation: Confirmación de contraseña
         role: Papel
-      practical_support:
-        confirmed: Confirmado
-        support_type: Tipo de apoyo
-        source: Fuente
   navigation:
     admin_tools:
       accounting: Contabilidad
@@ -356,10 +356,10 @@ es:
       practical_support:
         companion: Acompañante
         lodging: Hospedaje
+        not_sure_yet: No estamos seguro (ver notas)
+        other: Otro (ver notas)
         travel_inside_region: Viajar dentro de la región
         travel_to_region: Viajar a la región
-        other: Otro (ver notas)
-        not_sure_yet: No estamos seguro (ver notas)
       race:
         asian_south_asian: Asiática o Sur de Asia
         black_african_american: Negra/Afroamericana
@@ -484,13 +484,13 @@ es:
         weeks_along_at_procedure: Semanas a lo largo del procedimiento
       title: Cumplimiento de la promesa
     practical_support:
-      delete_confirm: "¿Está seguro de que desea eliminar esta entrada de soporte práctico?"
-      support_needed: Soporte Necesarios
-      point_of_contact: Punto de contacto
       create: Crear una nueva entrada de soporte práctico
-      title: Apoyo practico
-      remove: Quita
+      delete_confirm: "¿Está seguro de que desea eliminar esta entrada de soporte práctico?"
       new: 'Grabar nueva información de soporte práctico:'
+      point_of_contact: Punto de contacto
+      remove: Quita
+      support_needed: Soporte Necesarios
+      title: Apoyo practico
     shared:
       appt_date: Día de la cita
       name: Nombre y apellido

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -248,6 +248,10 @@ es:
         password: Contraseña
         password_confirmation: Confirmación de contraseña
         role: Papel
+      practical_support:
+        confirmed: Confirmado
+        support_type: Tipo de apoyo
+        source: Fuente
   navigation:
     admin_tools:
       accounting: Contabilidad
@@ -413,6 +417,7 @@ es:
       notes: Notas
       patient_information: Información del Paciente
       pledge_fulfillment: Cumplimiento de la Promesa
+      practical_support: Apoyo Practico
       submit_pledge: Crear Promesa
     new:
       add_button: Añadir nuevo paciente
@@ -474,6 +479,14 @@ es:
         procedure_date: Fecha de procedimiento
         weeks_along_at_procedure: Semanas a lo largo del procedimiento
       title: Cumplimiento de la promesa
+    practical_support:
+      delete_confirm: "¿Está seguro de que desea eliminar esta entrada de soporte práctico?"
+      support_needed: Soporte Necesarios
+      point_of_contact: Punto de contacto
+      create: Crear una nueva entrada de soporte práctico
+      title: Apoyo practico
+      remove: Quita
+      new: 'Grabar nueva información de soporte práctico:'
     shared:
       appt_date: Día de la cita
       name: Nombre y apellido

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -10,11 +10,11 @@ class PracticalSupportsHelperTest < ActionView::TestCase
            nil,
           "Metallica Tickets",
           "Clothing",
-          "Travel to the region",
-          "Travel inside the region",
-          "Lodging",
-          "Companion",
-          'Other (see notes)'
+          ["Travel to the region", "Travel to the region"],
+          ["Travel inside the region", "Travel inside the region"],
+          ["Lodging", "Lodging"],
+          ["Companion", "Companion"],
+          ['Other (see notes)', 'Other (see notes)']
         ]
         assert_same_elements expected, practical_support_options
       end
@@ -28,11 +28,11 @@ class PracticalSupportsHelperTest < ActionView::TestCase
 
         expected = [
           nil,
-          "Travel to the region",
-          "Travel inside the region",
-          "Lodging",
-          "Companion",
-          'Other (see notes)'
+          ["Travel to the region", "Travel to the region"],
+          ["Travel inside the region", "Travel inside the region"],
+          ["Lodging", "Lodging"],
+          ["Companion", "Companion"],
+          ['Other (see notes)', 'Other (see notes)']
         ]
         assert_same_elements expected, @options
         assert Config.find_by(config_key: 'practical_support')
@@ -43,11 +43,11 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       it 'should push onto the end' do
         expected = [
           nil,
-          "Travel to the region",
-          "Travel inside the region",
-          "Lodging",
-          "Companion",
-          'Other (see notes)',
+          ["Travel to the region", "Travel to the region"],
+          ["Travel inside the region", "Travel inside the region"],
+          ["Lodging", "Lodging"],
+          ["Companion", "Companion"],
+          ['Other (see notes)', 'Other (see notes)'],
           'bandmates'
         ]
         assert_same_elements expected, practical_support_options('bandmates')
@@ -66,10 +66,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
           'Baltimore Abortion Fund',
           'Tiller Fund (NNAF)',
           'NYAAF (New York)',
-          'Patient',
-          'Clinic',
-          'Other (see notes)',
-          'Not sure yet (see notes)'
+          ['Patient', 'Patient'],
+          ['Clinic', 'Clinic'],
+          ['Other (see notes)', 'Other (see notes)'],
+          ['Not sure yet (see notes)', 'Not sure yet (see notes)']
         ]
         assert_same_elements expected, practical_support_source_options
       end
@@ -84,10 +84,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
         expected = [
           nil,
           'DC Abortion Fund',
-          'Patient',
-          'Clinic',
-          'Other (see notes)',
-          'Not sure yet (see notes)'
+          ['Patient', 'Patient'],
+          ['Clinic', 'Clinic'],
+          ['Other (see notes)', 'Other (see notes)'],
+          ['Not sure yet (see notes)', 'Not sure yet (see notes)']
         ]
         assert_same_elements expected, @options
         assert Config.find_by(config_key: 'external_pledge_source')
@@ -99,10 +99,10 @@ class PracticalSupportsHelperTest < ActionView::TestCase
         expected = [
           nil,
           'DC Abortion Fund',
-          'Patient',
-          'Clinic',
-          'Other (see notes)',
-          'Not sure yet (see notes)',
+          ['Patient', 'Patient'],
+          ['Clinic', 'Clinic'],
+          ['Other (see notes)', 'Other (see notes)'],
+          ['Not sure yet (see notes)', 'Not sure yet (see notes)'],
           'yolo'
         ]
         assert_same_elements expected, practical_support_source_options('yolo')

--- a/test/system/practical_support_behaviors_test.rb
+++ b/test/system/practical_support_behaviors_test.rb
@@ -94,7 +94,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
 
     it 'destroy practical supports if you click the big red button' do
       within :css, '#existing-practical-supports' do
-        accept_confirm { click_button 'Delete' }
+        accept_confirm { click_button 'Remove' }
       end
 
       reload_page_and_click_link 'Practical Support'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This does the translation for practical support.

It involved a little bit of gut work in practical_support_helper; I remember this now, but the reason we had the complex checking system is because i18n keys-value pairs don't reduce to english values easily. So we do a little bit of of a dance, which I've rolled up into a private method here.

This pull request makes the following changes:
* adds i18n keys for practical support
* fixes up some helpers to account for different keys and values because of translation

Example of the view changes: 
![image](https://user-images.githubusercontent.com/3866868/61599072-294fa980-abf3-11e9-9666-cf066fbf8636.png)

@montanezp can you review the translations the same way we reviewed the old stuff? Take a look at the green stuff in es.yml and compare it to the corresponding language in en.yml to make sure I didn't screw up any translations. You can ignore the stuff outside of those two files. Let me know if I can be helpful.

It relates to the following issue #s: 
* Fixes #1722 
