### PR TITLE
clarified instructions for using terminal

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -3,7 +3,7 @@
 The directions below get you to a point where you can run the app with a test-seeded database.
 
 * **First things first**: Make a copy of your own to wrench on by forking! Go to https://github.com/DCAFEngineering/dcaf_case_management and hit the `fork` button up in the top right.
-* **Second things second**: `git clone https://github.com/{YOUR GITHUB USERNAME}/dcaf_case_management` to pull it down to your local system
+* **Second things second**: `git clone https://github.com/{YOUR GITHUB USERNAME}/dcaf_case_management` to pull it down to your local system. Use `cd dcaf_case_management` to change directory to where you saved the clone.
 * **Third things third**: Add the source repo as the upstream with the command `git remote add upstream https://github.com/DCAFEngineering/dcaf_case_management`. This will let you update when the source repo changes by running the command `git pull upstream master`.
 * **Fourth things fourth**: Make the source repo fetch-only by unsetting the URL: `git remote set-url --push upstream no-pushing-to-upstream`. This will prevent mistakenly pushing to upstream if you get push access down the road.
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I added a sentence to the instructions that clarifies how to use the terminal to clone the github repository.

This pull request makes the following changes:
* adds a sentence that tells the user to change the directory before entering the next command into the terminal.
* (another change here)
* (etc)

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #X
* Bumps #Y
