### PR TITLE
BS4ify events log

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -2,13 +2,21 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.event-item {
-  padding: 5px;
+svg.event-item {
   border-radius: 50%;
-  font-size: 12px;
-  margin-right: 3px;
-  &.glyphicon-thumbs-up {
+  margin-right: 1em;
+  color: white;
+  padding: 4px;
+  background-color: #337ab7;
+  font-size: 1.25em;
+  
+  &.fa-thumbs-up {
     background-color: green;
+  }
+
+  &.fa-comment {
+    background-color: #f8f9fa; // TODO replace with $light;
+    color: black;
   }
 }
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,9 +1,10 @@
 # Functions to display events for activity feed
 module EventsHelper
   def display_event(event)
+    fontawesome_kit = event.icon == 'thumbs-up' ? 'far' : 'fas'
     safe_join [
       tag(:span,
-          class: ['glyphicon', "glyphicon-#{event.glyphicon}", 'event-item']),
+          class: [fontawesome_kit, "fa-#{event.icon}", 'event-item']),
       entry_text(event)
     ], ' '
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,14 +31,14 @@ class Event
   validates :cm_name, :patient_name, :patient_id, :line, presence: true
   validates :pledge_amount, presence: true, if: :pledged_type?
 
-  def glyphicon
+  def icon
     case event_type
     when 'Pledged'
       'thumbs-up'
     when 'Reached patient'
       'comment'
     else
-      'earphone'
+      'phone-alt'
     end
   end
 

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -3,7 +3,7 @@
     <ul id='event-list'>
       <% @events.map { |event| event.created_at.display_date }.uniq.each do |date| %>
         <li>
-          <h3><%= date %></h3>
+          <h3 class="mb-3"><%= date %></h3>
           <% @events.select { |event| event.created_at.display_date == date }.each do |event| %>
             <%= content_tag :p, display_event(event), class: 'event-item' %>
           <% end %>

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -4,7 +4,7 @@ class EventsHelperTest< ActionView::TestCase
   describe 'display_event' do
     it 'should render an event line - pledged' do
       event = create :event, event_type: 'Pledged', pledge_amount: 100
-      expected = "<span class=\"glyphicon glyphicon-thumbs-up event-item\" /> " \
+      expected = "<span class=\"far fa-thumbs-up event-item\" /> " \
                  "#{event.created_at.display_time} -- #{event.cm_name} sent a " \
                  "$100 pledge for <a href=\"/patients/#{event.patient_id}/edit\">" \
                  "#{event.patient_name}</a> <a data-remote=\"true\" rel=\"nofollow\" " \

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -38,19 +38,19 @@ class EventTest < ActiveSupport::TestCase
   end
 
   describe 'rendering methods' do
-    describe 'glyphicon' do
-      it 'should render the correct glyphicon' do
+    describe 'icon' do
+      it 'should render the correct icon' do
         @event.event_type = "Couldn't reach patient"
-        assert_equal 'earphone', @event.glyphicon
+        assert_equal 'phone-alt', @event.icon
 
         @event.event_type = 'Reached patient'
-        assert_equal 'comment', @event.glyphicon
+        assert_equal 'comment', @event.icon
 
         @event.event_type = 'Pledged'
-        assert_equal 'thumbs-up', @event.glyphicon
+        assert_equal 'thumbs-up', @event.icon
 
         @event.event_type = 'Left voicemail'
-        assert_equal 'earphone', @event.glyphicon
+        assert_equal 'phone-alt', @event.icon
       end
     end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Convert the events log on the main dashboard to BS4. Nothing terribly interesting.

Note that CI fails intentionally here because we're merging this into the feature branch.

This pull request makes the following changes:
* bs4ify event log
* use fontawesome icons instead of glyphicons (rip)

old:

![image](https://user-images.githubusercontent.com/3866868/65822653-e246eb80-e215-11e9-8232-87c109ee92a6.png)


new -- the font size is a little increased and the thumbs ups are white now to make them easier to see:

![image](https://user-images.githubusercontent.com/3866868/65822647-cb07fe00-e215-11e9-9108-100252be82fa.png)

It relates to the following issue #s: 
* Bumps #1632 
