### PR TITLE
Add font-awesome library to make glyphicons available

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,5 +10,6 @@
 import '../src/call_list_drag_and_drop';
 import '../src/clinic_finder';
 import '../src/clinics';
+import '../src/fontawesome';
 import '../src/pledge_calculator';
 import '../src/table_sorting';

--- a/app/javascript/src/fontawesome.js
+++ b/app/javascript/src/fontawesome.js
@@ -1,0 +1,2 @@
+// Load font-awesome icons.
+import '@fortawesome/fontawesome-free/js/all';

--- a/app/views/dashboards/_search_form.html.erb
+++ b/app/views/dashboards/_search_form.html.erb
@@ -8,7 +8,7 @@
 
     <%= p.text_field :search, placeholder: t('dashboard.search.input_placeholder'), hide_label: true, class: 'search_form_input' %>
     <%= p.button class: 'btn btn-primary', title: t('common.search'), aria: {label: t('common.search') } do %>
-      <i class="glyphicon glyphicon-search"></i>
+      <i class="fas fa-search"></i>
     <% end %>
   <% end %>
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.10.2",
     "@rails/webpacker": "4.0.7",
     "jquery": "^3.3.1",
     "jquery-ui": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,6 +752,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.10.2.tgz#27e02da1e34b50c9869179d364fb46627b521130"
+  integrity sha512-9pw+Nsnunl9unstGEHQ+u41wBEQue6XPBsILXtJF/4fNN1L3avJcMF/gGF86rIjeTAgfLjTY9ndm68/X4f4idQ==
+
 "@rails/webpacker@4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-4.0.7.tgz#268571bf974e78ce57eca9fa478f5bd97fd5182c"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds the fontawesome library to our app so we can start subbing out glyphicons in BS4 work. Am sorry to take a hacknight issue but this is starting to butt up against BS4 work.

This pull request makes the following changes:
* yarn add fontawesome something something
* add it to webpack

here it is on our searchbar:

![image](https://user-images.githubusercontent.com/3866868/64909531-64de8f80-d6db-11e9-97cf-c52e7ba8da04.png)


It relates to the following issue #s: 
* Fixes #1750 
