### PR TITLE
set lockfile to use bundler 2 instead of bundler 1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -495,4 +495,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.1.0


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

CircleCI doesn't seem to support bundler v1 in their buildpacks anymore. Guess how I found this out.

This pull request makes the following changes:
* ran `gem install bundler && bundle update --bundler` to install new bundler gem and rebundle

no views, no issues
