### PR TITLE
manage turbolinks in webpack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby '2.6.5'
 # Standard rails
 gem 'rails', '~> 6.0.2'
 gem 'puma', '~> 4.3' # roar
-gem 'turbolinks', '~> 5.2.0'
 gem 'sdoc', '~> 1.0.0', group: :doc
 gem 'nokogiri', '>= 1.10.5'
 gem 'tzinfo-data', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,9 +387,6 @@ GEM
     tilt (2.0.10)
     timecop (0.9.1)
     ttfunk (1.5.1)
-    turbolinks (5.2.0)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     tzinfo-data (1.2018.5)
@@ -476,7 +473,6 @@ DEPENDENCIES
   simplecov
   sqreen
   timecop
-  turbolinks (~> 5.2.0)
   tzinfo-data
   webdrivers
   webpacker (~> 4.2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require popper
 //= require jquery_ujs
 //= require jquery-ui
-//= require turbolinks
 //= require js-routes
 //= require bootstrap-sprockets
 //= require_tree .

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,3 +13,4 @@ import '../src/clinics';
 import '../src/fontawesome';
 import '../src/pledge_calculator';
 import '../src/table_sorting';
+import '../src/turbolinks';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,10 +7,11 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
+import '../src/turbolinks';
+
 import '../src/call_list_drag_and_drop';
 import '../src/clinic_finder';
 import '../src/clinics';
 import '../src/fontawesome';
 import '../src/pledge_calculator';
 import '../src/table_sorting';
-import '../src/turbolinks';

--- a/app/javascript/src/turbolinks.js
+++ b/app/javascript/src/turbolinks.js
@@ -1,0 +1,5 @@
+// Require turbolinks to not constantly do full page refreshes.
+
+import Turbolinks from 'turbolinks';
+
+Turbolinks.start();

--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col">
-    <%= bootstrap_form_with model: config, inline: true do |f| %>
+    <%= bootstrap_form_with model: config, inline: true, local: true do |f| %>
       <%= f.text_area :options, label: "#{config.config_key.to_s.humanize} options",
                                 value: config.config_value.try(:values_at, 'options')
                                                           .try(:join, ', '),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= favicon_link_tag %>
 
     <%= stylesheet_link_tag :application, media: 'all' %>
-    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true %>
+    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
 
     <%= javascript_include_tag :application %>
     <%= content_for :render_async %>

--- a/app/views/patients/_new_patient.html.erb
+++ b/app/views/patients/_new_patient.html.erb
@@ -1,6 +1,6 @@
 <h3 class="mt-5 mb-5"><small><%= t('patient.new.title') %></small></h3>
 
-<%= bootstrap_form_with model: patient do |f| %>
+<%= bootstrap_form_with model: patient, local: true do |f| %>
   <div class="row">
     <div class="col">
       <%= f.text_field :primary_phone,

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -29,7 +29,7 @@
 
   <div id='user-details-update' class="top-spacer">
     <h3><%= t('user.edit.update_details') %></h3>
-    <%= bootstrap_form_with model: @user do |f| %>
+    <%= bootstrap_form_with model: @user, local: true do |f| %>
       <%= f.text_field :name, label: t('common.name'), autocomplete: 'off' %>
 
       <%= f.text_field :email, label: t('common.email'), autocomplete: 'off' %>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "jquery": "^3.3.1",
     "jquery-ui": "^1.12.1",
     "set-value": "^3.0.1",
-    "stupid-table-plugin": "^1.1.3"
+    "stupid-table-plugin": "^1.1.3",
+    "turbolinks": "^5.2.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -16,7 +16,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
 
   describe 'create method' do
     before do
-      @call = attributes_for :call
+      @call = attributes_for :call, status: 'Reached patient'
       post patient_calls_path(@patient), params: { call: @call }, xhr: true
     end
 
@@ -35,14 +35,14 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should redirect to the edit patient path if patient is reached' do
-      assert_response :success
+      assert_redirected_to edit_patient_path(@patient)
     end
 
     it 'should not save and flash an error if status is blank or bad' do
       [nil, 'not a real status'].each do |bad_status|
-        @call[:status] = bad_status
+        call = attributes_for :call, status: bad_status
         assert_no_difference 'Patient.find(@patient).calls.count' do
-          post patient_calls_path(@patient), params: { call: @call }, xhr: true
+          post patient_calls_path(@patient), params: { call: call }, xhr: true
         end
         assert_response :bad_request
       end

--- a/yarn.lock
+++ b/yarn.lock
@@ -8014,6 +8014,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbolinks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
+  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We're trying to get out of the business of sprockets so we can go full webpack. To that effect, let's use the npm package to manage turbolinks rather than the gem.

This pull request makes the following changes:
* `yarn add turbolinks` plus some config
* remove it from gemfile
* a couple forms are using xhr where they should be using synchronous requests; bump those

no view changes

It relates to the following issue #s: 
* Bumps #1752 kinda
