### PR TITLE
Port patient dashboard partial; un-doubleapply container; restore form styling

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -164,7 +164,6 @@ html {
   font-size: $font-size;
 }
 main {
-  @extend .container;
   background-color: #ffffff;
   padding-bottom: 80px;
   width: 100%;
@@ -380,4 +379,13 @@ $daria-color-lt : #825fb9;
 
 #budget-progress-bar {
   margin-bottom: 1em;
+}
+
+// Form styling
+label {
+  font-weight: 700;
+}
+
+form {
+  line-height: 1.0;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,13 +18,11 @@
         <%= render 'layouts/navigation' %>
       </header>
     <% end %>
-    <main role="main">
-      <div class="container">
-        <%= render 'layouts/messages' %>
+    <main class="container" role="main">
+      <%= render 'layouts/messages' %>
 
-        <br>
-        <%= yield %>
-      </div>
+      <br>
+      <%= yield %>
     </main>
     <% if current_user.present? %>
       <footer>

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -1,39 +1,42 @@
 <div id="patient_dashboard_content">
   <%= bootstrap_form_for patient, html: { id: 'patient_dashboard_form' }, remote: true do |f| %>
-    <div class="col-sm-4" >
-      <%= f.text_field :name, label: t('patient.shared.name'), autocomplete: 'off' %>
-      <%= f.text_field :primary_phone, value: patient.primary_phone_display, label: t('patient.dashboard.phone'), autocomplete: 'off' %>
-    </div>
+    <div class="row">
 
-    <div class="col-sm-4">
-      <div class="row">
-        <div class="col-sm-6">
-          <%= f.select :last_menstrual_period_weeks,
-                       options_for_select(weeks_options, patient.last_menstrual_period_weeks ),
-                       label: t('patient.dashboard.weeks_along'),
-                       autocomplete: 'off',
-                       help: t('patient.dashboard.currently', weeks: patient.last_menstrual_period_now_weeks, days: patient.last_menstrual_period_now_days) %>
-        </div>
-        <div class="col-sm-6 hide-label">
-          <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), autocomplete: 'off', skip_label: true, help: t('patient.dashboard.called_on', date: patient.initial_call_date.strftime("%m/%d/%Y")) %>
-          <%= f.label :last_menstrual_period_days, t('common.days_along'), class: "sr-only" %>
-        </div>
+      <div class="col-4">
+        <%= f.text_field :name, label: t('patient.shared.name'), autocomplete: 'off', class: 'col' %>  
       </div>
-      <div class="row">
-        <div class="col-sm-12">
-          <p><strong><%= t 'patient.shared.status' %></strong> <span id='patient_status'><%= patient.status %></span> <%= tooltip_shell status_help_text(patient) %></p>
-        </div>
+      
+      <div class="col">
+        <%= f.select :last_menstrual_period_weeks,
+                     options_for_select(weeks_options, patient.last_menstrual_period_weeks ),
+                     label: t('patient.dashboard.weeks_along'),
+                     autocomplete: 'off',
+                     help: t('patient.dashboard.currently', weeks: patient.last_menstrual_period_now_weeks, days: patient.last_menstrual_period_now_days) %>
       </div>
-    </div>
 
-    <div class="col-sm-4">
-      <div class="row">
+      <div class="col hide-label">
+        <%= f.select :last_menstrual_period_days, options_for_select(days_options, patient.last_menstrual_period_days ), autocomplete: 'off', skip_label: true, help: t('patient.dashboard.called_on', date: patient.initial_call_date.strftime("%m/%d/%Y")) %>
+        <%= f.label :last_menstrual_period_days, t('common.days_along'), class: "sr-only" %>
+      </div>          
+
+      <div class="col-3">
         <%= f.date_field :appointment_date,
                          label: t('patient.shared.appt_date'),
                          autocomplete: 'off',
                          help: t('patient.dashboard.approx_gestation', weeks: patient.last_menstrual_period_at_appt_weeks, days: patient.last_menstrual_period_at_appt_days) %>
       </div>
-      <div class="row">
+    </div>
+
+    <div class="row">
+      <div class="col-4">
+        <%= f.text_field :primary_phone, value: patient.primary_phone_display, label: t('patient.dashboard.phone'), autocomplete: 'off' %>
+      </div>
+
+      <div class="col">
+        <p><strong><%= t 'patient.shared.status' %></strong> <span id='patient_status'><%= patient.status %></span> <%= tooltip_shell status_help_text(patient) %></p>
+      </div>
+
+      <div class="col-3">
         <% if current_user.admin? %>
           <%= link_to t('patient.dashboard.delete'), patient_path(patient), class: 'btn btn-danger', method: :delete, data: { confirm: t('patient.dashboard.confirm_del', name: patient.name) }, remote: true %>
         <% end %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "patients/modal" %>
 
-<div id="patient_dashboard" class="row">
+<div id="patient_dashboard">
   <%= render 'patients/patient_dashboard', patient: @patient %>
 </div>
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

BS4's grid system uses flexboxes now, which are MUCH more forgiving about equal spacing and don't require us to define columns with numbers, so we port the top header there to that style.

Along the way we make some changes to not double-apply container (it was happening on both `main` and `div.container` blocks), and do some tweaking to restore form fields being bolded, and to compress the form line height a little bit so it doesn't run on.

Note that this goes into a feature branch rather than master.

This pull request makes the following changes:
* removes double-applied container
* adds some form css to bold form labels and compress forms
* refactors patient dashboard into columns

before:
![image](https://user-images.githubusercontent.com/3866868/64070490-2ce14200-cc2f-11e9-9299-e07f94db6ed5.png)

after (only real diff is that status moves up to label level, I think):
![image](https://user-images.githubusercontent.com/3866868/64070495-37034080-cc2f-11e9-94fa-bcf2d3d1f66a.png)


It relates to the following issue #s: 
* Bumps #1632 
