### PR TITLE
BS4ify CM dashboard table content

### DIFF
--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -2,13 +2,11 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.glyphicon-earphone {
+.call-icon {
   color: white;
   background-color: #337ab7;
   padding: 5px;
   border-radius: 50%;
-  font-size: 12px;
-  vertical-align: top;
 }
 
 .search_bar {
@@ -23,13 +21,4 @@
 
 .bootstrap_toggle_spacing .checkbox {
   margin-top: 0px;
-}
-
-.pt-spacer {
-  padding-right: 5px;
-}
-
-.glyphicon-remove {
-  color: red;
-  padding: 0px 10px 0px 10px;
 }

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -22,20 +22,4 @@ module DashboardsHelper
            .values
            .map { |option| [enum_text[option.to_sym], option.to_sym] }
   end
-
-  def remove_from_call_list_glyphicon
-    safe_join [
-      tag(:span, class: ['glyphicon', 'glyphicon-remove'],
-                 aria: { hidden: true }),
-      tag(:span, class: ['sr-only'], text: 'Remove call')
-    ]
-  end
-
-  def call_glyphicon
-    safe_join [
-      tag(:span, class: ['glyphicon', 'glyphicon-earphone'],
-                 aria: { hidden: true }),
-      tag(:span, class: ['sr-only'], text: 'Call')
-    ]
-  end
 end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,12 +1,11 @@
 # Functions related to displaying notes
 module NotesHelper
-  def plus_sign_glyphicon(note)
+  def plus_sign_icon(note)
     return nil unless note && note.try(:full_text).length > 31
-    note = tag(:span, class: 'glyphicon glyphicon-plus-sign',
-                      title: t('note.most_recent_no_user'),
-                      aria: { hidden: true },
-                      data: { toggle: 'popover', placement: 'bottom',
-                              content: note.full_text })
+    note = tag(:i, class: 'fas fa-plus-circle',
+                   title: t('note.most_recent_no_user'),
+                   aria: { hidden: true },
+                   data: { toggle: 'popover', placement: 'bottom', content: note.full_text })
     sr = tag(:span, class: 'sr-only', text: 'Full note')
     safe_join([note, sr], '')
   end

--- a/app/helpers/tables_helper.rb
+++ b/app/helpers/tables_helper.rb
@@ -2,7 +2,7 @@ module TablesHelper
   def th_autosortable(column_name, type, local_assigns)
     # Throw a flag unless sorting by string, int, or float
     raise 'Bad datatype' unless %w(string string-ins int float).include? type
-    content_tag :th, data: { sort: type } do
+    content_tag :th, data: { sort: type }, html: { scope: "col" } do
       safe_join [column_name, autosort_arrow_span(local_assigns)], ' '
     end
   end

--- a/app/views/dashboards/_search_form.html.erb
+++ b/app/views/dashboards/_search_form.html.erb
@@ -6,8 +6,13 @@
   <%= bootstrap_form_tag url: '/search', remote: true, layout: :inline do |p| %>
     <%= p.hidden_field :locale, value: params[:locale] %>
 
-    <%= p.text_field :search, placeholder: t('dashboard.search.input_placeholder'), hide_label: true, class: 'search_form_input' %>
-    <%= p.button class: 'btn btn-primary', title: t('common.search'), aria: {label: t('common.search') } do %>
+    <%= p.text_field :search,
+                     placeholder: t('dashboard.search.input_placeholder'),
+                     hide_label: true,
+                     class: 'search_form_input' %>
+    <%= p.button class: 'btn btn-primary ml-5',
+                 title: t('common.search'),
+                 aria: { label: t('common.search') } do %>
       <i class="fas fa-search"></i>
     <% end %>
   <% end %>

--- a/app/views/dashboards/_table_content.html.erb
+++ b/app/views/dashboards/_table_content.html.erb
@@ -1,6 +1,6 @@
 <!-- locals: title, table_type (for div id and tbody div id), pregnancies, sortable, autosortable -->
 
-<div id="<%= table_type %>" class="margin-bottom">
+<div id="<%= table_type %>" class="margin-bottom mt-5">
   <h1 class="border-bottom title">
     <%= title %>
     <%= dashboard_table_content_tooltip_shell table_type %>
@@ -9,17 +9,15 @@
   <table class="table border-side" id="<%= table_type %>_table">
     <thead>
       <tr>
-        <% if local_assigns[:sortable] %>
-          <th><!-- handle --></th>
-        <% end %>
-        <th><%= t 'common.phone' %></th>
-        <th><%= t 'common.name' %></th>
-        <th><%= t 'common.weeks_along_short' %></th>
+        <th scope="col"><!-- handle/spacer --></th>
+        <th scope="col"><%= t 'common.phone' %></th>
+        <th scope="col"><%= t 'common.name' %></th>
+        <th scope="col"><%= t 'common.weeks_along_short' %></th>
         <%= th_autosortable t('common.status'), 'string', local_assigns %>
         <%= th_autosortable t('common.appointment_date_short'), 'string', local_assigns %>
-        <th><%= t 'common.notes' %></th>
-        <th></th>
-        <th></th>
+        <th scope="col"><%= t 'common.notes' %></th>
+        <th scope="col"><!-- add/delete from call list --></th>
+        <th scope="col"><!-- call --></th>
       </tr>
     </thead>
 
@@ -27,35 +25,60 @@
       <% patients.each do |patient| %>
         <tr class="patient-data" id="<%= patient.id %>">
           <% if local_assigns[:sortable] %>
-            <td class="handle"><span class="glyphicon glyphicon-move"></span></td>
+            <td class="handle" scope="row">
+              <i class="fas fa-arrows-alt fa-fw sortable-handle text-muted"></i>
+            </td>
+          <% else %>
+            <td scope="row"><!-- spacer --></td>
           <% end %>
-          <td class="pt-spacer"><%= patient.primary_phone_display %></td>
-          <td class="pt-spacer"><%= link_to patient.name, edit_patient_path(patient) %></td>
-          <td class="pt-spacer">
+
+          <td><%= patient.primary_phone_display %></td>
+          <td><%= link_to patient.name, edit_patient_path(patient) %></td>
+
+          <td>
             <%= t 'common.weeks_days_short',
                   weeks: patient.last_menstrual_period_now_weeks,
                   days: patient.last_menstrual_period_now_days %>
           </td>
+
           <td><%= patient.status %></td>
           <td><%= patient.appointment_date_display %></td>
-          <td><%= patient.most_recent_note_display_text %> <%= plus_sign_glyphicon(patient.most_recent_note) %></td>
+          <td><%= patient.most_recent_note_display_text %> <%= plus_sign_icon(patient.most_recent_note) %></td>
 
           <% if table_type == 'completed_calls' || table_type == 'urgent_cases' %>
             <td class="blank-td"></td>
           <% else %>
             <% if current_user.patient_ids.include?(patient.id) %>
-              <td><%= link_to remove_from_call_list_glyphicon, remove_patient_path(patient), method: :patch, data: { confirm: t('dashboard.table_content.remove_from_call_list_confirm', name: patient.name) }, aria: {label: t('dashboard.table_content.remove_from_call_list_confirm', name: patient.name)},  remote: true %></td>
+              <td>
+                <%= link_to remove_patient_path(patient),
+                            method: :patch,
+                            data: { confirm: t('dashboard.table_content.remove_from_call_list_confirm',
+                                    name: patient.name) },
+                            aria: { label: t('dashboard.table_content.remove_from_call_list_confirm',
+                                    name: patient.name)},
+                            remote: true do %>
+                  <i class="fas fa-times fa-fw text-danger" aria-hidden="true"></i>
+                  <span class="sr-only">Remove call</span>
+                <% end %>
+              </td>
             <% else %>
-              <td><%= link_to t('common.add'), add_patient_path(patient), method: :patch, remote: true %></td>
+              <td>
+                <%= link_to t('common.add'),
+                            add_patient_path(patient),
+                            method: :patch,
+                            remote: true %>
+              </td>
             <% end %>
           <% end %>
 
           <td>
-            <%= link_to call_glyphicon,
-                        new_patient_call_path(patient),
+            <%= link_to new_patient_call_path(patient),
                         class: "call_button call-#{patient.primary_phone_display}",
-                        aria: {label: "Call #{patient.primary_phone_display}"},
-                        remote: true %>
+                        aria: { label: "Call #{patient.primary_phone_display}" },
+                        remote: true do %>
+              <i class="fas fa-phone-alt fa-lg fa-fw call-icon"></i>
+              <span class="sr-only">Call</span>
+            <% end %>
           </td>
         </tr>
       <% end %>
@@ -65,7 +88,7 @@
   <% if table_type == 'call_list' && current_user.patients.count.nonzero? %>
     <%= link_to t('dashboard.table_content.clear_call_list'),
                 clear_current_user_call_list_path,
-                class: "pull-right text-danger",
+                class: "float-right text-danger",
                 data: { confirm: t('dashboard.table_content.clear_call_list_confirm') },
                 method: :patch,
                 remote: true %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

BS4ifys (and fontawesomeifies) patient dashboard.

This pull request makes the following changes:
* BS4ify dashboard tables
* readd fontawesome icons in place of glyphicons

Very slight difference in the icon -- the new targets are very slightly bigger. The reorder handle is a little darker too, and the spacing is a little different, but it comes together nicely.

olde:

![image](https://user-images.githubusercontent.com/3866868/65398363-ad094c00-dd84-11e9-8824-3553f9d2e68f.png)

newe:

![image](https://user-images.githubusercontent.com/3866868/65398347-93680480-dd84-11e9-8b7a-b1671f7e8141.png)

It relates to the following issue #s: 
* Bumps #1632 
