### PR TITLE
Remove Docker Yarn Integrity Check

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,7 +56,4 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   Mongo::Logger.logger.level = ::Logger::FATAL
-
-  # Don't check yarn package integrity in docker
-  config.webpacker.check_yarn_integrity = ENV['DOCKER'] ? false : true
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Removing this line allows the yarn integrity check to always be true (set at the top of the file).  Newer docker builds have no issues with this removal.  Possibly fixed from webpacker docker service.

This pull request makes the following changes:
* Removed docker env check for yarn `check_yarn_integrity`

It relates to the following issue #s: 
* Fixes #1667 
