### PR TITLE
BS4: Early return if there's no URL to generate on practical support helper

### DIFF
--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -31,9 +31,9 @@ module PracticalSupportsHelper
 
   def practical_support_guidance_link
     url = Config.find_or_create_by(config_key: 'practical_support_guidance_url').options.first
-    link_content = link_to t('patient.practical_support.guidance_link', fund: FUND), url, target: '_blank'
-    link_content if url.present?
-    #"For guidance on practical support, view the #{link_content}."
+    return unless url.present?
+    link_to t('patient.practical_support.guidance_link', fund: FUND), url, target: '_blank'
+    # "For guidance on practical support, view the #{link_content}."
   end
 
   private

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -122,7 +122,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
       end
 
     it 'should return a link if config set' do
-      expected_link = '<small class="float-right"><a target="_blank" href="https://www.yahoo.com">DCAF practical support guidance</a></small>'
+      expected_link = '<a target="_blank" href="https://www.yahoo.com">DCAF practical support guidance</a>'
       assert_equal expected_link, practical_support_guidance_link
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Unit test caught a potential issue if a practical support config is not set. This fixes that and adjusts another unit test to match reality.

This pull request makes the following changes:
* add early return to avoid URLGeneration error
* fix unit test to match new output without `small` html tags

no changes

It relates to the following issue #s: 
* Bumps #1632 
