### PR TITLE
squelch zeitwerk warning about undefined module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - run: brakeman --exit-on-warn .
       - run: bundle exec ruby-audit check
       - run: bundle-audit update; bundle-audit check --ignore CVE-2015-9284
+      - run: rails zeitwerk:check
       # - run: yarn audit
       - store_artifacts:
           path: /home/circleci/abortioneering/tmp/capybara/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run: brakeman --exit-on-warn .
       - run: bundle exec ruby-audit check
       - run: bundle-audit update; bundle-audit check --ignore CVE-2015-9284
-      - run: rails zeitwerk:check
+      - run: bundle exec rails zeitwerk:check
       # - run: yarn audit
       - store_artifacts:
           path: /home/circleci/abortioneering/tmp/capybara/

--- a/app/services/clinic_finder/modules/gestation_helper.rb
+++ b/app/services/clinic_finder/modules/gestation_helper.rb
@@ -1,3 +1,17 @@
+ require 'ostruct'
+
+# Currently defining this as a placeholder to keep the autoloader happy.
+# Actual code for the old gem is commented out below. Comment it it in
+# someday.
+module ClinicFinder
+  # Functionality pertaining to gestation age calculation
+  module Modules
+    # Nesting due to rails autoload
+    module GestationHelper; end
+  end
+end
+
+# Old code from gem 
 # class ClinicFinder
 #   class GestationHelper
 #     attr_reader :gestational_age, :gestational_weeks


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Paired with #1893 this eliminates an outstanding zeitwerk warning about how it's expecting a module to be defined.

Also add `rails zeitwerk:check` to CI, so we don't accidentally intro new problems, kinda similar to how we're enforcing a bunch of i18n stuff.

Note that this leaves an existing warning with ActionMailer previews, which I've opened an issue about at https://github.com/rails/rails/issues/38156 

This pull request makes the following changes:
* fix existing warning
* add zeitwerk:check to CI

no view changes

bumps #1876 