### PR TITLE
BS4 upgrade for Config and Accountants page

### DIFF
--- a/app/assets/stylesheets/accountants.scss
+++ b/app/assets/stylesheets/accountants.scss
@@ -2,16 +2,18 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.pagination-entries {
-  font-size: .5em;
-  display: inline-block;
-}
-
-nav.pagination {
-  // font-size: 100%;
-  display: inline-block;
-
-  span {
+.accountants-pagination {
+  .pagination-entries {
     font-size: .5em;
+    display: inline-block;
   }
+
+  nav.pagination {
+    // font-size: 100%;
+    display: inline-block;
+
+    span {
+      font-size: .5em;
+    }
+  }  
 }

--- a/app/assets/stylesheets/accountants.scss
+++ b/app/assets/stylesheets/accountants.scss
@@ -2,6 +2,16 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.pagination {
-  font-size: 50%;  
+.pagination-entries {
+  font-size: .5em;
+  display: inline-block;
+}
+
+nav.pagination {
+  // font-size: 100%;
+  display: inline-block;
+
+  span {
+    font-size: .5em;
+  }
 }

--- a/app/views/accountants/_search_form.html.erb
+++ b/app/views/accountants/_search_form.html.erb
@@ -1,13 +1,12 @@
 <div id="search_form" class="margin-bottom">
-  <h1 class="border-bottom title">
-    <%= t 'accountants.search_cases' %>
-  </h1>
-
   <!-- TODO change submit tag to a search glyphicon -->
-  <%= bootstrap_form_tag url: 'accountant/search', remote: true, layout: :inline do |p| %>
-    <%= p.hidden_field :locale, value: params[:locale] %>
-    <%= p.text_field :search, placeholder: t('accountants.search_placeholder'), hide_label: true, class: 'search_form_input accountant' %>
-    <%= p.submit t('common.search'), class: 'btn btn-primary' %>
+  <%= bootstrap_form_tag url: 'accountant/search', remote: true, layout: :inline do |f| %>
+    <%= f.hidden_field :locale, value: params[:locale] %>
+    <%= f.text_field :search,
+                     placeholder: t('accountants.search_placeholder'),
+                     hide_label: true,
+                     class: 'search_form_input accountant' %>
+    <%= f.submit t('common.search'), class: 'btn btn-primary ml-2' %>
   <% end %>
 
   <div id="search_results_shell"></div>

--- a/app/views/accountants/_table_content.html.erb
+++ b/app/views/accountants/_table_content.html.erb
@@ -1,6 +1,7 @@
 <table class="table border-side">
   <thead>
-    <tr>
+    <tr class="accountants-table-header">
+      <th><!-- spacer --></th>
       <th><%= t 'accountants.table_content.clinic' %></th>
       <th><%= t 'accountants.table_content.pt_initials' %></th>
       <th><%= t 'accountants.table_content.fund_payout', fund: FUND %></th>
@@ -12,7 +13,7 @@
     </tr>
   </thead>
 
-  <tbody id="patient_information_form">
+  <tbody id="accountants-table-content">
     <% patients.each do |patient| %>
       <tr id='row-<%= patient.id %>'>
         <%= render 'accountants/table_content_row', patient: patient %>

--- a/app/views/accountants/_table_content_row.html.erb
+++ b/app/views/accountants/_table_content_row.html.erb
@@ -1,3 +1,4 @@
+<td><!-- spacer --></td>
 <td><%= patient.clinic&.name %></td>
 <td><%= link_to patient.initials, edit_patient_path(patient) %></td>
 <td><%= number_to_currency patient.fulfillment&.fund_payout, precision: 0, unit: '$', format: '%u%n' %></td>
@@ -7,6 +8,6 @@
 <td><%= patient.fulfillment&.date_of_check %></td>
 <td>
   <%= link_to edit_accountant_path(patient), id: "edit-#{patient.id}", remote: true do %>
-    <i class="glyphicon glyphicon-pencil"></i>
+    <i class="glyphicon glyphicon-pencil"></i>edit
   <% end %>
 </td>

--- a/app/views/accountants/index.html.erb
+++ b/app/views/accountants/index.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class='border-bottom title'>
   <%= t 'accountants.title' %>
-  <small class='float-right'>
+  <small class='float-right accountants-pagination'>
     <span class='pagination-entries'>
       <%= page_entries_info @patients, entry_name: 'patient' %>
     </span>

--- a/app/views/accountants/index.html.erb
+++ b/app/views/accountants/index.html.erb
@@ -1,25 +1,18 @@
-<div class="container">
-  <div class="col-sm-12">
-    <div class="row">
-      <%= render partial: 'accountants/search_form' %>    
-    </div>
+<h1 class="border-bottom title"><%= t 'accountants.search_cases' %></h1>
 
-    <div class="row">
-      <h1 class='border-bottom title'>
-        <%= t 'accountants.title' %>
-        <small class='pull-right'>
-          <span id='pagination-entries' class='pagination'>
-            <%= page_entries_info @patients, entry_name: 'patient' %>
-          </span>
-          <%= paginate @patients %> 
-        </small>
-      </h1>
-    </div>
+<%= render partial: 'accountants/search_form' %>    
 
-    <div class="row" id='accounting-list'>
-      <%= render partial: 'accountants/table_content', locals: { patients: @patients, autosortable: true } %>
-    </div>
-  </div>
+<h1 class='border-bottom title'>
+  <%= t 'accountants.title' %>
+  <small class='float-right'>
+    <span class='pagination-entries'>
+      <%= page_entries_info @patients, entry_name: 'patient' %>
+    </span>
+    <%= paginate @patients %> 
+  </small>
+</h1>
 
-  <%= render partial: "patients/modal" %>
-</div>
+<%= render partial: 'accountants/table_content',
+           locals: { patients: @patients, autosortable: true } %>
+
+<%= render partial: "patients/modal" %>

--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
-  <div class="col-md-6">
-    <%= bootstrap_form_for config, inline: true do |f| %>
+  <div class="col">
+    <%= bootstrap_form_with model: config, inline: true do |f| %>
       <%= f.text_area :options, label: "#{config.config_key.to_s.humanize} options",
                                 value: config.config_value.try(:values_at, 'options')
                                                           .try(:join, ', '),
@@ -10,7 +10,7 @@
     <% end %>  
   </div>
 
-  <div class="col-md-6" id="<%= config.config_key.to_s %>_options_list">
+  <div class="col" id="<%= config.config_key.to_s %>_options_list">
     <% if Config::HELP_TEXT_OVERRIDES[config.config_key.to_sym] %>
     <% else %>
       <label><%= t('configs.config.current_options') %></label>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bump  config and accountants pages. Had to add some custom styling to get accountants to play nice but it worked!

Stop me if you've heard this one before but just note changes to accountants and configs dirs, and accountants.scss (which had to get bumped to play nice with new kaminari styles, I think).

This pull request makes the following changes:
* bump configs styling (slightly)
* bump accountants page styling (less slightly)

olde:

![image](https://user-images.githubusercontent.com/3866868/64915340-393ac400-d732-11e9-9305-6d08faec7995.png)

![image](https://user-images.githubusercontent.com/3866868/64915344-422b9580-d732-11e9-98d7-19517d8c4ebc.png)

new (edit is a placeholder until we get glyphicons back, and the modal is the fulfiillment page which isn't done yet):

![image](https://user-images.githubusercontent.com/3866868/64915333-2e802f00-d732-11e9-819e-0cdb01740e4c.png)

![image](https://user-images.githubusercontent.com/3866868/64915321-127c8d80-d732-11e9-8d00-b5c3d5bb5df4.png)

It relates to the following issue #s: 
* Bumps #1632 
