### PR TITLE
Setup spacing utility in bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ db/*.sqlite3
 /db/*.sqlite3-journal
 /log/*
 /tmp/*
-/bin/*
 
 # cert file
 cacert.pem

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ db/*.sqlite3
 /db/*.sqlite3-journal
 /log/*
 /tmp/*
+/bin/*
 
 # cert file
 cacert.pem

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -5,6 +5,24 @@
  *= require_tree .
 */
 
+$spacer: .5rem !default;
+
+$spacers: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$spacers: map-merge(
+  (
+    0: 0,
+    1: ($spacer * .25), //.125 rem
+    2: ($spacer * .5), //.25 rem
+    3: $spacer, //.5 rem
+    4: ($spacer * 1.5), //.75rem
+    5: ($spacer * 2), //1rem
+    6: ($spacer * 3) //1.5rem
+
+  ),
+  $spacers
+);
+
 @import "bootstrap";
 @charset "utf-8";
 
@@ -239,10 +257,6 @@ h5 {
   @extend .btn-sm;
 }
 
-.btn-space {
-   margin-top:25px;
-}
-
 .info-form .checkbox label {
   font-weight: bold;
 }
@@ -376,12 +390,6 @@ $daria-color-lt : #825fb9;
   font-size: 12px;
 }
 
-
-
-#budget-progress-bar {
-  margin-bottom: 1em;
-}
-
 // Form styling
 label {
   font-weight: 700;
@@ -391,18 +399,9 @@ form {
   line-height: 1.0;
 }
 
-.patient-section-title {
-  margin-top: .5em;
-}
-
-.top-spacer {
-  margin-top: .75em;
-}
-
 .hidden {
   display: none;
 }
-
 .bottom-spacer {
   margin-bottom: .75em;
 }

--- a/app/views/dashboards/_budget_bar.html.erb
+++ b/app/views/dashboards/_budget_bar.html.erb
@@ -1,4 +1,4 @@
-<div class="progress" id='budget-progress-bar'>
+<div class="progress mb-5" id='budget-progress-bar'>
   <% expenditures.each_pair do |type, patient_hashes| %>
     <% patient_hashes.each do |patient| %>
       <div class="progress-bar <%= progress_bar_color type %> expenditure-block" style='<%= progress_bar_width patient[:fund_pledge], limit %>' role='progressbar'>

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -1,5 +1,5 @@
 <div id="abortion_information_content">
-  <h2 class="mt-3"><%= t('patient.abortion_information.title') %></h2>
+  <h2 class="mt-5"><%= t('patient.abortion_information.title') %></h2>
 
   <div class="practical-support-flag">
     <% if patient.practical_supports.any? %>
@@ -46,7 +46,7 @@
   <%= render partial: 'clinicfinders/search_form',
              locals: { patient: patient } %>
 
-  <h3 class="mt-3"><%= t('patient.abortion_information.cost_section.title') %></h3>
+  <h3 class="mt-5"><%= t('patient.abortion_information.cost_section.title') %></h3>
 
   <%= bootstrap_form_with model: patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
     <div class="row patient-cost-fields">

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -1,5 +1,5 @@
 <div id="abortion_information_content">
-  <h2 class="patient-section-title"><%= t('patient.abortion_information.title') %></h2>
+  <h2 class="mt-3"><%= t('patient.abortion_information.title') %></h2>
 
   <div class="practical-support-flag">
     <% if patient.practical_supports.any? %>
@@ -46,7 +46,7 @@
   <%= render partial: 'clinicfinders/search_form',
              locals: { patient: patient } %>
 
-  <h3 class="patient-section-title"><%= t('patient.abortion_information.cost_section.title') %></h3>
+  <h3 class="mt-3"><%= t('patient.abortion_information.cost_section.title') %></h3>
 
   <%= bootstrap_form_with model: patient, html: { id: 'abortion-information-form-2' }, remote: true do |f| %>
     <div class="row patient-cost-fields">

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -1,5 +1,5 @@
 <div id="call_log_content">
-  <h2 class="patient-section-title">
+  <h2 class="mt-5">
     <%= t('patient.call_log.title') %>
 
     <small class="float-right"> 

--- a/app/views/patients/_change_log.html.erb
+++ b/app/views/patients/_change_log.html.erb
@@ -1,5 +1,5 @@
 <div id="change_log_content">
-  <h2 class="patient-section-title"><%= t('patient.change_log.title') %></h2>
+  <h2 class="mt-5"><%= t('patient.change_log.title') %></h2>
 
   <table class="table border-side" id="change-log-table">
     <thead>

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -1,5 +1,5 @@
 <div id="notes_content">
-  <h2 class="patient-section-title"><%= t('patient.notes.title') %></h2>
+  <h2 class="mt-5"><%= t('patient.notes.title') %></h2>
 
   <%# this has a confusing doc structure; the urgent checkbox needs to be same row as submit btn. %>
   <%= bootstrap_form_with model: [patient, note],

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -1,5 +1,5 @@
 <div id="patient_information_content">
-  <h2 class="mt-3"><%= t 'patient.information.title' %></h2>
+  <h2 class="mt-5"><%= t 'patient.information.title' %></h2>
 
   <%= bootstrap_form_with model: patient, html: { id: 'patient_information_form' }, remote: true do |f| %>
     <div class="row">

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -1,5 +1,5 @@
 <div id="patient_information_content">
-  <h2 class="patient-section-title"><%= t 'patient.information.title' %></h2>
+  <h2 class="mt-3"><%= t 'patient.information.title' %></h2>
 
   <%= bootstrap_form_with model: patient, html: { id: 'patient_information_form' }, remote: true do |f| %>
     <div class="row">
@@ -28,7 +28,7 @@
                         label: t('patient.information.textable'),
                         checked: patient.textable? %>
 
-        <div class="row top-spacer">
+        <div class="row mt-4">
           <div class="col-8">
             <%= f.text_field :city, autocomplete: 'off' %>
           </div>

--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -1,5 +1,5 @@
 <div id="practical_support_content">
-  <h2 class="patient-section-title"><%= t 'patient.practical_support.title' %> <%= practical_support_guidance_link %></h2>
+  <h2 class="mt-5"><%= t 'patient.practical_support.title' %> <%= practical_support_guidance_link %></h2>
 
   <%= render 'practical_supports/entries',
              patient: patient %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bootstrap has a nice inline spacing utility. Instead of creating our utility classes, we can leverage them from BS4. 

I just targeted unique ids and classes that were used once.

Anyways utility CSS is another coffee table discussion because it enforces a structure whilst being highly flexible. The current app has custom utility functions which can use a refactor. But it's definitely worth looking into.



https://getbootstrap.com/docs/4.0/utilities/spacing/

This pull request makes the following changes:
* Setups spacing 
```
    1: ($spacer * .25), //.125 rem
    2: ($spacer * .5), //.25 rem
    3: $spacer, //.5 rem
    4: ($spacer * 1.5), //.75rem
    5: ($spacer * 2), //1rem
    6: ($spacer * 3) //1.5rem
```

It relates to the following issue #s: 
* Bumps #1776 
