### PR TITLE
Upgrade nokogiri to squelch a CVE warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Get the build passing by running bundle upgrade nokogiri.

This pull request makes the following changes:
* bump nokogiri to 1.10.4

no views, no issues