### PR TITLE
explicitly declare turbolinks in render_async calls

### DIFF
--- a/app/views/dashboards/_activity_log.html.erb
+++ b/app/views/dashboards/_activity_log.html.erb
@@ -4,6 +4,6 @@
   </h1>
 
   <div id="activity_log_content">
-    <%= render_async events_path, html_options: { nonce: true } %>
+    <%= render_async events_path, html_options: { nonce: true }, 'data-turbolinks-track': 'reload' %>
   </div>
 </div>

--- a/app/views/dashboards/_overview.html.erb
+++ b/app/views/dashboards/_overview.html.erb
@@ -5,6 +5,6 @@
   </h1>
 
   <div id="budget_bar">
-    <%= render_async budget_bar_path, html_options: { nonce: true } %>
+    <%= render_async budget_bar_path, html_options: { nonce: true }, 'data-turbolinks-track': 'reload' %>
   </div>
 </div>

--- a/config/initializers/render_async.rb
+++ b/config/initializers/render_async.rb
@@ -1,4 +1,3 @@
 RenderAsync.configure do |config|
   config.jquery = true # This will render jQuery code, and skip Vanilla JS code
-  config.turbolinks = true # Automatically data-turbolinks-track: reload
 end


### PR DESCRIPTION
hotfix to make the budget bar show up again, because for some reason this isn't working in prod environments? 