### PR TITLE
Fix add new user button miscolorization

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -90,6 +90,12 @@ body {
   background-color: lighten($daria-color,15%);
 }
 
+.btn-primary:focus {
+  background-color: lighten($daria-color,15%);
+  color: white;
+  text-decoration: none;
+}
+
 .border-bottom {
   border-bottom: 1px solid black;
   padding-bottom: 10px;


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Anchor and button tag focus states were a little different for some reason, and now they're not. Circle of life.

Don't worry about the test failures.

This pull request makes the following changes:
* set focus styling on anchor tags -- we're overriding some stuff but not all, now we are

New focus state looks like:

![image](https://user-images.githubusercontent.com/3866868/68523240-50a2b300-0284-11ea-83c2-ae68e7fa3d17.png)

It relates to the following issue #s: 
* Fixes #1823
