### PR TITLE
added the webpacker service to dockerization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,17 @@
 version: '3.1'
 services:
+  webpacker:
+    image: colinxfleming/dcaf_case_management:latest
+    command: ["./scripts/start_webpack_dev.sh"]
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - '3035:3035'
   web:
     build:
       context: .
       dockerfile: .docker/Dockerfile
-    command: rails s -p 3000 -b 0.0.0.0
+    command: ["./scripts/start_rails.sh"]
     image: colinxfleming/dcaf_case_management:latest
     volumes:
       - .:/usr/src/app

--- a/scripts/start_rails.sh
+++ b/scripts/start_rails.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b 0.0.0.0

--- a/scripts/start_webpack_dev.sh
+++ b/scripts/start_webpack_dev.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "starting webpack dev" && export NODE_OPTIONS="--max_old_space_size=4096" && yarn && rm -rf /opt/dockerrailsdemo/public/packs && bin/webpack-dev-server
+echo "starting webpack dev" && export NODE_OPTIONS="--max_old_space_size=4096" && yarn && rm -rf /public/packs && bin/webpack-dev-server

--- a/scripts/start_webpack_dev.sh
+++ b/scripts/start_webpack_dev.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "starting webpack dev" && export NODE_OPTIONS="--max_old_space_size=4096" && yarn && rm -rf /opt/dockerrailsdemo/public/packs && bin/webpack-dev-server


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

On a fresh `docker-compose up --build` the app fails to load due to the unavailability of webpack and assets.

This pull request makes the following changes:
* add webpacker as a service
* moved the entry point commands to their own scripts for easier modification
* included the pid server removal in the script


It relates to the following issue #s: 
* Fixes #1741
