### PR TITLE
BS4: Widen the default modal

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -410,3 +410,8 @@ form {
 .hide {
   @extend .d-none;
 }
+
+// widen default modal from bootstrap default
+.modal-dialog {
+  max-width: 60%;
+}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

The modal in BS4 slims down to a max width of 500px at the highest breakpoint, which is kinda tiny. I'm setting it to 60% instead so that it doesn't get super cramped up in, for example, the accountants view, new call modal, or submit pledge modal.

like other BS4 PRs, CI fails intentionally because we're smashing this into a feature branch `bs4-2`, so don't be put off by that when reviewing.

This pull request makes the following changes:
* `max-width: 60%` on `.dialog-modal`

olde:

![image](https://user-images.githubusercontent.com/3866868/65931260-f259f900-e3d6-11e9-9c47-a9ea11c3af92.png)

new:

![image](https://user-images.githubusercontent.com/3866868/65931154-7eb7ec00-e3d6-11e9-980a-2818b4a6aaa6.png)


It relates to the following issue #s: 
* Bumps #1632 