### PR TITLE
render_async: move data-turbolinks-track to html options

### DIFF
--- a/app/views/dashboards/_activity_log.html.erb
+++ b/app/views/dashboards/_activity_log.html.erb
@@ -4,6 +4,6 @@
   </h1>
 
   <div id="activity_log_content">
-    <%= render_async events_path, html_options: { nonce: true }, 'data-turbolinks-track': 'reload' %>
+    <%= render_async events_path, html_options: { nonce: true, 'data-turbolinks-track': 'reload' } %>
   </div>
 </div>

--- a/app/views/dashboards/_overview.html.erb
+++ b/app/views/dashboards/_overview.html.erb
@@ -5,6 +5,6 @@
   </h1>
 
   <div id="budget_bar">
-    <%= render_async budget_bar_path, html_options: { nonce: true }, 'data-turbolinks-track': 'reload' %>
+    <%= render_async budget_bar_path, html_options: { nonce: true, 'data-turbolinks-track': 'reload' }  %>
   </div>
 </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

really dunked on myself with this one.

This pull request makes the following changes:
* pass `data-turbolinks-track: reload` in the right spot, so it actually gets passed into `content_for` instead of just disappearing into the void

no views, no issues - this is a hotfix of something I broke in #1890 