### PR TITLE
Fix pledge generation by making it synchronous

### DIFF
--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -21,7 +21,9 @@
         <p class="row"><strong><%= t('patient.pledge.step_two.generate_note') %></strong></p>
 
         <div class="row">
-          <%= bootstrap_form_with url: generate_pledge_patient_path(patient), method: 'get' do |f| %>
+          <%= bootstrap_form_with url: generate_pledge_patient_path(patient),
+                                  method: 'get',
+                                  local: true do |f| %>
             <%= f.text_field :case_manager_name, label: t('patient.pledge.step_two.sign_pledge') %>
             <%= f.submit t('patient.pledge.step_two.generate_pledge_button'), class: 'btn btn-large btn-primary' %>
           <% end %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

`form_with` is ajax by default. This is not an ajax endpoint, so it would be generated and then nothing would happen. 

don't worry about test failures because feature branch.

This pull request makes the following changes:
* make this endpoint ajaxy

no view change, really, but the download works!

It relates to the following issue #s: 
* Fixes #1822 
