### PR TITLE
Status helper text updates when patient status updates (#1825)

### DIFF
--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -5,7 +5,13 @@ $('#patient_appointment_date')
   .text("<%= t('patient.dashboard.approx_gestation', weeks: @patient.last_menstrual_period_at_appt_weeks, days: @patient.last_menstrual_period_at_appt_days) %>");
 
 // rerack status
-$('#patient_status').text('<%= @patient.status %>');
+$('#patient_status')
+  .text('<%= @patient.status %>');
+
+// rerack tooltip content 
+$('.daria-tooltip.tooltip-header-help')
+                  .attr('title', "<%= status_help_text(@patient)%>")
+                  .tooltip('fixTitle')
 
 // rerack current LMP
 $('#patient_last_menstrual_period_weeks')


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Hello! I added a little bit of code in update.js.erb to dynamically update the tooltip content rendered in _patient_dashboard.html.erb. 

This pull request makes the following changes:
* Without having to refresh the page, the helper text content in the tooltip (which shows up when you hover over the '?' next to a patient's status text) updates accordingly when the status itself changes (the change usually happens when a CM has entered the patient's  appointment date, or a pledge has been sent). 

![dynamic-tooltip](https://user-images.githubusercontent.com/13320420/68251209-a2330f80-fff0-11e9-899d-0fc0235c53f7.gif)


It relates to the following issue #s: 
* Fixes #1825 
