### PR TITLE
Remove section tag and bootstrap_form_tag

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -195,11 +195,6 @@ main {
   margin-top: 51px; // accommodate the navbar
 }
 
-section {
-  @extend .row;
-  margin-top: 20px;
-}
-
 h1.title {
   font-weight: 100;
   margin-bottom: 20px;

--- a/app/views/accountants/_search_form.html.erb
+++ b/app/views/accountants/_search_form.html.erb
@@ -1,6 +1,6 @@
 <div id="search_form" class="margin-bottom">
   <!-- TODO change submit tag to a search glyphicon -->
-  <%= bootstrap_form_tag url: 'accountant/search', remote: true, layout: :inline do |f| %>
+  <%= bootstrap_form_with url: 'accountant/search', remote: true, layout: :inline do |f| %>
     <%= f.hidden_field :locale, value: params[:locale] %>
     <%= f.text_field :search,
                      placeholder: t('accountants.search_placeholder'),

--- a/app/views/lines/new.html.erb
+++ b/app/views/lines/new.html.erb
@@ -2,7 +2,7 @@
   <div class="col lines-form">
     <h1 class="border-bottom title"><%= t 'lines.new.welcome_to_daria', fund: FUND %></h1>
 
-    <%= bootstrap_form_tag url: lines_path, class: 'line-select-form' do |f| %>
+    <%= bootstrap_form_with url: lines_path, local: true, class: 'line-select-form' do |f| %>
       <%= f.form_group :line, label: { text: t('lines.new.what_line') } do %>
         <% lines.each do |line| %>
           <%= f.radio_button :line, line, label: line %>

--- a/app/views/patients/_menu.html.erb
+++ b/app/views/patients/_menu.html.erb
@@ -1,4 +1,4 @@
-<section id='menu-content'>
+<div id='menu-content' class="row mt-5">
   <div class="nav nav-pills flex-column abortion-left-menu" id='menu-list' role='tablist' aria-orientation="vertical">
     <%= render 'menu_item', link_for: 'patient_information', active: true %>
     <%= render 'menu_item', link_for: 'abortion_information', active: false %>
@@ -11,7 +11,7 @@
       <%= render 'menu_item', link_for: 'pledge_fulfillment', active: false %>
     <% end %>
   </div>
-</section>
+</div>
 
 <div id="menu-pledge-button">
   <%= render 'menu_pledge_button', patient: patient %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Removes a few things we don't need to use anymore now that we're in full on BS4.

The new rails hotness is `bootstrap_form_with`, so we're converting some of these over. The bootstrap_form_for stuff is more complicated to port and there's more of it, so we can do that in its own ticket which I'll write up in a sec.

This pull request makes the following changes:
* remove section tag and styling
* convert bootstrap_form_tag to bootstrap_form_with url:

It relates to the following issue #s: 
* Fixes #1787 
