### PR TITLE
Configurable BudgetBar Max

### DIFF
--- a/app/controllers/concerns/budget_bar_calculable.rb
+++ b/app/controllers/concerns/budget_bar_calculable.rb
@@ -3,7 +3,7 @@ module BudgetBarCalculable
 
   def budget_bar_calculations(line)
     expenditures = Patient.pledged_status_summary line
-    default_cash_ceiling = 1_000
+    default_cash_ceiling = Config.budget_bar_max
 
     cash_spent = expenditures.values.flatten.map { |x| x[:fund_pledge] }.inject(:+) || 0
     { limit: [default_cash_ceiling, cash_spent].max,

--- a/app/helpers/budget_bar_helper.rb
+++ b/app/helpers/budget_bar_helper.rb
@@ -5,7 +5,7 @@ module BudgetBarHelper
     "bg-#{color}"
   end
 
-  def progress_bar_width(value, cash_ceiling = 1_000)
+  def progress_bar_width(value, cash_ceiling = Config.budget_bar_max)
     "width: #{to_pct(value, cash_ceiling)}%"
   end
 
@@ -27,10 +27,11 @@ module BudgetBarHelper
 
   private
 
-  def to_pct(value, cash_ceiling = 1_000)
+  def to_pct(value, cash_ceiling = Config.budget_bar_max)
     return '0' if cash_ceiling == 0
 
     pct = (value.to_f / cash_ceiling.to_f) * 100
     pct.round.to_s
   end
+
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,7 +1,7 @@
 # Convenience methods consumed in the dashboards controller index view
 module DashboardsHelper
   def date_range(date: Time.zone.now)
-    if (Config.start_day.downcase == :monthly )
+    if (Config.start_day == :monthly )
       month_range(date: date)
     else
       week_range(date: date)

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -10,7 +10,7 @@ class Config
   CONFIG_FIELDS = [
     :insurance, :external_pledge_source, :pledge_limit_help_text,
     :language, :resources_url, :practical_support_guidance_url, :fax_service, :referred_by,
-    :practical_support, :hide_practical_support, :start_of_week
+    :practical_support, :hide_practical_support, :start_of_week, :budget_bar_max
   ].freeze
 
   # Define overrides for particular config fields.
@@ -22,6 +22,7 @@ class Config
                    'Ex: https://drive.google.com/drive/my-practical_support',
     fax_service: 'A link to your fax service. ex: https://www.efax.com',
     start_of_week: "How to render your budget bar. Default is weekly starting on Monday. Enter \"Sunday\" for weekly budget starting on Sunday, or \"Monthly\" for a calendar month based budget.",
+    budget_bar_max: "The maximum for the budget bar. Default $1,000",
     hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.'
   }.freeze
 
@@ -63,13 +64,19 @@ class Config
     end
   end
 
-  def self.start_day
-    start = Config.find_or_create_by(config_key: 'start_of_week').options.try :last
-    start ||= "monday"
-    start.downcase.to_sym
+  def self.budget_bar_max
+    budget_max = Config.find_or_create_by(config_key: 'budget_bar_max').options.try :last
+    budget_max ||= 1_000
+    budget_max.to_i
   end
 
   def self.hide_practical_support?
     Config.find_or_create_by(config_key: 'hide_practical_support').options.try(:last).to_s =~ /yes/i ? true : false
+  end
+
+  def self.start_day
+    start = Config.find_or_create_by(config_key: 'start_of_week').options.try :last
+    start ||= "monday"
+    start.downcase.to_sym
   end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -22,7 +22,7 @@ class Config
                    'Ex: https://drive.google.com/drive/my-practical_support',
     fax_service: 'A link to your fax service. ex: https://www.efax.com',
     start_of_week: "How to render your budget bar. Default is weekly starting on Monday. Enter \"Sunday\" for weekly budget starting on Sunday, or \"Monthly\" for a calendar month based budget.",
-    budget_bar_max: "The maximum for the budget bar. Default $1,000",
+    budget_bar_max: "The maximum for the budget bar. Defaults to 1000 if not set. Enter as a number with no dollar sign or commas.",
     hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.'
   }.freeze
 

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -82,16 +82,16 @@ class ConfigTest < ActiveSupport::TestCase
       end
     end
 
-    describe '#start_day' do
-      it 'should return the day of week as a symbol' do
-        assert(Config.start_day.equal? :monday)
+    describe '#budget_bar_max' do
+      it 'should return an integer of 1_000 if unconfigured' do
+        assert(Config.budget_bar_max == 1_000)
       end
 
-      it 'should return another day of the week if configured' do
-        c = Config.find_or_create_by(config_key: 'start_of_week')
-        c.config_value = { options: ["Tuesday"] }
+      it 'should return another amount if configured' do
+        c = Config.find_or_create_by(config_key: 'budget_bar_max')
+        c.config_value = { options: [2000] }
         c.save!
-        assert(Config.start_day.equal? :tuesday)
+        assert(Config.budget_bar_max == 2_000)
       end
     end
 
@@ -112,6 +112,19 @@ class ConfigTest < ActiveSupport::TestCase
 
       it "returns false by default" do
         assert(Config.hide_practical_support? == false)
+      end
+    end
+
+    describe '#start_day' do
+      it 'should return the day of week as a symbol' do
+        assert(Config.start_day.equal? :monday)
+      end
+
+      it 'should return another day of the week if configured' do
+        c = Config.find_or_create_by(config_key: 'start_of_week')
+        c.config_value = { options: ["Tuesday"] }
+        c.save!
+        assert(Config.start_day.equal? :tuesday)
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ~ready for review!~

Made the max value of the BudgetBar configurable.


Old  (_number for demo purposes only_)
![Screenshot from 2019-12-21 18-20-48](https://user-images.githubusercontent.com/6129479/71556656-49d52880-2a09-11ea-80a0-7acab3e92565.png)

New (_number for demo purposes only_)
![Screenshot from 2019-12-29 06-45-11](https://user-images.githubusercontent.com/6129479/71556654-49d52880-2a09-11ea-9aa0-14f5765b2d7b.png)



This pull request makes the following changes:  
 - [x] Add Config option for budget bar max
 - [x] Budget Bar sizes proportional to that number


* Fixes #1883 