### PR TITLE
Convert practical support partial to bootstrap 4

### DIFF
--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -32,7 +32,7 @@ module PracticalSupportsHelper
   def practical_support_guidance_link
     url = Config.find_or_create_by(config_key: 'practical_support_guidance_url').options.first
 
-    content_tag :small, class: 'pull-right' do
+    content_tag :small, class: 'float-right' do
       link_to t('patient.practical_support.guidance_link', fund: FUND), url, target: '_blank'
     end if url.present?
   end

--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -1,19 +1,10 @@
-<section id="practical_support_content">
-  <div id="patient_fields" class="col-sm-12">
-    <div class="row">
-      <div class="col-sm-12">
-        <h2><%= t 'patient.practical_support.title' %> <%= practical_support_guidance_link %></h2>
-      </div>
-    </div>
+<div id="practical_support_content">
+  <h2 class="patient-section-title"><%= t 'patient.practical_support.title' %> <%= practical_support_guidance_link %></h2>
 
-    <div class="row" id="practical-support-entries">
-      <%= render 'practical_supports/entries',
-                 patient: patient %>
-    </div>
+  <%= render 'practical_supports/entries',
+             patient: patient %>
 
-    <div class="row" id="practical-support-new-form">
-      <%= render 'practical_supports/new',
-                 patient: patient %>
-    </div>
+  <%= render 'practical_supports/new',
+             patient: patient %>
   </div>
-</section>
+</div>

--- a/app/views/practical_supports/_edit.html.erb
+++ b/app/views/practical_supports/_edit.html.erb
@@ -1,26 +1,33 @@
-<div class="row practical-support-item" id="practical-support-item-<%= practical_support.id %>">
-  <%= bootstrap_form_for practical_support, url: patient_practical_support_path(patient, practical_support), html: { class: 'edit_practical_support' }, remote: true do |f| %>
-    <div class="col-sm-4">
-      <%= f.select :support_type,
-                   options_for_select(practical_support_options(practical_support.support_type),
-                                      practical_support.support_type),
-                   hide_label: true %>
-    </div>
+<div class="row info-form practical-support-item" id="practical-support-item-<%= practical_support.id %>">
+  <%= bootstrap_form_for practical_support,
+                         url: patient_practical_support_path(patient, practical_support),
+                         html: { class: 'edit_practical_support col-10' },
+                         remote: true do |f| %>
+    <div class="row">
+      <div class="col-5">
+        <%= f.select :support_type,
+                     options_for_select(practical_support_options(practical_support.support_type),
+                                        practical_support.support_type),
+                     hide_label: true %>
+      </div>
 
-    <div class="col-sm-3">
-      <%= f.select :source,
-                   options_for_select(practical_support_source_options(practical_support.source),
-                                      practical_support.source),
-                   hide_label: true %>
-    </div>
-      
-    <div class="col-sm-3">
-      <%= f.check_box :confirmed,
-                      id: "practical_support_confirmed_#{practical_support.id}" %>
+      <div class="col-4">
+        <%= f.select :source,
+                     options_for_select(practical_support_source_options(practical_support.source),
+                                        practical_support.source),
+                     hide_label: true %>
+      </div>
+
+      <div class="col">
+        <%= f.form_group :confirmed do %>
+          <%= f.check_box :confirmed,
+                          id: "practical_support_confirmed_#{practical_support.id}" %>
+        <% end %>
+      </div>
     </div>
   <% end %>
 
-  <div class="col-sm-2">
+  <div class="col">
     <%= button_to t('patient.practical_support.remove'),
                   patient_practical_support_path(patient, practical_support),
                   remote: true,
@@ -28,5 +35,4 @@
                   data: { confirm: t('patient.practical_support.delete_confirm') },
                   class: "btn btn-danger" %>
   </div>
-  <br />
 </div>

--- a/app/views/practical_supports/_entries.html.erb
+++ b/app/views/practical_supports/_entries.html.erb
@@ -1,17 +1,20 @@
-<div class="col-sm-12 info-form">
-  <div id="existing-practical-supports"> 
-    <% if patient.practical_supports.present? %>
+<div id="practical-support-entries">
+  <% if patient.practical_supports.present? %>
+  <div class="row practical-support-headers">
+    <div class="col-10">
       <div class="row">
-        <div class="col-sm-4"><h5><%= t 'patient.practical_support.support_needed' %></h5></div>
-        <div class="col-sm-4"><h5><%= t 'patient.practical_support.point_of_contact' %></h5></div>
-        <div class="col-sm-4"><!-- Where confirmation would go --></div>
+        <h5 class="col-5"><%= t 'patient.practical_support.support_needed' %></h5>
+        <h5 class="col-3"><%= t 'patient.practical_support.point_of_contact' %></h5>
+        <h5 class="col-2"><!-- Where confirmation would go --></h5>
       </div>
-
-      <% patient.practical_supports.each do |entry| %>
-        <%= render 'practical_supports/edit',
-                   patient: patient,
-                   practical_support: entry %>
-      <% end %>
-    <% end %>
+    </div>
+    <div class="col"><!-- Where button would go --></div>
   </div>
+
+  <% patient.practical_supports.each do |entry| %>
+    <%= render 'practical_supports/edit',
+               patient: patient,
+               practical_support: entry %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/practical_supports/_new.html.erb
+++ b/app/views/practical_supports/_new.html.erb
@@ -1,10 +1,11 @@
-<div class="col-sm-12 info-form">
-  <h5><%= t 'patient.practical_support.new' %></h5>
+<div id="practical-support-new-form">
+  <h4><%= t 'patient.practical_support.new' %></h4>
+
   <%= bootstrap_form_for [patient, patient.practical_supports.new], html: { id: 'new-practical-support' }, remote: true do |f| %>
     <%= f.select :support_type, practical_support_options %>
     <%= f.select :source, practical_support_source_options %>
     <%= f.check_box :confirmed %>
-    <br>
+    <br />
     <%= f.submit t('patient.practical_support.create'), class: 'btn btn-primary', id: 'create-practical-support' %>
   <% end %>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Converts the practical support partials to bootstrap 4. Nothing too fancy but did have to redo the way we do rows a little bit.

This pull request makes the following changes:
* bootstrap-4-ify practical support

got this pretty close! recommend to focus on the files with practical_support in the name somewhere.

olde:

![image](https://user-images.githubusercontent.com/3866868/64902587-121fbc00-d678-11e9-8afb-9d0455852889.png)

newe:

![image](https://user-images.githubusercontent.com/3866868/64902584-fa483800-d677-11e9-9942-caae9b528d48.png)


It relates to the following issue #s: 
* Bumps #1632 
