### PR TITLE
Tell our ruby mongodb connection to not support rewrites

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -3,6 +3,7 @@ development:
     default:
       uri: mongodb://<%= ENV['mongohost'] || 'localhost' %>:<%= ENV['mongoport'] || 27017 %>/dcaf_case_management_development
       options:
+        retry_writes: false
 
 test:
   clients:
@@ -18,3 +19,5 @@ production:
   clients:
     default:
       uri: <%= ENV['MONGODB_URI'] %>
+      options:
+        retry_writes: false


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Not sure this will work but when I shipped rails 6 to prod it got mad about this:

```
Mongo::Error::OperationFailure (Mongo::Error::OperationFailure: Transaction numbers are only allowed on storage engines that support document-level locking (20) This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string or use the retry_writes: false Ruby client option):
```

This seems to be because mlab doesn't support this; hopefully this is as simple as changing the database connection and not indicative of a bigger, prod-only problem!

This pull request makes the following changes:
* adds a mongoid connection option: `retry_writes: false`

no view changes

It relates to the following issue #s: 
* Bumps #1589 
