### PR TITLE
BS4 - Replace remaining glyphicons

### DIFF
--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -36,8 +36,10 @@ $font-size: 17px;
     background-color: white;
 
     &:before {
-      font-family: 'Glyphicons Halflings';
-      content: "\e080";
+      display: none;
+      font-family: "Font Awesome 5 Free";
+      font-weight: 900;
+      content: "\f054";
       margin-left: -1.5em;
       padding-right: .85em;
       color: $daria-color;
@@ -47,6 +49,11 @@ $font-size: 17px;
   a.submit-btn, a.cancel-btn {
     font-size: 1rem;
   }
+}
+
+.svg-inline--fa {
+  margin-left: -1.5em;
+  margin-right: .85em;
 }
 
 .border-side {

--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -44,16 +44,16 @@ $font-size: 17px;
       padding-right: .85em;
       color: $daria-color;
     }
+
+    .svg-inline--fa {
+      margin-left: -1.5em;
+      margin-right: .85em;
+    }
   }
 
   a.submit-btn, a.cancel-btn {
     font-size: 1rem;
   }
-}
-
-.svg-inline--fa {
-  margin-left: -1.5em;
-  margin-right: .85em;
 }
 
 .border-side {

--- a/app/views/accountants/_table_content_row.html.erb
+++ b/app/views/accountants/_table_content_row.html.erb
@@ -8,6 +8,6 @@
 <td><%= patient.fulfillment&.date_of_check %></td>
 <td>
   <%= link_to edit_accountant_path(patient), id: "edit-#{patient.id}", remote: true do %>
-    <i class="glyphicon glyphicon-pencil"></i>edit
+    <i class="fas fa-pencil-alt"></i>
   <% end %>
 </td>

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -3,7 +3,7 @@
     <h4 class="clinic-finder-expand patient-section-title">
       <%= t('clinic_locator.title') %>
       <small><%= t('clinic_locator.experimental_note') %></small>
-      <span class='glyphicon glyphicon-plus-sign float-right'>glyph</span>
+      <i class='fas fa-plus-circle float-right'></i>
     </h4>
   </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <title><%= content_for?(:title) ? yield(:title) : "DARIA" %></title>
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "DCAF" %>">
     <meta name='ROBOTS' content='NOINDEX, NOFOLLOW'>
-    <%= javascript_pack_tag 'application' %>
+    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true %>
     <%= stylesheet_link_tag :application, media: 'all' %>
     <%= favicon_link_tag %>
     <%= javascript_include_tag :application %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Sub in the remaining fontawesome icons for the glyphicons. rip glyphicons.

Along the way, I have learned some valuable lessons about doing col-s in bootstrap 4, so subbed those in, and removed some extraneous comments.

This pull request makes the following changes:
* remove remaining glyphicons

It relates to the following issue #s: 
* Bumps #1632 
