### PR TITLE
Requires roles for users. Adds default role of case manager to users#create

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,8 @@ class UsersController < ApplicationController
 
   def create
     raise Exceptions::UnauthorizedError unless current_user.admin?
-    @user = User.new(user_params)
+    binding.pry
+    @user = User.new(user_params.merge(role: :cm))
     hex = SecureRandom.urlsafe_base64
     @user.password, @user.password_confirmation = hex
     if @user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,6 @@ class UsersController < ApplicationController
 
   def create
     raise Exceptions::UnauthorizedError unless current_user.admin?
-    binding.pry
     @user = User.new(user_params.merge(role: :cm))
     hex = SecureRandom.urlsafe_base64
     @user.password, @user.password_confirmation = hex

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
 
   def create
     raise Exceptions::UnauthorizedError unless current_user.admin?
-    @user = User.new(user_params)
+    @user = User.new(user_params.merge(role: :cm))
     hex = SecureRandom.urlsafe_base64
     @user.password, @user.password_confirmation = hex
     if @user.save
@@ -95,7 +95,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :role)
+    params.require(:user).permit(:name, :email)
   end
 
   def user_not_demoting_themself?(user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
 
   def create
     raise Exceptions::UnauthorizedError unless current_user.admin?
-    @user = User.new(user_params.merge(role: :cm))
+    @user = User.new(user_params)
     hex = SecureRandom.urlsafe_base64
     @user.password, @user.password_confirmation = hex
     if @user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
 
   def create
     raise Exceptions::UnauthorizedError unless current_user.admin?
-    @user = User.new(user_params.merge(role: :cm))
+    @user = User.new(user_params)
     hex = SecureRandom.urlsafe_base64
     @user.password, @user.password_confirmation = hex
     if @user.save
@@ -95,7 +95,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email)
+    params.require(:user).permit(:name, :email, :role)
   end
 
   def user_not_demoting_themself?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User
   # Non-devise generated
   field :name, type: String
   field :line, type: String
-  field :role
+  field :role, default: :cm
 
   enumerize :role, in: [:cm, :admin, :data_volunteer], predicates: true
   field :call_order, type: Array # Manipulated by the call list controller

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,7 @@ class User
   # Validations
   # email presence validated through Devise
   validates :name, presence: true
+  validates :role, presence: true
   validate :secure_password
 
   TIME_BEFORE_DISABLED_BY_FUND = 9.months

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,5 +6,6 @@
         <%= f.submit t('common.add'), class: 'btn btn-primary' %>
     <% end %>
     <br>
+    <p><%= I18n.t('user.new.edit_role_after_creating') %></p>
     <%= link_to t('common.back'), :back %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,6 @@
     <%= bootstrap_form_for @user do |f| %>
         <%= f.email_field :email, label: t('common.email') %>
         <%= f.text_field :name, label: t('common.name') %>
-        <%= f.select :role, options_for_select(user_role_options), label: t('user.common.role') %>
         <%= f.submit t('common.add'), class: 'btn btn-primary' %>
     <% end %>
     <br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -541,6 +541,7 @@ en:
       user_account_management: User Account Management
     new:
       create_user: Create User
+      edit_role_after_creating: New users by default have CM permissions, which let them use the case management workflow. To give someone data access or admin permissions, edit them after you create their accounts here.
     profile_edit:
       awaiting_confirmation: 'Currently waiting for confirmation for: %{email}'
       change_password: Change your password

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -541,6 +541,7 @@ es:
       user_account_management: Administración de Cuentas de Usuario
     new:
       create_user: Crear Usuario
+      edit_role_after_creating: Los nuevos usuarios por defecto tienen permisos CM, lo que les permite usar el flujo de trabajo de administración de casos. Para dar a alguien acceso a datos o permisos de administrador, edítelos después de crear sus cuentas aquí.
     profile_edit:
       awaiting_confirmation: 'Actualmente en espera de confirmación para: %{email}'
       change_password: Cambia tu contraseña

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,9 +23,11 @@ user = User.create! name: 'testuser (admin)', email: 'test@test.com',
                    password: 'P4ssword', password_confirmation: 'P4ssword',
                    role: :admin
 user2 = User.create! name: 'testuser2', email: 'test2@test.com',
-                    password: 'P4ssword', password_confirmation: 'P4ssword'
+                    password: 'P4ssword', password_confirmation: 'P4ssword',
+                    role: :cm
 user3 = User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
-                    password: 'P4ssword', password_confirmation: 'P4ssword'
+                    password: 'P4ssword', password_confirmation: 'P4ssword',
+                    role: :cm
 
 # Seed a pair of clinics, Sample 1 and Sample 2
 Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '1600 Pennsylvania Ave',

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -101,13 +101,21 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   describe 'create method' do
-    it 'should create a user with the role cm' do
+    it 'can create a user with the role cm' do
       attributes = attributes_for(:user)
-      attributes.delete :role
       assert_difference 'User.count', 1 do
         post users_path, params: { user: attributes }
       end
       assert(User.last.role == :cm)
+    end
+
+    it 'can create a user with the role data_volunteer' do
+      attributes = attributes_for(:user)
+      attributes[:role] = :data_volunteer
+      assert_difference 'User.count', 1 do
+        post users_path, params: { user: attributes }
+      end
+      assert(User.last.role == :data_volunteer)
     end
 
     it 'should show errors if creation fails' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -101,7 +101,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   describe 'create method' do
-    it 'can create a user with the role cm' do
+    it 'should create a user with the role cm' do
       attributes = attributes_for(:user)
       assert_difference 'User.count', 1 do
         post users_path, params: { user: attributes }
@@ -109,14 +109,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert(User.last.role == :cm)
     end
 
-    it 'can create a user with the role data_volunteer' do
-      attributes = attributes_for(:user)
-      attributes[:role] = :data_volunteer
-      assert_difference 'User.count', 1 do
-        post users_path, params: { user: attributes }
-      end
-      assert(User.last.role == :data_volunteer)
-    end
 
     it 'should show errors if creation fails' do
       attributes = attributes_for(:user)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -101,12 +101,13 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   describe 'create method' do
-    it 'should create a user' do
+    it 'should create a user with the role cm' do
       attributes = attributes_for(:user)
       attributes.delete :role
       assert_difference 'User.count', 1 do
         post users_path, params: { user: attributes }
       end
+      assert(User.last.role == :cm)
     end
 
     it 'should show errors if creation fails' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -106,7 +106,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_difference 'User.count', 1 do
         post users_path, params: { user: attributes }
       end
-      assert_equal :cm, User.last.role
+      assert_equal "cm", User.last.role
     end
 
 

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     end
     password { 'FCZCidQP4C8GTz' }
     password_confirmation { 'FCZCidQP4C8GTz' }
+    role "cm"
   end
 end


### PR DESCRIPTION
Previously users were created without roles by default. This makes a few changes to correct this:
- Newly created users have role CM
- Users are required to have a role
- Updated tests/factories
Fixes #1749 