### PR TITLE
Adds fund name for i18n key

### DIFF
--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -80,7 +80,7 @@
     <%= f.check_box :pledge_sent, label: t('patient.status.key.pledge_sent') %>
     <%= f.check_box :referred_to_clinic, label: t('patient.abortion_information.clinic_section.referred_to_clinic') %>
     <%= f.check_box :completed_ultrasound, label: t('patient.abortion_information.clinic_section.ultrasound_completed') %>
-    <%= f.check_box :resolved_without_fund, label: t('patient.status.key.resolved') %>
+    <%= f.check_box :resolved_without_fund, label: t('patient.status.key.resolved', fund: "#{FUND}") %>
 
 
   <p style="font-weight:bold"><%= t('patient.information.special_circumstances.title')%></p>


### PR DESCRIPTION

I rule and have completed some work on Case Manager that's ready for review!

This fixes a minor bug that I noticed on the data entry page where the fund name was not provided for the i18n key.

Before:
<img width="256" alt="Screen Shot 2019-10-22 at 9 20 22 PM" src="https://user-images.githubusercontent.com/5439589/67348929-71dd7280-f514-11e9-865a-d3366ceb1120.png">

After:
<img width="243" alt="Screen Shot 2019-10-22 at 9 22 57 PM" src="https://user-images.githubusercontent.com/5439589/67348935-743fcc80-f514-11e9-947f-13a395966341.png">
