### PR TITLE
BS4 convert login page and line selection

### DIFF
--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -11,12 +11,11 @@
     }
 
     label {
-        margin: 10px;
         font-size: 24px;
     }
 
-    .radio label {
-        float: left;
+    .form-check-label {
+        margin-left: 2em;
     }
 
     .btn-primary {

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,7 +7,7 @@
 
       <p><%= t('devise.sessions.new.password_signin') %></p>
 
-      <%= bootstrap_form_for resource, as: resource_name, url: session_path(resource_name) do |f| %>
+      <%= bootstrap_form_with model: resource, as: resource_name, url: session_path(resource_name) do |f| %>
         <%= render "devise/shared/error_messages" %>
 
         <%- if devise_mapping.registerable? %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <div class="col-sm-6">
+  <div class="col">
     <h2><%= random_welcome_message %></h2>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
-  <div class="col-sm-6">
+  <div class="col-6">
     <div class="authform">
       <h3>
-        <%= button_to t('devise.sessions.new.google_signin'), user_google_oauth2_omniauth_authorize_path, class: 'btn btn-primary' %>
+        <%= button_to t('devise.sessions.new.google_signin'), user_google_oauth2_omniauth_authorize_path, class: 'btn btn-primary btn-lg' %>
       </h3>
 
       <p><%= t('devise.sessions.new.password_signin') %></p>
@@ -13,18 +13,26 @@
         <%- if devise_mapping.registerable? %>
           <%#= link_to 'Sign up', new_registration_path(resource_name), class: 'right' %>
         <% end -%>
-        <%= f.email_field :email, label: t('mongoid.attributes.user.email'), :autofocus => true, autocorrect: 'off', autocapitalize: 'off', autocomplete: 'off', class: 'form-control' %>
+        <%= f.email_field :email,
+                          label: t('mongoid.attributes.user.email'),
+                          autofocus: true,
+                          autocorrect: 'off',
+                          autocapitalize: 'off',
+                          autocomplete: 'off',
+                          class: 'form-control' %>
 
         <%- if devise_mapping.recoverable? %>
           <%#= link_to "Forgot password?", new_password_path(resource_name), class: 'right' %>
         <% end -%>
-        <%= f.password_field :password, label: t('devise.sessions.new.password'), autocomplete: 'off' %>
+        <%= f.password_field :password,
+                             label: t('devise.sessions.new.password'),
+                             autocomplete: 'off' %>
 
         <% if devise_mapping.rememberable? -%>
-      <%= f.check_box :remember_me %>
+          <%#= f.check_box :remember_me %>
         <% end -%>
 
-        <%= f.submit t('devise.sessions.new.password_submit'), class: 'btn btn-default' %>
+        <%= f.submit t('devise.sessions.new.password_submit'), class: 'btn btn-outline-secondary' %>
       <% end %>
 
       <%= render "devise/shared/links" %>

--- a/app/views/lines/new.html.erb
+++ b/app/views/lines/new.html.erb
@@ -1,5 +1,5 @@
-<div class="container">
-  <div class="col-sm-12 lines-form">
+<div class="row">
+  <div class="col lines-form">
     <h1 class="border-bottom title"><%= t 'lines.new.welcome_to_daria', fund: FUND %></h1>
 
     <%= bootstrap_form_tag url: lines_path, class: 'line-select-form' do |f| %>
@@ -10,6 +10,5 @@
       <% end %>
       <%= f.submit t('lines.new.start'), class: 'btn-lg btn-primary' %>
     <% end %>
-
   </div>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I think this is the last of it! Just the line selection and login page.

This pull request makes the following changes:
* bump login page
* bump line selection page

olde:

![image](https://user-images.githubusercontent.com/3866868/66278831-d218b700-e87a-11e9-87e8-f475a154b460.png)

![image](https://user-images.githubusercontent.com/3866868/66278840-de047900-e87a-11e9-8b40-384c8df7d1f3.png)


new (bigger google button, outlined password button on login page; some slight realignment on line selection):

![image](https://user-images.githubusercontent.com/3866868/66278796-9847b080-e87a-11e9-9762-886ef64e9e48.png)

![image](https://user-images.githubusercontent.com/3866868/66278811-b44b5200-e87a-11e9-9b0a-0eddfb096ec1.png)


It relates to the following issue #s: 
* Bumps #1632 
