### PR TITLE
add information about roles to user edit/creation pages

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -21,6 +21,10 @@
       <%= role_toggle_button @user, 'data_volunteer' %>
       <%= role_toggle_button @user, 'cm' %>
     </div>
+    <br /><br />
+    <% User.role.values.each do |r| %>
+      <p><%= t("user.roles.#{r}") %></p>
+    <% end %>
   <% end %>
 
   <div id='user-details-update' class="top-spacer">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,5 +7,8 @@
     <% end %>
     <br>
     <p><%= I18n.t('user.new.edit_role_after_creating') %></p>
+    <% User.role.values.each do |r| %>
+      <p><%= t("user.roles.#{r}") %></p>
+    <% end %>
     <%= link_to t('common.back'), :back %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,8 +549,8 @@ en:
       update_info_button: Update info
       user_panel: User panel for %{email} (%{name})
     roles:
+      admin: 'The admin role is for people who are managing their fund''s DARIA instance or case manager corps. This gives access to what CMs and Data Volunteers have, plus the following: user management tools, clinic management tools, DARIA instance configuration tools, and the ability to delete patients from the individual patient record page (such as in the case of a duplicate entry).'
       cm: The Case Manager role is for people doing patient intake and making calls. This gives access to the main call list dashboard, the individual patient record page (minus the ability to edit fulfillment info), and the data entry page.
-      admin: "The admin role is for people who are managing their fund's DARIA instance or case manager corps. This gives access to what CMs and Data Volunteers have, plus the following: user management tools, clinic management tools, DARIA instance configuration tools, and the ability to delete patients from the individual patient record page (such as in the case of a duplicate entry)."
       data_volunteer: 'The Data Volunteer role is for people who require access to data or accounting tools. This gives access to what CMs have, plus the following: accounting tools for pledge reconcilling, reporting tools with summary data on patient intake, the fulfillment tab on the individual patient record page (for marking pledges as paid out), and the ability to download an anonymized spreadsheet of data for analysis.'
     search:
       button: Search

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -548,6 +548,10 @@ en:
       new_password: New password
       update_info_button: Update info
       user_panel: User panel for %{email} (%{name})
+    roles:
+      cm: The Case Manager role is for people doing patient intake and making calls. This gives access to the main call list dashboard, the individual patient record page (minus the ability to edit fulfillment info), and the data entry page.
+      admin: "The admin role is for people who are managing their fund's DARIA instance or case manager corps. This gives access to what CMs and Data Volunteers have, plus the following: user management tools, clinic management tools, DARIA instance configuration tools, and the ability to delete patients from the individual patient record page (such as in the case of a duplicate entry)."
+      data_volunteer: 'The Data Volunteer role is for people who require access to data or accounting tools. This gives access to what CMs have, plus the following: accounting tools for pledge reconcilling, reporting tools with summary data on patient intake, the fulfillment tab on the individual patient record page (for marking pledges as paid out), and the ability to download an anonymized spreadsheet of data for analysis.'
     search:
       button: Search
       text_field: Name or Email

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -548,6 +548,10 @@ es:
       new_password: Contraseña nueva
       update_info_button: Actualizar información
       user_panel: Panel de usuario para %{email} (%{name})
+    roles:
+      admin: 'El rol de administrador es para las personas que administran la instancia DARIA de su fondo o el cuerpo de administrador de casos. Esto da acceso a lo que tienen los CM y los voluntarios de datos, además de lo siguiente: herramientas de administración de usuarios, herramientas de administración de clínicas, herramientas de configuración de instancias DARIA y la capacidad de eliminar pacientes de la página de registro de pacientes individuales (como en el caso de una entrada duplicada).'
+      cm: El rol de administrador de casos es para las personas que ingresan pacientes y hacen llamadas. Esto le da acceso al panel principal de la lista de llamadas, la página de registro individual del paciente (menos la capacidad de editar la información de cumplimiento) y la página de entrada de datos.
+      data_volunteer: 'El rol del voluntario de datos es para las personas que requieren acceso a datos o herramientas de contabilidad. Esto da acceso a lo que tienen los CM, además de lo siguiente: herramientas de contabilidad para la conciliación de compromisos, herramientas de informes con datos resumidos sobre la admisión del paciente, la pestaña de cumplimiento en la página de registro individual del paciente (para marcar compromisos como pagados) y la capacidad de descargar Una hoja de cálculo anónima de datos para el análisis.'
     search:
       button: Buscar
       text_field: Nombre o Correo Electrónico


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I added the suggested text about what each role does to the user edit and create pages. Corresponding text is missing for the Spanish localization file, though. 

<img width="1254" alt="edit" src="https://user-images.githubusercontent.com/4549286/74092696-a65e4580-4a95-11ea-8e06-bdc9ba7e8ddc.png">
<img width="1112" alt="create" src="https://user-images.githubusercontent.com/4549286/74092697-a8280900-4a95-11ea-9188-3e7462262958.png">

It relates to the following issue #s: 
* Fixes #1868 
