### PR TITLE
bump loofah to squash a security complaint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'figaro' # we handle secrets differently now
 gem 'js-routes' # Not sure if this is used anymore
 
 # Stuff we're hardsetting because of security concerns
-gem 'loofah', '>= 2.2.3'
+gem 'loofah', '>= 2.3.1'
 gem 'rails-html-sanitizer', '>= 1.0.4'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     coffee-script-source (1.12.2)
     colored (1.2)
     concurrent-ruby (1.1.5)
-    crass (1.0.4)
+    crass (1.0.5)
     database_cleaner (1.7.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -182,7 +182,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.3)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -434,7 +434,7 @@ DEPENDENCIES
   knapsack
   launchy
   listen
-  loofah (>= 2.2.3)
+  loofah (>= 2.3.1)
   mini_backtrace
   minitest-ci
   minitest-optional_retry


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Squash a loofah security complaint by bumping to 2.3.1

This pull request makes the following changes:
* loofah to >= 2.3.1

no issues