### PR TITLE
Remove unused datepicker library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'geokit' # clinic_finder service lat-lng
 # Stuff that we're targeting removal of
 gem 'figaro' # we handle secrets differently now
 gem 'js-routes' # Not sure if this is used anymore
-gem 'bootstrap_form-datetimepicker' # not sure if this is used anymore
 
 # Stuff we're hardsetting because of security concerns
 gem 'loofah', '>= 2.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,8 +67,6 @@ GEM
     bootstrap_form (4.2.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
-    bootstrap_form-datetimepicker (0.0.1)
-      bootstrap_form
     bson (4.3.0)
     bson_ext (1.5.1)
     builder (3.2.3)
@@ -412,7 +410,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4.1)
   bootstrap_form
-  bootstrap_form-datetimepicker
   bson_ext
   bundler-audit
   byebug


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This library hasn't been bumped in five years and we don't use it, and it's not compat with rails 6, so off it goes.

This pull request makes the following changes:
* remove bootstrap_form-datepicker library

It relates to the following issue #s: 
* Bumps #1589 
