### PR TITLE
darken contrast foreground on navbar

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,7 +10,7 @@
 @charset "utf-8";
 
 $daria-color: #5D3E8D;
-$grey-color: #828282;
+$grey-color: #525252;
 $font-size: 17px;
 
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Darker foreground, more accessibility, (aka remembering how git forks work at all)

This pull request makes the following changes:
*  darker grey text
*  looking super compliant here.
<img width="574" alt="Screen Shot 2019-10-26 at 2 01 46 PM" src="https://user-images.githubusercontent.com/1946584/67623986-a2195f80-f7f9-11e9-99fe-6a98eb96b9ad.png">

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes       #1754 


