### PR TITLE
Favor mx-* and d-none in frontend code

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -393,10 +393,6 @@ form {
   line-height: 1.0;
 }
 
-.hidden {
-  display: none;
-}
-
 // This is necessary because of a vendored multimodal plugin that we should aim to deprecate
 .hide {
   @extend .d-none;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -126,14 +126,6 @@ body {
   padding-right: 2px;
 }
 
-// add spacing
-.margin-bottom {
-  margin-bottom: 3em;
-}
-.margin-bottom-sm {
-  margin-bottom: 1.5em;
-}
-
 // increase size of text in form fields
 .form-control {
   font-size: $font-size;
@@ -403,9 +395,6 @@ form {
 
 .hidden {
   display: none;
-}
-.bottom-spacer {
-  margin-bottom: .75em;
 }
 
 // This is necessary because of a vendored multimodal plugin that we should aim to deprecate

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,8 +17,9 @@ $spacers: map-merge(
     3: $spacer, //.5 rem
     4: ($spacer * 1.5), //.75rem
     5: ($spacer * 2), //1rem
-    6: ($spacer * 3) //1.5rem
-
+    6: ($spacer * 3), //1.5rem
+    7: ($spacer * 4), // 2rem;
+    8: ($spacer * 5) // 2.5rem;
   ),
   $spacers
 );

--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -2,6 +2,8 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+@import './application';
+
 .lines-form {
     input[type="radio"] {
         -ms-transform: scale(2); /* IE 9 */
@@ -15,8 +17,7 @@
     }
 
     .form-check-label {
-        // Keeping this because it needs more space than our ml-6
-        margin-left: 2em;
+        @extend .ml-8;
     }
 
     .btn-primary {

--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -15,6 +15,7 @@
     }
 
     .form-check-label {
+        // Keeping this because it needs more space than our ml-6
         margin-left: 2em;
     }
 

--- a/app/assets/stylesheets/pregnancies.scss
+++ b/app/assets/stylesheets/pregnancies.scss
@@ -11,12 +11,6 @@ $font-size: 17px;
   padding: 15px 0;
 }
 
-.hide-label{
-  select{
-    margin-top: 28px;
-  }
-}
-
 // TODO This should be a class!
 #sections {
   border-left: 1px solid black;

--- a/app/javascript/src/clinic_finder.js
+++ b/app/javascript/src/clinic_finder.js
@@ -1,6 +1,6 @@
 $(document).on('turbolinks:load', () => {
   // Click on the clinic-locator expand to show it.
   $(document).on('click', '.clinic-finder-expand', () => {
-    $('#clinic-finder-search-form').toggleClass('hidden');
+    $('#clinic-finder-search-form').toggleClass('d-none');
   });
 });

--- a/app/views/clinicfinders/_search_form.html.erb
+++ b/app/views/clinicfinders/_search_form.html.erb
@@ -7,7 +7,7 @@
     </h4>
   </div>
 
-  <div class="card-body hidden" id="clinic-finder-search-form">
+  <div class="card-body d-none" id="clinic-finder-search-form">
     <h5><%= t('clinic_locator.description') %></h5>
 
     <%= bootstrap_form_with url: clinicfinder_search_path,

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -19,7 +19,7 @@
                      help: t('patient.dashboard.currently', weeks: patient.last_menstrual_period_now_weeks, days: patient.last_menstrual_period_now_days) %>
       </div>
 
-      <div class="col hide-label">
+      <div class="col mt-6">
         <%= f.select :last_menstrual_period_days,
                      options_for_select(days_options, patient.last_menstrual_period_days),
                      autocomplete: 'off',

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t('user.index.user_account_management') %></h1>
 
-<div class="row top-spacer bottom-spacer">
+<div class="row top-spacer mb-4">
   <div class="col">
     <%= button_to t('user.index.add_new_user'), new_user_path, method: :get, class: "btn btn-primary" %>
   </div>
@@ -10,6 +10,6 @@
   </div>
 </div>
 
-<div id="user-list" class="margin-bottom">
+<div id="user-list" class="mb-6">
   <%= render partial: 'users/users_table', locals: { users: @users, autosortable: true } %>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

In the spirit of cleaning up messes I made, this PR uses mx-* and d-none in places where we were using `margin-x` or `hidden`. Much nicer! Credit to @tingaloo for this insight, and lets us kill off a decent chunk of handrolled css.

This pull request makes the following changes:
* use bootstrap-4-y `mx-*` over custom margin declarations except in like one spot
* use bootstrap-4-y `d-none` over custom hidden classes except in one spot

no view changes!

It relates to the following issue #s: 
* Fixes #1788 
