### PR TITLE
BS4: Remix abortion info partial

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -389,3 +389,7 @@ label {
 form {
   line-height: 1.0;
 }
+
+.patient-section-title {
+  margin-top: .5em;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -398,3 +398,7 @@ form {
 .top-spacer {
   margin-top: .75em;
 }
+
+.hidden {
+  display: none;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -356,12 +356,11 @@ $daria-color-lt : #825fb9;
 //   @extend .input-group-addon;
 // }
 
-.form-check label{
+.form-check label {
   min-height: 20px;
-  padding-left: 2em;
-  margin-bottom: 0;
   font-weight: 400;
   cursor: pointer;
+  line-height: 1.5;
 }
 
 .form-check-label{
@@ -376,6 +375,8 @@ $daria-color-lt : #825fb9;
 .tooltip-inner {
   font-size: 12px;
 }
+
+
 
 #budget-progress-bar {
   margin-bottom: 1em;
@@ -392,4 +393,8 @@ form {
 
 .patient-section-title {
   margin-top: .5em;
+}
+
+.top-spacer {
+  margin-top: .75em;
 }

--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -21,52 +21,30 @@ $font-size: 17px;
   padding-left: 9.5%;
 }
 
-#menu {
-  height: 70vh;
-  ul{
-    li{
-      a{
-      &:hover{
-        color: lighten(#337ab7, 20%)
-        }
-      }
-    }
-  }
-}
-
-.abortion-left-menu {
+.abortion-left-menu.nav-pills {
   font-size: 22px;
 
-  li {
-    // padding-left: 10px;
+  .nav-link {
+    color: #337ab7;
     background-color: white;
-
-    a:hover {
-      color: #337ab7;
-      background-color: white;
-    }
   }
 
-  li.active {
+  a.nav-link.active {
+    color: #5D3E8D;
+    background-color: white;
 
-    a, a:hover, a:active, a:focus {
-      color: #5D3E8D;
-      background-color: white;
-    }
-
-    a:before {
+    &:before {
       font-family: 'Glyphicons Halflings';
       content: "\e080";
       margin-left: -1.5em;
-      padding-right: .5em;
-      color: #5D3E8D;
-
+      padding-right: .85em;
+      color: #5D3E8D;      
     }
   }
+
   a.submit-btn, a.cancel-btn {
     font-size: 22px;
   }
-
 }
 
 .border-side {

--- a/app/javascript/src/clinic_finder.js
+++ b/app/javascript/src/clinic_finder.js
@@ -1,6 +1,6 @@
 $(document).on('turbolinks:load', () => {
   // Click on the clinic-locator expand to show it.
   $(document).on('click', '.clinic-finder-expand', () => {
-    $('#clinic-finder-search-form').toggleClass('hide');
+    $('#clinic-finder-search-form').toggleClass('hidden');
   });
 });

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -1,46 +1,49 @@
-<div class="row col clinic_finder_container">
-  <h4 class="clinic-finder-expand patient-section-title">
-    <%= t('clinic_locator.title') %>
-    <small><%= t('clinic_locator.experimental_note') %></small>
-    <span class='glyphicon glyphicon-plus-sign pull-right'></span>
-  </h4>
+<div class="card clinic_finder_container">
+  <div class="card-header">
+    <h4 class="clinic-finder-expand patient-section-title">
+      <%= t('clinic_locator.title') %>
+      <small><%= t('clinic_locator.experimental_note') %></small>
+      <span class='glyphicon glyphicon-plus-sign mr-auto'>glyph</span>
+    </h4>
+  </div>
 
-
-  <div class='col-sm-12 hide' id='clinic-finder-search-form'>
+  <div class="card-body hidden" id="clinic-finder-search-form">
     <h5><%= t('clinic_locator.description') %></h5>
 
-    <%= bootstrap_form_tag url: clinicfinder_search_path, remote: true do |f| %>
+    <%= bootstrap_form_with url: clinicfinder_search_path,
+                            remote: true do |f| %>
       <%= f.hidden_field :locale, value: params[:locale] %>
       <div class="row">
-        <div class="col-sm-6 info-form-left">
+        <div class="col info-form-left">
           <%= f.text_field :zip, label: t('clinic_locator.patient_zip_code') %>
           <%= f.check_box :naf_only, label: t('clinic_locator.naf_only_toggle') %>
           <%= f.check_box :medicaid_only, label: t('clinic_locator.medicaid_only_toggle') %>
         </div>
 
-        <div class="col-sm-3 info-form-right">
-          <%= f.select :gestation_weeks,
-                       options_for_select(weeks_options, patient.last_menstrual_period_now_weeks),
-                       label: t('clinic_locator.gestation_above'),
-                       autocomplete: 'off' %>
-        </div>
-
-        <div class="col-sm-3 info-form-right hide-label">
-          <%= f.select :gestation_days,
-                       options_for_select(days_options, patient.last_menstrual_period_now_days),
-                       skip_label: true,
-                       autocomplete: 'off' %>
-          <%= f.label :last_menstrual_period_days, t('common.days_along'), class: "sr-only" %>
+        <div class="col info-form-right">
+          <div class="row">
+            <div class="col">
+              <%= f.select :gestation_weeks,
+                           options_for_select(weeks_options, patient.last_menstrual_period_now_weeks),
+                           label: t('clinic_locator.gestation_above'),
+                           autocomplete: 'off' %>
+            </div>
+            <div class="col">
+              <%= f.select :gestation_days,
+                           options_for_select(days_options, patient.last_menstrual_period_now_days),
+                           hide_label: true, 
+                           autocomplete: 'off' %>
+              <%= f.label :last_menstrual_period_days,
+                          t('common.days_along'),
+                          class: "sr-only" %>
+            </div>
+          </div>
         </div>
       </div>
 
-      <div class="row">
-        <div class='col-sm-6'>
-          <%= f.submit t('clinic_locator.search_button'), class: "btn btn-primary" %>
-        </div>
-      </div>
+      <%= f.submit t('clinic_locator.search_button'), class: "btn btn-primary" %>
     <% end %>
-  </div>
 
-  <div class='col-sm-12' id='clinic-finder-results'></div>
+    <div class="row col" id="clinic-finder-results"></div>
+  </div>
 </div>

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -3,7 +3,7 @@
     <h4 class="clinic-finder-expand patient-section-title">
       <%= t('clinic_locator.title') %>
       <small><%= t('clinic_locator.experimental_note') %></small>
-      <span class='glyphicon glyphicon-plus-sign mr-auto'>glyph</span>
+      <span class='glyphicon glyphicon-plus-sign float-right'>glyph</span>
     </h4>
   </div>
 
@@ -14,29 +14,27 @@
                             remote: true do |f| %>
       <%= f.hidden_field :locale, value: params[:locale] %>
       <div class="row">
-        <div class="col info-form-left">
+        <div class="col">
           <%= f.text_field :zip, label: t('clinic_locator.patient_zip_code') %>
           <%= f.check_box :naf_only, label: t('clinic_locator.naf_only_toggle') %>
           <%= f.check_box :medicaid_only, label: t('clinic_locator.medicaid_only_toggle') %>
         </div>
 
-        <div class="col info-form-right">
-          <div class="row">
-            <div class="col">
-              <%= f.select :gestation_weeks,
-                           options_for_select(weeks_options, patient.last_menstrual_period_now_weeks),
-                           label: t('clinic_locator.gestation_above'),
-                           autocomplete: 'off' %>
-            </div>
-            <div class="col">
-              <%= f.select :gestation_days,
-                           options_for_select(days_options, patient.last_menstrual_period_now_days),
-                           hide_label: true, 
-                           autocomplete: 'off' %>
-              <%= f.label :last_menstrual_period_days,
-                          t('common.days_along'),
-                          class: "sr-only" %>
-            </div>
+        <div class="col">
+          <div class="col">
+            <%= f.select :gestation_weeks,
+                         options_for_select(weeks_options, patient.last_menstrual_period_now_weeks),
+                         label: t('clinic_locator.gestation_above'),
+                         autocomplete: 'off' %>
+          </div>
+          <div class="col">
+            <%= f.select :gestation_days,
+                         options_for_select(days_options, patient.last_menstrual_period_now_days),
+                         hide_label: true, 
+                         autocomplete: 'off' %>
+            <%= f.label :last_menstrual_period_days,
+                        t('common.days_along'),
+                        class: "sr-only" %>
           </div>
         </div>
       </div>

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -1,5 +1,5 @@
-<div class='col-sm-12'>
-  <h4 class='clinic-finder-expand'>
+<div class="row col clinic_finder_container">
+  <h4 class="clinic-finder-expand patient-section-title">
     <%= t('clinic_locator.title') %>
     <small><%= t('clinic_locator.experimental_note') %></small>
     <span class='glyphicon glyphicon-plus-sign pull-right'></span>

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -1,64 +1,51 @@
-<section id="abortion_information_content">
-  <div id="patient_fields" class="col-sm-12">
-    <div class="row">
-      <div class="col-sm-12">
-        <h2><%= t('patient.abortion_information.title') %></h2>
+<div id="abortion_information_content">
+  <h2 class="patient-section-title"><%= t('patient.abortion_information.title') %></h2>
 
-        <% if patient.practical_supports.any? %>
-          <h5 class="text-danger">This patient requires practical support. See Practical Support tab.</h5>
+  <div class="practical-support-flag">
+    <% if patient.practical_supports.any? %>
+      <h5 class="text-danger">This patient requires practical support. See Practical Support tab.</h5>
+    <% end %>
+  </div>
+
+  <h3><%= t('patient.abortion_information.clinic_section.title') %></h3>
+
+  <%= bootstrap_form_with model: patient,
+                          html: { id: 'abortion-information-form-1' },
+                          remote: true do |f| %>
+    <div class="row info-form">
+      <div class="col info-form-left">
+        <%= f.select :clinic_id,
+                     options_for_select(clinic_options, patient.clinic.try(:id)),
+                     label: t('patient.abortion_information.clinic_section.clinic') %>
+
+        <%= f.form_group :clinic_filters do %>
+          <%= f.check_box :naf_filter, label: t('patient.abortion_information.clinic_section.naf_only_toggle') %>
+          <%= f.check_box :medicaid_filter, label: t('patient.abortion_information.clinic_section.medicaid_only_toggle') %>
+        <% end %>
+      </div>
+
+      <div class="col info-form-right">
+        <%= f.form_group :abortion_info_checkboxes do %>
+          <%= f.check_box :resolved_without_fund, 
+                          label: t('patient.abortion_information.clinic_section.resolved_without_fund', fund: "#{FUND}"),
+                          label_class: 'tooltip-header-checkbox',
+                          data: { 'tooltip-text': resolved_without_fund_help_text } %>
+          <%= f.check_box :referred_to_clinic,
+                          label: t('patient.abortion_information.clinic_section.referred_to_clinic'),
+                          label_class: 'tooltip-header-checkbox',
+                          data: { 'tooltip-text': referred_to_clinic_help_text } %>
+          <%= f.check_box :completed_ultrasound,
+                          label: t('patient.abortion_information.clinic_section.ultrasound_completed'),
+                          label_class: 'tooltip-header-checkbox',
+                          data: { 'tooltip-text': mandatory_ultrasound_help_text } %>
         <% end %>
       </div>
     </div>
+  <% end %>
 
-    <div class="row">
-      <div class="col-sm-12 info-form">
-        <h3><%= t('patient.abortion_information.clinic_section.title') %></h3>
-
-        <%= bootstrap_form_for patient, html: { id: 'abortion-information-form-1' }, remote: true do |f| %>
-          <div class="col-sm-6">
-            <div class="info-form-left">
-              <%= f.select :clinic_id,
-                options_for_select(clinic_options, patient.clinic.try(:id)),
-                label: t('patient.abortion_information.clinic_section.clinic') %>
-              <div class="checkbox">
-                <%= label_tag 'naf_filter' do %>
-                  <%= check_box_tag 'naf_filter' %>
-                  <%= t('patient.abortion_information.clinic_section.naf_only_toggle') %>
-                <% end %>
-              </div>
-              <div class="checkbox">
-                <%= label_tag 'medicaid_filter' do %>
-                  <%= check_box_tag 'medicaid_filter' %>
-                  <%= t('patient.abortion_information.clinic_section.medicaid_only_toggle') %>
-                <% end %>
-              </div>
-            </div>
-          </div>
-
-          <div class="col-sm-6">
-            <div class="info-form-right">
-              <%= f.check_box :resolved_without_fund, 
-                label: t('patient.abortion_information.clinic_section.resolved_without_fund', fund: "#{FUND}"),
-                              label_class: 'tooltip-header-checkbox',
-                              data: { 'tooltip-text': resolved_without_fund_help_text } %>
-              <%= f.check_box :referred_to_clinic,
-                              label: t('patient.abortion_information.clinic_section.referred_to_clinic'),
-                              label_class: 'tooltip-header-checkbox',
-                              data: { 'tooltip-text': referred_to_clinic_help_text } %>
-              <%= f.check_box :completed_ultrasound,
-                              label: t('patient.abortion_information.clinic_section.ultrasound_completed'),
-                              label_class: 'tooltip-header-checkbox',
-                              data: { 'tooltip-text': mandatory_ultrasound_help_text } %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="row col-md-12 clinic_finder_container">
-      <%= render partial: 'clinicfinders/search_form',
-                 locals: { patient: patient } %>
-    </div>
+  <div class="row col clinic_finder_container">
+    <%= render partial: 'clinicfinders/search_form',
+               locals: { patient: patient } %>
   </div>
 
   <div id="cost_fields" class="col-sm-12">

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -48,7 +48,6 @@
 
   <h3 class="patient-section-title"><%= t('patient.abortion_information.cost_section.title') %></h3>
 
-
   <%= bootstrap_form_with model: patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
     <div class="row patient-cost-fields">
       <div class="col">

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -43,55 +43,62 @@
     </div>
   <% end %>
 
-  <div class="row col clinic_finder_container">
-    <%= render partial: 'clinicfinders/search_form',
-               locals: { patient: patient } %>
-  </div>
+  <%= render partial: 'clinicfinders/search_form',
+             locals: { patient: patient } %>
 
-  <div id="cost_fields" class="col-sm-12">
-    <div class="row">
-      <div class="col-sm-12">
-        <h3><%= t('patient.abortion_information.cost_section.title') %></h3>
+  <h3 class="patient-section-title"><%= t('patient.abortion_information.cost_section.title') %></h3>
+
+
+  <%= bootstrap_form_with model: patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
+    <div class="row patient-cost-fields">
+      <div class="col">
+        <%= f.number_field :procedure_cost,
+                           label: t('patient.abortion_information.cost_section.abortion_cost'),
+                           autocomplete: 'off',
+                           prepend: '$' %>
+
+        <div class="info-form-left form-group outstanding-balance-ctn hidden">
+          <label class="col-form-label"><%= t('patient.abortion_information.cost_section.outstanding_balance') %></label>
+          <div id="outstanding-balance"></div>
+        </div>
+      </div>
+
+      <div class="col">
+        <div id="pledge-contributions">
+          <%= f.number_field :patient_contribution,
+                             label: t('patient.abortion_information.cost_section.patient_contribution'),
+                             autocomplete: 'off',
+                             prepend: '$' %>
+          <%= f.number_field :naf_pledge,
+                             label: t('patient.abortion_information.cost_section.naf_pledge'),
+                             autocomplete: 'off',
+                             prepend: '$' %>
+          <%= f.number_field :fund_pledge,
+                             label: t('patient.abortion_information.cost_section.fund_pledge', fund: "#{FUND}"),
+                             autocomplete: 'off',
+                             prepend: '$',
+                             label_class: 'tooltip-header-input',
+                             data: { 'tooltip-text' => pledge_limit_help_text_options.join("<br />") } %>
+        </div>
       </div>
     </div>
-
-    <div class="row col-sm-12" >
-      <div class="patient_cost_fields">
-        <%= bootstrap_form_for patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
-          <div class="col-sm-6">
-            <%= f.number_field :procedure_cost, label: t('patient.abortion_information.cost_section.abortion_cost'), autocomplete: 'off', prepend: '$' %>
-
-            <div class="info-form-left form-group outstanding-balance-ctn hidden">
-              <label class="col-form-label"><%= t('patient.abortion_information.cost_section.outstanding_balance') %></label>
-              <div id="outstanding-balance"></div>
-            </div>
-          </div>
-
-          <div class="col-sm-6">
-            <div id="pledge-contributions">
-              <%= f.number_field :patient_contribution, label: t('patient.abortion_information.cost_section.patient_contribution'), autocomplete: 'off', prepend: '$' %>
-              <%= f.number_field :naf_pledge, label: t('patient.abortion_information.cost_section.naf_pledge'), autocomplete: 'off', prepend: '$' %>
-              <%= f.number_field :fund_pledge, label: t('patient.abortion_information.cost_section.fund_pledge', fund: "#{FUND}"), autocomplete: 'off', prepend: '$', label_class: 'tooltip-header-input', data: { 'tooltip-text' => pledge_limit_help_text_options.join("<br />") } %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  </div>
+  <% end %>
 
   <div id="external_pledges" class="col-sm-12">
-    <div class="row col-sm-12">
-      <div class="col-sm-6">
-        <!-- Future right of math -->
-      </div>
+    <div class="row external-pledge-fields">
+      <div class="col"><!-- intentionally empty --></div>
 
-      <div class="col-sm-6">
-        <%= render partial: 'external_pledges/external_pledges_table', locals: { patient: patient, external_pledges: patient.external_pledges.order_by('created_at desc') } %>
+      <div class="col">
+        <%= render partial: 'external_pledges/external_pledges_table',
+                   locals: { patient: patient,
+                             external_pledges: patient.external_pledges.order_by('created_at desc') } %>
 
         <div id="new-external-pledge">
-          <%= render partial: 'external_pledges/new', locals: { patient: patient, new_external_pledge: new_external_pledge } %>
+          <%= render partial: 'external_pledges/new',
+                     locals: { patient: patient,
+                               new_external_pledge: new_external_pledge } %>
         </div>
       </div>
     </div>
   </div>
-</section>
+</div>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -1,5 +1,5 @@
-<section id='menu-content' class="abortion-left-menu">
-  <ul class="nav nav-pills nav-stacked" id='menu-list'>
+<section id='menu-content'>
+  <div class="nav nav-pills flex-column abortion-left-menu" id='menu-list' role='tablist' aria-orientation="vertical">
     <%= render 'menu_item', link_for: 'patient_information', active: true %>
     <%= render 'menu_item', link_for: 'abortion_information', active: false %>
     <%= render 'menu_item', link_for: 'practical_support', active: false unless Config.hide_practical_support? %>
@@ -10,11 +10,10 @@
     <% if current_user.allowed_data_access? && patient.pledge_sent? %>
       <%= render 'menu_item', link_for: 'pledge_fulfillment', active: false %>
     <% end %>
-  </ul>
-
-  <div class="row">
-    <div class="col-sm-10" id='menu-pledge-button'>
-      <%= render 'menu_pledge_button', patient: patient %>
-    </div>
   </div>
 </section>
+
+<div id="menu-pledge-button">
+  <%= render 'menu_pledge_button', patient: patient %>
+</div>
+

--- a/app/views/patients/_menu_item.html.erb
+++ b/app/views/patients/_menu_item.html.erb
@@ -1,3 +1,7 @@
-<li class='<%= "active" if active %>' id='<%= link_for %>-menu-item'>
-  <%= link_to t("patient.menu.#{link_for}"), "##{link_for}", data: { toggle: 'tab' } %>
-</li>
+<%= link_to t("patient.menu.#{link_for}"),
+            "##{link_for}",
+            data: { toggle: 'pill' },
+            aria: { controls: link_for, selected: active },
+            role: 'tab',
+            class: "nav-link #{'active' if active}",
+            id: "#{link_for}-menu-item" %>

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -1,9 +1,7 @@
 <div id="patient_information_content">
-
   <h2 class="patient-section-title"><%= t 'patient.information.title' %></h2>
 
   <%= bootstrap_form_with model: patient, html: { id: 'patient_information_form' }, remote: true do |f| %>
-
     <div class="row">
       <div class="col info-form-left">
         <% if current_user.admin? %>
@@ -13,23 +11,139 @@
         <% end %>
 
         <%= f.number_field :age, autocomplete: 'off' %>
-
         <%= f.select :race_ethnicity,
                      options_for_select(race_ethnicity_options,
                                         patient.race_ethnicity),
                      autocomplete: 'off' %>
+        <%= f.select :language,
+                     options_for_select(language_options,
+                                       patient.language),
+                     label: t('patient.information.language'),
+                     autocomplete: 'off' %>
+        <%= f.select :voicemail_preference,
+                     options_for_select(voicemail_options,
+                                        patient.voicemail_preference),
+                     label: t('patient.information.voicemail_preference') %>
+        <%= f.check_box :textable,
+                        label: t('patient.information.textable'),
+                        checked: patient.textable? %>
 
-        REST OF IT
-        
+        <div class="row top-spacer">
+          <div class="col-8">
+            <%= f.text_field :city, autocomplete: 'off' %>
+          </div>
+          <div class="col-4">
+            <%= f.text_field :state, autocomplete: 'off' %>
+          </div>
+        </div>
+
+        <%= f.text_field :county, autocomplete: 'off' %>
+
+        <h3><%= t 'patient.information.other_contact.title' %></h3>
+        <%= f.text_field :other_contact,
+                         autocomplete: 'off',
+                         label: t('patient.information.other_contact.name') %>
+        <%= f.text_field :other_phone,
+                         value: patient.other_phone_display,
+                         autocomplete: 'off',
+                         label: t('patient.information.other_contact.phone') %>
+        <%= f.text_field :other_contact_relationship,
+                         autocomplete: 'off',
+                         label: t('patient.information.other_contact.relationship')%>
       </div>
 
       <div class="col info-form-right">
-        THE WHOLE RIGHT SIDE
+        <%= f.select :employment_status,
+                     options_for_select(employment_status_options,
+                                        patient.employment_status),
+                     autocomplete: 'off' %>
+        <%= f.select :income,
+                     options_for_select(income_options,
+                                        patient.income),
+                     help: t('patient.information.income_help'),
+                     autocomplete: 'off' %>
 
+        <div class="row">
+          <div class="col">
+            <%= f.select :household_size_adults,
+                          options_for_select(household_size_options,
+                                             patient.household_size_adults),
+                                             help: t('patient.information.household_help') %>
+          </div>
+          <div class="col">
+            <%= f.select :household_size_children,
+                          options_for_select(household_size_options,
+                                             patient.household_size_children) %>
+          </div>
+        </div>
 
+        <%= f.select :insurance,
+                     options_for_select(insurance_options(patient.insurance),
+                                        patient.insurance),
+                     label: t('patient.information.insurance') %>
+        <%= f.select :referred_by,
+                     options_for_select(referred_by_options,
+                                        patient.referred_by),
+                     label: t('patient.information.referred_by', fund: "#{FUND}"),
+                     autocomplete: 'off' %>
+
+        <fieldset>
+          <legend class="font-weight-bold" id="special_circumstances_label">
+            <%= t 'patient.information.special_circumstances.title' %>    
+          </legend>
+
+          <%= f.form_group :special_circumstances do %>
+            <div class="row">
+              <div class="col">
+                <%= f.check_box :special_circumstances, {
+                                label: t('patient.information.special_circumstances.fetal_diagnosis'), 
+                                name: 'patient[special_circumstances][]',
+                                checked: patient.special_circumstances.include?('Fetal diagnosis'), 
+                                id: 'fetal_patient_special_circumstances' },
+                                'Fetal diagnosis', '' %>
+                <%= f.check_box :special_circumstances, {
+                                label: t('patient.information.special_circumstances.homelessness'),
+                                name: 'patient[special_circumstances][]',
+                                checked: patient.special_circumstances.include?('Homelessness'),
+                                id: 'home_patient_special_circumstances' },
+                                'Homelessness', '' %>
+                <%= f.check_box :special_circumstances, {
+                                label: t('patient.information.special_circumstances.domestic_violence'),
+                                name: 'patient[special_circumstances][]',
+                                checked: patient.special_circumstances.include?('Domestic violence'),
+                                id: 'domestic_patient_special_circumstances' },
+                                'Domestic violence', '' %>
+                <%= f.check_box :special_circumstances, {
+                                label: t('patient.information.special_circumstances.other_medical_issue'),
+                                name: 'patient[special_circumstances][]',
+                                checked: patient.special_circumstances.include?('Other medical issue'),
+                                id: 'other_patient_special_circumstances' },
+                                'Other medical issue', '' %>
+              </div>
+              <div class="col">
+                <%= f.check_box :special_circumstances, {
+                                label: t('patient.information.special_circumstances.rape'),
+                                name: 'patient[special_circumstances][]',
+                                checked: patient.special_circumstances.include?('Rape'),
+                                id: 'rape_patient_special_circumstances' },
+                                'Rape', '' %>
+                <%= f.check_box :special_circumstances, {
+                                label: t('patient.information.special_circumstances.incest'),
+                                name: 'patient[special_circumstances][]',
+                                checked: patient.special_circumstances.include?('Incest'),
+                                id: 'incest_patient_special_circumstances' },
+                                'Incest', '' %>
+                <%= f.check_box :special_circumstances, {
+                                label: t('patient.information.special_circumstances.prison'),
+                                name: 'patient[special_circumstances][]',
+                                checked: patient.special_circumstances.include?('Prison'),
+                                id: 'prison_patient_special_circumstances' },
+                                'Prison', '' %>
+              </div>
+            </div>
+          <% end %>
+        </fieldset>
       </div>
-
     </div>
   <% end %>
-
 </div>

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -1,119 +1,35 @@
-<section id="patient_information_content">
-  <%= bootstrap_form_for patient, html: { id: 'patient_information_form' }, remote: true do |f| %>
-    <div class="col-sm-12">
-      <div class="row">
-        <div class="col-sm-12">
-          <h2><%= t 'patient.information.title' %></h2>
-        </div>
+<div id="patient_information_content">
+
+  <h2 class="patient-section-title"><%= t 'patient.information.title' %></h2>
+
+  <%= bootstrap_form_with model: patient, html: { id: 'patient_information_form' }, remote: true do |f| %>
+
+    <div class="row">
+      <div class="col info-form-left">
+        <% if current_user.admin? %>
+          <%= f.select :line,
+                     options_for_select(lines,
+                                        patient.line) %>
+        <% end %>
+
+        <%= f.number_field :age, autocomplete: 'off' %>
+
+        <%= f.select :race_ethnicity,
+                     options_for_select(race_ethnicity_options,
+                                        patient.race_ethnicity),
+                     autocomplete: 'off' %>
+
+        REST OF IT
+        
       </div>
 
-      <div class="row">
-        <div class="info-form-left col-sm-6">
-          <% if current_user.admin? %>
-            <%= f.select :line,
-                       options_for_select(lines,
-                                          patient.line) %>
-          <% end %>
-          <%= f.number_field :age, autocomplete: 'off' %>
-          <%= f.select :race_ethnicity,
-                       options_for_select(race_ethnicity_options,
-                                          patient.race_ethnicity),
-                                          autocomplete: 'off' %>
-
-          <%= f.form_group :language do %>
-            <%= f.select :language,
-                       options_for_select(language_options,
-                                          patient.language),
-                                          label: t('patient.information.language'),
-                                          autocomplete: 'off' %>
-          <% end %>
-
-          <%= f.select :voicemail_preference,
-                       options_for_select(voicemail_options,
-                                          patient.voicemail_preference),
-                       label: t('patient.information.voicemail_preference') %>
-          <div class="form-group">
-            <%= f.check_box :textable, label: t('patient.information.textable'), checked: patient.textable?  %>
-          </div>
-
-          <div class="row">
-            <div class="col-sm-8">
-              <%= f.text_field :city, autocomplete: 'off' %>
-            </div>
-            <div class="col-sm-4">
-              <%= f.text_field :state, autocomplete: 'off' %>
-            </div>
-          </div>
-
-          <%= f.text_field :county, autocomplete: 'off' %>
-
-          <h3><%= t 'patient.information.other_contact.title' %></h3>
-            <%= f.text_field :other_contact, autocomplete: 'off', label: t('patient.information.other_contact.name') %>
-            <%= f.text_field :other_phone, value: patient.other_phone_display, autocomplete: 'off', label: t('patient.information.other_contact.phone')%>
-            <%= f.text_field :other_contact_relationship, autocomplete: 'off', label: t('patient.information.other_contact.relationship')%>
-        </div>
-
-        <div class="info-form-right col-sm-6">
-          <%= f.select :employment_status,
-                       options_for_select(employment_status_options,
-                                          patient.employment_status),
-                                          autocomplete: 'off' %>
-          <%= f.select :income,
-                       options_for_select(income_options,
-                                          patient.income),
-                                          help: t('patient.information.income_help'),
-                                          autocomplete: 'off' %>
-          <div class="row">
-            <div class="col-sm-6">
-              <%= f.select :household_size_adults,
-                            options_for_select(household_size_options,
-                                               patient.household_size_adults),
-                                               help: t('patient.information.household_help') %>
-            </div>
-            <div class="col-sm-6">
-              <%= f.select :household_size_children,
-                            options_for_select(household_size_options,
-                                               patient.household_size_children) %>
-            </div>
-          </div>
-
-          <%= f.select :insurance,
-                       options_for_select(insurance_options(patient.insurance),
-                                          patient.insurance),
-                                          label: t('patient.information.insurance') %>
-          <%= f.select :referred_by,
-                       options_for_select(referred_by_options,
-                                          patient.referred_by),
-                                          label: t('patient.information.referred_by', fund: "#{FUND}"),
-                                          autocomplete: 'off' %>
+      <div class="col info-form-right">
+        THE WHOLE RIGHT SIDE
 
 
-
-          <fieldset>
-            <legend style="font-weight:bold" id="special_circumstances_label"><%= t 'patient.information.special_circumstances.title' %></legend>
-            <%= f.form_group :special_circumstances do %>
-              <div class="col-sm-6">
-                <%= f.check_box :special_circumstances, { label: t('patient.information.special_circumstances.fetal_diagnosis'), name: 'patient[special_circumstances][]',
-                                checked: patient.special_circumstances.include?('Fetal diagnosis'), id: 'Fetal_patient_special_circumstances' }, 'Fetal diagnosis', '' %>
-                <%= f.check_box :special_circumstances, { label: t('patient.information.special_circumstances.homelessness'), name: 'patient[special_circumstances][]',
-                                checked: patient.special_circumstances.include?('Homelessness'), id: 'Home_patient_special_circumstances' }, 'Homelessness', '' %>
-                <%= f.check_box :special_circumstances, { label: t('patient.information.special_circumstances.domestic_violence'), name: 'patient[special_circumstances][]',
-                                checked: patient.special_circumstances.include?('Domestic violence'), id: 'Domestic_patient_special_circumstances' }, 'Domestic violence', '' %>
-                <%= f.check_box :special_circumstances, { label: t('patient.information.special_circumstances.other_medical_issue'), name: 'patient[special_circumstances][]',
-                                checked: patient.special_circumstances.include?('Other medical issue'), id: 'Other_patient_special_circumstances' }, 'Other medical issue', '' %>
-              </div>
-              <div class="col-sm-6">
-              <%= f.check_box :special_circumstances, { label: t('patient.information.special_circumstances.rape'), name: 'patient[special_circumstances][]',
-                                checked: patient.special_circumstances.include?('Rape'), id: 'Rape_patient_special_circumstances' }, 'Rape', '' %>
-              <%= f.check_box :special_circumstances, { label: t('patient.information.special_circumstances.incest'), name: 'patient[special_circumstances][]',
-                                checked: patient.special_circumstances.include?('Incest'), id: 'Incest_patient_special_circumstances' }, 'Incest', '' %>
-              <%= f.check_box :special_circumstances, { label: t('patient.information.special_circumstances.prison'), name: 'patient[special_circumstances][]',
-                                checked: patient.special_circumstances.include?('Prison'), id: 'Prison_patient_special_circumstances' }, 'Prison', '' %>
-              </div>
-            <% end %>
-          </fieldset>
-        </div>
       </div>
+
     </div>
   <% end %>
-</section>
+
+</div>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -5,13 +5,11 @@
 </div>
 
 <div id="patient_detail" class="row">
-  <div>
-    <div id="menu" class="col-sm-3">
-      <%= render 'patients/menu', patient: @patient %>
-    </div>
+  <div id="menu" class="col-3">
+    <%= render 'patients/menu', patient: @patient %>
   </div>
 
-  <div id="sections" class="col-sm-9 tab-content">
+  <div id="sections" class="col tab-content">
     <div id="patient_information" class="patient-info tab-pane active">
       <%= render 'patients/patient_information', patient: @patient %>
     </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Restyles the abortion information partial. Got this pretty close as well!

Didn't have to commit any particular HTML/CSS to get there either.

Note that this contains a few commits from earlier in the process; please focus your attention on the files patients/_abortion_information and clinicfinders/_search_form.

This pull request makes the following changes:
* refactor abortion information partial to use BS4

olde: 

![image](https://user-images.githubusercontent.com/3866868/64838163-e17c4b80-d5bf-11e9-8d74-da26d1dcaaf3.png)

new: 

![image](https://user-images.githubusercontent.com/3866868/64838144-ca3d5e00-d5bf-11e9-8bc6-1cd7742e9f76.png)

It relates to the following issue #s: 
* Bumps #1632 
