### PR TITLE
BS4 system test failures: bs4ify tooltip bump; fix system test misspelling

### DIFF
--- a/app/views/patients/update.js.erb
+++ b/app/views/patients/update.js.erb
@@ -11,7 +11,8 @@ $('#patient_status')
 // rerack tooltip content 
 $('.daria-tooltip.tooltip-header-help')
                   .attr('title', "<%= status_help_text(@patient)%>")
-                  .tooltip('fixTitle')
+                  .attr('data-original-title', "<%= status_help_text(@patient)%>")
+                  .tooltip('update');
 
 // rerack current LMP
 $('#patient_last_menstrual_period_weeks')

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -44,7 +44,7 @@ class DataEntryTest < ApplicationSystemTestCase
       select 'English', from: 'patient_language'
       select 'Do not leave a voicemail', from: 'patient_voicemail_preference'
       check 'patient_referred_to_clinic'
-      check 'patient_completed_ultasound'
+      check 'patient_completed_ultrasound'
       check 'patient_resolved_without_fund'
       check 'Pledge Sent'
       check 'fetal_patient_special_circumstances'

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -77,8 +77,8 @@ class DataEntryTest < ApplicationSystemTestCase
         assert has_field? 'City', with: 'Washington'
         assert has_field? 'State', with: 'DC'
         assert has_field? 'County', with: 'Wash'
-        assert_equal 'English', find('#patient_language').value
-        assert_equal 'Do not leave a voicemail', find('#patient_voicemail_preference').value
+        assert_equal 'English', find('#patient_language').text
+        assert_equal 'no', find('#patient_voicemail_preference').value
         assert_equal 'Student', find('#patient_employment_status').value
         assert_equal 'Under $9,999',
                      find('#patient_income').value


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

System tests picked up some failures in the flash message and data entry tests. This gets everything green again, I hope.

This pull request makes the following changes:
* BS4 changed the way tooltips get refreshed, though not by much, so adapted @harumhelmy 's status refreshing code a little bit (s/o to my dog stack overflow)
* one of the element renames got weird; this was iso'd to just system tests

no view changes

It relates to the following issue #s: 
* Fixes #1632 
