### PR TITLE
update nav_bar and corresponding tests

### DIFF
--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -20,7 +20,6 @@
         <%= link_to t('navigation.admin_tools.config_management'), configs_path, class: 'dropdown-item' %>
       <% end %>
       <%= link_to t('navigation.admin_tools.accounting'), accountants_path, class: 'dropdown-item' %>
-      <%= link_to t('navigation.admin_tools.reporting'), reports_path, class: 'dropdown-item' %>
       <%= link_to t('navigation.admin_tools.export'), patients_path(format: :csv), class: 'dropdown-item' %>
     </div>
   </div>

--- a/test/system/navbar_links_test.rb
+++ b/test/system/navbar_links_test.rb
@@ -33,10 +33,6 @@ class NavbarLinksTest < ApplicationSystemTestCase
         assert has_link? t('navigation.admin_tools.accounting'), href: accountants_path
       end
 
-      it 'should display the Reporting link' do
-        assert has_link? t('navigation.admin_tools.reporting'), href: reports_path
-      end
-
       it 'should display the export link' do
         assert has_link? t('navigation.admin_tools.export'), href: patients_path(format: :csv)
       end
@@ -67,9 +63,6 @@ class NavbarLinksTest < ApplicationSystemTestCase
         assert has_link? t('navigation.admin_tools.accounting'), href: accountants_path
       end
 
-      it 'should display the Reporting link' do
-        assert has_link? t('navigation.admin_tools.reporting'), href: reports_path
-      end
 
       it 'should display the export link' do
         assert has_link? t('navigation.admin_tools.export'), href: patients_path(format: :csv)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I removed the link to the reports from the admin navbar, and the corresponding tests. I kept the reports controller and tests.

![image](https://user-images.githubusercontent.com/55513422/75195391-d8bfa200-5727-11ea-8cc0-91cd7b648dda.png)

It relates to the following issue #s: 
* Fixes #1924 