### PR TITLE
fixed budget bar

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -147,7 +147,7 @@ class Patient
     # Get patients who have been pledged this week, as a simplified hash
     patients = Patient.in(line: line)
                       .where(:fund_pledge.nin => [0, nil, ''])
-                      .where(:fund_pledged_at.gte => start_of_period)
+                      .or({:pledge_sent_at.gte => start_of_period}, {:fund_pledged_at.gte => start_of_period})
                       .where(:resolved_without_fund.in => [false, nil])
                       .order_by(fund_pledged_at: :asc)
                       .pluck(*plucked_attrs)

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -184,7 +184,7 @@ class PatientTest < ActiveSupport::TestCase
                     config_value: {options: ['Monday']}
       Timecop.freeze("January 20, 1973") { @patient.update! fund_pledge: 250 }                      
       Timecop.freeze("January 23, 1973") { @patient.update! pledge_sent: true, 
-                                                            appointment_date: @patient.initial_call_date + 1, 
+                                                            appointment_date: @patient.initial_call_date + 1.day, 
                                                             clinic: create(:clinic) }
 
       Timecop.freeze("January 25, 1973") do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Heyoo, I updated the `self.pledged_status_summary` method  in `patient.rb` by adding an or query so that the budget bar shows hard pledges sent since the start of the week, as well as soft pledges made that week. Working on writing the test for it! 

It relates to the following issue #s: 
* Fixes #1911 

