### PR TITLE
BS4 updates to user edit page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,32 +1,31 @@
-<div class="col-sm-12">
-  <div class="row" id='user-topline'>
-    <h1><%= @user.name %></h1>
+<div id="patient-edit-panel">
+  <h1><%= @user.name %></h1>
+
+  <div id='user-topline'>
     <h5><%= t('user.common.role') %>: <%= @user.role.to_s %></h5>
     <h5><%= t('common.status') %>: <%= user_lock_status(@user) %></h5>
     <h5><%= t('user.common.last_login') %>: <%= @user.current_sign_in_at&.display_timestamp %></h5>
   </div>
 
   <% if @user != current_user && current_user.admin? %>
-    <div class="row" id='user-panel'>
-      <h3><%= t('user.edit.admin_actions') %></h3>
+    <h3><%= t('user.edit.admin_actions') %></h3>
 
-      <h5><%= t('user.edit.lock_an_account') %></h5>
-      <div class="authorization-buttons">
-        <%= disabled_toggle_button(@user) %>
-      </div>
-        
-      <h5><%= t('user.edit.update_users_role_permissions') %></h5>
-      <div class="btn-group" role='group'>
-        <%= role_toggle_button @user, 'admin' %>
-        <%= role_toggle_button @user, 'data_volunteer' %>
-        <%= role_toggle_button @user, 'cm' %>
-      </div>
+    <h5><%= t('user.edit.lock_an_account') %></h5>
+    <div class="authorization-buttons">
+      <%= disabled_toggle_button(@user) %>
+    </div>
+      
+    <h5 class="top-spacer"><%= t('user.edit.update_users_role_permissions') %></h5>
+    <div class="btn-group" role='group'>
+      <%= role_toggle_button @user, 'admin' %>
+      <%= role_toggle_button @user, 'data_volunteer' %>
+      <%= role_toggle_button @user, 'cm' %>
     </div>
   <% end %>
 
-  <div class="row" id='user-details-update'>
+  <div id='user-details-update' class="top-spacer">
     <h3><%= t('user.edit.update_details') %></h3>
-    <%= bootstrap_form_for @user, html: { id: 'user-form' } do |f| %>
+    <%= bootstrap_form_with model: @user do |f| %>
       <%= f.text_field :name, label: t('common.name'), autocomplete: 'off' %>
 
       <%= f.text_field :email, label: t('common.email'), autocomplete: 'off' %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bump BS4 user edit page. Pretty easy! Pretty much identical.

Edits all in `app/views/users/edit.html.erb`

This pull request makes the following changes:
* BS4ify user edit page

olde:

![image](https://user-images.githubusercontent.com/3866868/64914396-8b71ea00-d71e-11e9-9feb-1ce8740c0588.png)

new:

![image](https://user-images.githubusercontent.com/3866868/64914394-7eed9180-d71e-11e9-92ab-06493d585e1f.png)


It relates to the following issue #s: 

* Bumps #1632 
