### PR TITLE
Modernize container links in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3.1'
+version: '3.7'
+
 services:
   webpacker:
     image: colinxfleming/dcaf_case_management:latest
@@ -17,12 +18,13 @@ services:
       - .:/usr/src/app
     ports:
       - "3000:3000"
-    links:
-      - db
     environment:
       mongohost: db
     env_file:
       - .docker/web-variables.env
+    depends_on:
+      - db
+      - webpacker
   db:
     image: mongo
     ports:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Turns out `links` in docker-compose are on their way out in favor of `network`. Removing explicit links puts everything in the same implied network, so we do that instead.

This pull request makes the following changes:
* deprecate links in docker-compose in favor of network

no views, no issues
