### PR TITLE
Convert user account management table to BS4

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -402,3 +402,7 @@ form {
 .hidden {
   display: none;
 }
+
+.bottom-spacer {
+  margin-bottom: .75em;
+}

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,4 +1,13 @@
-  <%= bootstrap_form_tag url: users_search_path, remote: true, layout: :inline do |p| %>
-    <%= p.text_field :search, placeholder: t('user.search.text_field'), hide_label: true, id: 'search_field', class: 'search_form_input' %>
-    <%= p.submit t('user.search.button'), id: 'search_button', class: 'btn btn-primary' %>
-  <% end %>
+<%= bootstrap_form_with url: users_search_path,
+                        remote: true,
+                        layout: :inline,
+                        html: { class: 'float-right' } do |p| %>
+  <%= p.text_field :search,
+                   placeholder: t('user.search.text_field'),
+                   skip_label: true,
+                   id: 'search_field',
+                   class: 'search_form_input' %>
+  <%= p.submit t('user.search.button'),
+               id: 'search_button',
+               class: 'btn btn-primary ml-2' %>
+<% end %>

--- a/app/views/users/_users_table.html.erb
+++ b/app/views/users/_users_table.html.erb
@@ -1,6 +1,6 @@
-<table class="table border-side users-table">
+<table class="table border-side user-table">
   <thead>
-    <tr>
+    <tr class="user-table-header">
       <th><!-- spacer --></th>
       <th><%= t('user.user_table.full_name') %></th>
       <th><%= t('user.common.role') %></th>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,13 +1,15 @@
 <h1><%= t('user.index.user_account_management') %></h1>
-<div class="row" style="padding-top: 10px; padding-bottom: 20px;">
-  <div class="col-md-12">
+
+<div class="row top-spacer bottom-spacer">
+  <div class="col">
     <%= link_to t('user.index.add_new_user'), new_user_path, class: "btn btn-primary" %>
-    <div style="float: right;">
-      <%= render partial: 'users/search_form', locals: { autosortable: true } %>
-    </div>
   </div>
 
+  <div class="col">
+    <%= render partial: 'users/search_form', locals: { autosortable: true } %>
+  </div>
 </div>
+
 <div id="user-list" class="margin-bottom">
   <%= render partial: 'users/users_table', locals: { users: @users, autosortable: true } %>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Changes to the user account management table to make it BS4 compat. Had to do very little to this, but did make some readability edits.

(Just look at the users dir changes.)

This pull request makes the following changes:
* nothing fancy, just some gentle column refactoring.

olde:

![image](https://user-images.githubusercontent.com/3866868/64914210-52387a80-d71c-11e9-98f5-971898be3bca.png)

new:

![image](https://user-images.githubusercontent.com/3866868/64914206-3e8d1400-d71c-11e9-8c21-284a96d23807.png)

It relates to the following issue #s: 
* Bumps #1632 
