### PR TITLE
Improved styling of the DCAF guidance link

### DIFF
--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -31,10 +31,9 @@ module PracticalSupportsHelper
 
   def practical_support_guidance_link
     url = Config.find_or_create_by(config_key: 'practical_support_guidance_url').options.first
-
-    content_tag :small, class: 'float-right' do
-      link_to t('patient.practical_support.guidance_link', fund: FUND), url, target: '_blank'
-    end if url.present?
+    link_content = link_to t('patient.practical_support.guidance_link', fund: FUND), url, target: '_blank'
+    link_content if url.present?
+    #"For guidance on practical support, view the #{link_content}."
   end
 
   private

--- a/app/views/patients/_practical_support.html.erb
+++ b/app/views/patients/_practical_support.html.erb
@@ -1,5 +1,6 @@
 <div id="practical_support_content">
-  <h2 class="mt-5"><%= t 'patient.practical_support.title' %> <%= practical_support_guidance_link %></h2>
+  <h2 class="mt-5"><%= t 'patient.practical_support.title' %></h2>
+  <p class="mb-5"><%= practical_support_guidance_link %></p>
 
   <div id="practical-support-entries">
     <%= render 'practical_supports/entries',


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

De-emphasized the DCAF guidance link 

This pull request makes the following changes:
* Changed styling of link from h2 to h5
* Separated header from the link so that it's located below header
* Added bottom margin to link 

![image](https://user-images.githubusercontent.com/17213530/67346399-99304180-f50c-11e9-8879-7d1396d3cd5a.png)

It relates to the following issue:
* Fixes #1821 
