### PR TITLE
upgrade devise to 4.7 to squelch a vuln

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'enumerize' # Mongoid doesn't have enum out of the box, so we get it here
 gem 'mongoid_rails_migrations' # Mongoid also does not have migrations out of the box, so we get that here
 
 # Our authentication library is devise, with oauth2 for google signin
-gem 'devise', '~> 4.6'
+gem 'devise', '~> 4.7'
 gem 'omniauth-google-oauth2', '~> 0.6.0'
 
 # We use `bootstrap_form_for` in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.4.8)
       execjs
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
@@ -102,10 +102,10 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     database_cleaner (1.7.0)
-    devise (4.6.1)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 6.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     docile (1.3.1)
@@ -295,7 +295,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     rails-i18n (5.1.2)
       i18n (>= 0.7, < 2)
@@ -307,16 +307,16 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (6.0.4)
     render_async (1.2.0)
       bundler (~> 1.8)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rubocop (0.59.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -418,7 +418,7 @@ DEPENDENCIES
   codecov
   coffee-rails (~> 4.2.2)
   database_cleaner
-  devise (~> 4.6)
+  devise (~> 4.7)
   enumerize
   factory_bot_rails
   faker


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bump devise to squelch a vuln

This pull request makes the following changes:
* `bundle update devise`

no issues