### PR TITLE
Add URI https-ification service

### DIFF
--- a/app/services/readme.md
+++ b/app/services/readme.md
@@ -1,0 +1,1 @@
+The services directory here is for utilty standalone service classes that are not coupled directly to the rails MVC

--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -1,0 +1,3 @@
+class UriService
+
+end

--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -2,7 +2,11 @@ class URIService
   attr_accessor :uri
 
   def initialize(uri)
-    @uri = URI.parse(URI.encode(uri))
+    begin 
+      @uri = URI.parse(URI.encode(uri))
+    rescue URI::InvalidURIError
+      nil
+    end
   end
 
   def secure_scheme!

--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -1,3 +1,11 @@
-class UriService
+class URIService
+  attr_accessor :uri
 
+  def initialize(uri)
+    @uri = URI.parse(URI.encode(uri))
+  end
+
+  def secure_scheme!
+    @uri.scheme = "https"
+  end
 end

--- a/test/services/uri_service_test.rb
+++ b/test/services/uri_service_test.rb
@@ -6,6 +6,11 @@ class URIServiceTest < ActiveSupport::TestCase
       uri = URIService.new("some yolo test uri").uri
       assert uri.is_a?(URI)
     end
+    
+    it 'instantiates nil on invalidURIs' do
+      uri = URIService.new(":::::::::::").uri
+      assert_nil uri
+    end
 
     it 'can force the scheme to use https' do
       u = URIService.new("http://www.someyolourl.com")

--- a/test/services/uri_service_test.rb
+++ b/test/services/uri_service_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class URIServiceTest < ActiveSupport::TestCase
+  describe 'URI service utility' do
+    it 'instantiates a uri from string' do
+      uri = URIService.new("some yolo test uri").uri
+      assert uri.is_a?(URI)
+    end
+
+    it 'can force the scheme to use https' do
+      u = URIService.new("http://www.someyolourl.com")
+      assert_equal u.uri.scheme, "http"
+      u.secure_scheme!
+      assert_equal u.secure_scheme!, "https"
+    end
+  end
+end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds a resilient URI service utility that can force the scheme to https

This pull request makes the following changes:
adds utility and test

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Connects #1826 (fix coming in #1843)
