### PR TITLE
Rails6 Cleanup: Bump coffee-rails to 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'webpacker', '~> 4.2.0'
 gem 'sass-rails', '>= 6'
 gem 'bootstrap', '~> 4.3.1'
 gem 'bootstrap_form', '~> 4.2.0'
-gem 'coffee-rails', '~> 4.2.2'
+gem 'coffee-rails', '~> 5.0.0'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,9 +105,9 @@ GEM
       simplecov
       url
     coderay (1.1.2)
-    coffee-rails (4.2.2)
+    coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
+      railties (>= 5.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -434,7 +434,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   codecov
-  coffee-rails (~> 4.2.2)
+  coffee-rails (~> 5.0.0)
   database_cleaner
   devise (~> 4.7)
   enumerize


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fixed the startup error & hopefully stops the dev email spam! :smile: 

> Single arity template handlers are deprecated” error

This pull request makes the following changes:
* Bumps from 4.2.2, now `coffee-rails ~> `5.0.0`` & then ran `bundle install`

No views changes.

It relates to the following issue #s: 
* Fixes #1885 
