### PR TITLE
Respect time zone in budget bar

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -142,7 +142,7 @@ class Patient
   # Methods
   def self.pledged_status_summary(line)
     plucked_attrs = [:fund_pledge, :pledge_sent, :id, :name, :appointment_date, :fund_pledged_at]
-    start_of_week = Time.zone.today.beginning_of_week(Config.start_day)
+    start_of_week = Time.zone.today.beginning_of_week(Config.start_day).in_time_zone
     # Get patients who have been pledged this week, as a simplified hash
     patients = Patient.in(line: line)
                       .where(:fund_pledge.nin => [0, nil, ''])


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

BRAF found a bug with the budget bar that stems from our casting to date being in UTC instead of eastern. This enforces timezone on our budget bar filter.

Tests TK because it's a late code change

This pull request makes the following changes:
* filters on a time instead of a date in budget bar, to account for timezone

no view changes, no issue