### PR TITLE
Has Special Circumstance Always Returns True

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -246,9 +246,9 @@ class Patient
   end
 
   def has_special_circumstances
-    has_circumstance = 0
+    has_circumstance = false
     special_circumstances.each do |cir|
-      has_circumstance = 1 if cir.present?
+      has_circumstance = true if cir.present?
       break
     end
     !!has_circumstance

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -246,12 +246,7 @@ class Patient
   end
 
   def has_special_circumstances
-    has_circumstance = false
-    special_circumstances.each do |cir|
-      has_circumstance = true if cir.present?
-      break
-    end
-    !!has_circumstance
+    special_circumstances.map { |circumstance| circumstance.present? }.any?
   end
 
   def archive_date

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -393,6 +393,18 @@ class PatientTest < ActiveSupport::TestCase
         assert_equal @patient.initial_call_date + 3.months, @patient.archive_date
       end
     end
+
+    describe 'has_special_circumstances' do
+      it 'should return false if there are no special circumstances' do
+        @patient.update special_circumstances: []
+        assert_equal @patient.has_special_circumstances, false
+      end
+
+      it 'should return true if there are special circumstances' do
+        @patient.update special_circumstances: ['special', 'circumstances']
+        assert_equal @patient.has_special_circumstances, true
+      end
+    end
   end
 
   describe 'pledge_sent validation' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -395,13 +395,23 @@ class PatientTest < ActiveSupport::TestCase
     end
 
     describe 'has_special_circumstances' do
-      it 'should return false if there are no special circumstances' do
+      it 'should return false if there is an empty array' do
         @patient.update special_circumstances: []
+        assert_equal @patient.has_special_circumstances, false
+      end
+
+      it 'should return false if there are no special circumstances' do
+        @patient.update special_circumstances: [nil, nil]
         assert_equal @patient.has_special_circumstances, false
       end
 
       it 'should return true if there are special circumstances' do
         @patient.update special_circumstances: ['special', 'circumstances']
+        assert_equal @patient.has_special_circumstances, true
+      end
+
+      it 'should return true if there are special circumstances and nils' do
+        @patient.update special_circumstances: [nil, 'circumstances']
         assert_equal @patient.has_special_circumstances, true
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

The `has_special_circumstance` method was always returning true to boolean safety checks against ints.

```
irb(main):001:0> !!0
=> true
irb(main):002:0> !!1
=> true
irb(main):003:0> !!false
=> false
irb(main):004:0> !!true
=> true
```

This pull request makes the following changes:
* switched from `0` and `1` to `true` and `false`
* added a test

It relates to the following issue #s: 
* Fixes #1827 
