### PR TITLE
Add instructions to get Docker-compose working on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 #Set default behavior to use Unix line endings so Docker on Windows doesn't fail
-* teolf=lf
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+#Set default behavior to use Unix line endings so Docker on Windows doesn't fail
+* teolf=lf

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,6 +33,19 @@ Any errors will show up in your terminal in the window you are running the `up` 
 
 If the server won't start, it may not have cleanly shut down. Run `rm tmp/pids/server.pid` to remove the leftover server process and run `docker-compose up` again.
 
+* On Windows 10, you may run into an error related to no matching manifest for Windows:
+ex: Step 1/21 : FROM ruby:2.6.5-slim-buster
+2.6.5-slim-buster: Pulling from library/ruby
+Service 'web' failed to build: no matching manifest for windows/amd64 10.0.18363 in the manifest list entries
+
+To fix this, you need to enable experimental features for Docker:
+1. Right click Docker icon in the Windows System Tray
+2. Go to Settings
+3. Go to Daemon
+4.Check Experimental features
+5. Hit Apply
+
+
 ## Local environment
 
 If you prefer a local environment, totally cool! We recommend the following:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -42,7 +42,7 @@ To fix this, you need to enable experimental features for Docker:
 1. Right click Docker icon in the Windows System Tray
 2. Go to Settings
 3. Go to Daemon
-4.Check Experimental features
+4. Check Experimental features
 5. Hit Apply
 
 


### PR DESCRIPTION

This pull request makes the following changes:
* Added instructions to get docker-compose working on windows


(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1904 