### PR TITLE
force white text on btn-primary

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -82,6 +82,7 @@ body {
   @extend .btn-primary;
   background-color: $daria-color;
   border: none;
+  color: white;
   margin-bottom: 2px;
   font-size: $font-size;
 }


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Links for btn-primary MOSTLY follow the standard, but for some reason on sandbox this isn't flying and the text color follows the anchor blue, which is unreadable on our purple background.

![image](https://user-images.githubusercontent.com/3866868/68609958-a3e35400-0484-11ea-9a10-1fee3ab0d647.png)

This forces text color white on btn-primary. Which hopefully resolves this in sandbox -- I can't recreate in staging.

This pull request makes the following changes:
* btn-primary now has color: white;

It relates to the following issue #s: 
* Fixes #1632 
