### PR TITLE
Add docs directory, glossary, and neutral case manager user guide

### DIFF
--- a/docs/user_guides/CASE_MANAGERS.md
+++ b/docs/user_guides/CASE_MANAGERS.md
@@ -1,24 +1,24 @@
 # Using DARIA as a Case Manager
 
-The main point of DARIA is to ensure case managers can focus on conversation with patients, rather than fighting with computers. DARIA tries hard to make sure case managers don't need to sweat the small stuff, and to organize patient information consistently.
+The main point of DARIA is to ensure case managers can focus on conversation with patients, rather than fighting with computers. DARIA's aim is to ensure case managers don't need to sweat the small stuff, and to organize patient information consistently.
 
-Case managers will spend most of their time on the `Call List View` and the `Patient Record View`. This document will go through those views and what they're used for.
+Case managers will spend most of their time on the `Call List page` and the `Patient Record page`. This document will go through those views and what they're used for.
 
-## The call list view
+## The call list page
 
-When you log in and pick your line, and see a header of `Build your call list`, you are on the `Call List View`. This is where you can plan your work for the evening, make a list of people to call, log any new callers, and keep tabs on who you've called.
+When you log in and pick your line, and see a header of `Build your call list`, you are on the `Call List page`. This is where you can plan your work for the evening, make a list of people to call, log any new callers, and keep tabs on who you've called.
 
 ### Build your call list
 
-You use this utility to populate your call list for the day. Entering either a phone number, part of a phone number, or a name will search patients for a match and return any matches it finds that aren't already in your call list. You can add people to your call list by clicking the `Add` link after searching for them.
+You use this tool to populate your call list for the day. Entering either a phone number, part of a phone number, or a name will search patients for a match and return any matches it finds that aren't already in your call list. You can add people to your call list by clicking the `Add` link after searching for them.
 
-Generally your shift will start by using this utility to find everyone you need to call that day, and then adding people as necessary, but you can use it for single patient lookups as well.
+Generally your shift will start by using this tool to find everyone you need to call that day, and then adding people as necessary, but you can use it for single patient lookups as well.
 
 Your call list is unique to you as a case manager, and other case managers can't see what patients you have on your list.
 
 #### Creating a new patient
 
-If a search doesn't find any results, instead of a list of patients, you will get a small form to create a new patient. Completing this form will save the patient in DARIA and add the patient to your call list.
+If a search doesn't find any results, instead of a list of patients, DARIA will show a new form to create a new patient case file. Once you save this form, the patient is in DARIA, and you can add the patient to your call list.
 
 DARIA won't let you save a patient unless the phone number is unique. Refer to your fund on guidance for how to handle duplicate phone numbers.
 
@@ -30,18 +30,18 @@ You can log a call to a patient by clicking the phone icon on the far right, whi
 
 * Click the phone icon on the right side to pop up the additional information
 * Dial your phone to make the call
-* If the patient picks up and you start a conversation with them, click the `I reached the patient` button; this will redirect you to their Patient Record View page. Otherwise, if you leave a voicemail or it just rings, you can click the appropriate link to return to your call list.
+* If the patient picks up and you start a conversation with them, click the `I reached the patient` button; this will redirect you to their `Patient Record page`. Otherwise, if you leave a voicemail or it just rings, you can click the appropriate link to return to your call list.
 * Either action will shift them to the `Completed Calls` section.
 
 You can remove patients from your call list by clicking the red X icon. Your call list will automatically empty out after two weeks of not logging in.
 
-You can click the patient's name to go straight to their `Patient Record View`.
+You can click the patient's name to go straight to their `Patient Record page`.
 
 ### Urgent cases
 
 There is a way to flag patients so that they are easier for others to find. This section is where they show up. This is shared across everyone who logs in on the line.
 
-To mark a patient urgent, look in the `Patient Record View` under `Notes`.
+To mark a patient urgent, look in the `Patient Record page` under `Notes`.
 
 Patients automatically filter out of this section after a week of not being updated, or if they're marked resolved, or if a pledge is sent for them to a clinic.
 
@@ -51,7 +51,7 @@ To make it easier to see who the previous case manager was communicating with, w
 
 You can use this section to add particular patients to your call list, or click into their patient records.
 
-## The patient record view
+## The patient record page
 
 One of DARIA's major strengths is consistent organization of information. Our team has worked hard to present information about particular patients in ways that are easy to sort. This information is associated with a patient, and shows up the same for every case manager.
 

--- a/docs/user_guides/CASE_MANAGERS.md
+++ b/docs/user_guides/CASE_MANAGERS.md
@@ -1,0 +1,74 @@
+# Using DARIA as a Case Manager
+
+The main point of DARIA is to ensure case managers can focus on conversation with patients, rather than fighting with computers. DARIA tries hard to make sure case managers don't need to sweat the small stuff, and to organize patient information consistently.
+
+Case managers will spend most of their time on the `Call List View` and the `Patient Record View`. This document will go through those views and what they're used for.
+
+## The call list view
+
+When you log in and pick your line, and see a header of `Build your call list`, you are on the `Call List View`. This is where you can plan your work for the evening, make a list of people to call, log any new callers, and keep tabs on who you've called.
+
+### Build your call list
+
+You use this utility to populate your call list for the evening. Entering either a phone number, part of a phone number, or a name will search patients for a match and return any matches it finds that aren't already in your call list. You can add people to your call list by clicking the `Add` link after searching for them.
+
+Generally your shift will start by using this utility to find everyone you need to call that day, and then adding people as necessary, but you can use it for single patient lookups as well.
+
+Your call list is unique to you as a case manager, and other case managers can't see what patients you have on your list.
+
+#### Creating a new patient
+
+If a search doesn't find any results, instead of a list of patients, you will get a small form to create a new patient. Completing this form will save the patient in DARIA add the patient to your call list.
+
+DARIA won't let you save a patient unless the phone number is unique. Refer to your fund on guidance for how to handle duplicate phone numbers.
+
+### Your call list / Completed calls
+
+This is a rollup of patients that you intend to call. It contains names, phone numbers, and some other additional information.
+
+You can log a call to a patient by clicking the phone icon on the far right, which will open a pop-up with some additional information. Generally, you'll do this as follows:
+
+* Click the phone icon on the right side to pop up the additional information
+* Dial your phone to make the call
+* If the patient picks up and you start a conversation with them, click the `I reached the patient` button; this will redirect you to their Patient Record View page. Otherwise, if you leave a voicemail or it just rings, you can click the appropriate link to return to your call list.
+* Either action will shift them to the `Completed Calls` section.
+
+You can remove patients from your call list by clicking the red X icon. Your call list will automatically empty out after two weeks of not logging in.
+
+You can click the patient's name to go straight to their `Patient Record View`.
+
+### Urgent cases
+
+There is a way to flag patients so that they are easier for others to find. This section is where they show up. This is shared across everyone who logs in on the line.
+
+To mark a patient urgent, look in the `Patient Record View` under `Notes`.
+
+Patients automatically filter out of this section after a week of not being updated, or if they're marked resolved, or if a pledge is sent for them to a clinic.
+
+### Line Activity Log
+
+To make it easier to see who the previous case manager was communicating with, we have the `Line Activity Log`. DARIA keeps track of every call and pledge in the last three weeks, and displays them in this section for a given line.
+
+You can use this section to add particular patients to your call list, or click into their patient records.
+
+## The patient record view
+
+One of DARIA's major strengths is consistent organization of information. Our team has worked hard to present information about particular patients in ways that are easy to sort. This information is associated with a patient, and shows up the same for every case manager.
+
+Your fund will have guidance on what data to collect specifically.
+
+### Entering information about a patient
+
+Most fields on this page detect changes automatically, and autosave. (Logging notes, external pledges, and practical support requires pressing a button.)
+
+### Sending (or unsending) a pledge
+
+To send a pledge, click the button on the left sidebar. This will open a pop-up with information about the patient for you to confirm.
+
+If DARIA has all the information it needs, click next to go to the next screen. At a minimum, DARIA needs a clinic, appointment date, and amount of money to mark a pledge.
+
+DARIA will now prompt you to send the pledge to the clinic. Note that DARIA does not automatically send pledges to clinics. Ask your fund for guidance on how to send pledges.
+
+Finally, click next again, and check the box to indicate that you sent the pledge.
+
+To withdraw a sent pledge, click the `Cancel pledge` button, click next, and uncheck the box.

--- a/docs/user_guides/CASE_MANAGERS.md
+++ b/docs/user_guides/CASE_MANAGERS.md
@@ -10,7 +10,7 @@ When you log in and pick your line, and see a header of `Build your call list`, 
 
 ### Build your call list
 
-You use this utility to populate your call list for the evening. Entering either a phone number, part of a phone number, or a name will search patients for a match and return any matches it finds that aren't already in your call list. You can add people to your call list by clicking the `Add` link after searching for them.
+You use this utility to populate your call list for the day. Entering either a phone number, part of a phone number, or a name will search patients for a match and return any matches it finds that aren't already in your call list. You can add people to your call list by clicking the `Add` link after searching for them.
 
 Generally your shift will start by using this utility to find everyone you need to call that day, and then adding people as necessary, but you can use it for single patient lookups as well.
 
@@ -18,7 +18,7 @@ Your call list is unique to you as a case manager, and other case managers can't
 
 #### Creating a new patient
 
-If a search doesn't find any results, instead of a list of patients, you will get a small form to create a new patient. Completing this form will save the patient in DARIA add the patient to your call list.
+If a search doesn't find any results, instead of a list of patients, you will get a small form to create a new patient. Completing this form will save the patient in DARIA and add the patient to your call list.
 
 DARIA won't let you save a patient unless the phone number is unique. Refer to your fund on guidance for how to handle duplicate phone numbers.
 
@@ -71,4 +71,4 @@ DARIA will now prompt you to send the pledge to the clinic. Note that DARIA does
 
 Finally, click next again, and check the box to indicate that you sent the pledge.
 
-To withdraw a sent pledge, click the `Cancel pledge` button, click next, and uncheck the box.
+If changes are needed, you can withdraw the pledge in DARIA by clicking the `Cancel pledge` button, then `Next`, and uncheck the box. Ask your fund for guidance on contacting the clinic to inform them of any changes to a pledge that was already sent.

--- a/docs/user_guides/GLOSSARY.md
+++ b/docs/user_guides/GLOSSARY.md
@@ -1,0 +1,34 @@
+# Glossary of DARIA terms
+
+These are quick explanations of concepts or specialized terms in DARIA.
+
+## Lines
+
+Some funds divide their operations into multiple funnels, which we call lines. DCAF, for example, sorts callers into _lines_ of DC, MD, VA, and Spanish, so that case managers don't get overwhelmed and work is divided up more equally. (Email the DARIA team if you want your DARIA instance to get a new line.)
+
+## Urgent cases
+
+Case managers can flag particular patients as `Urgent`, which will pull them into their own section on the call list view. Generally, this is to facilitate easier case manager handoff, though your fund may use it in a slightly different way.
+
+Patients are automatically removed from this section if six days goes by without their information being changed, or if they're marked as resolved without fund assistance, or if they're marked as pledge sent.
+
+## External pledges
+
+This is DARIA's term for other abortion funds or institutions who are contributing to a particular case. For example, if I am a case manager for the Baltimore Abortion Fund, and Women's Medical Fund has agreed to contribute $50, Women's Medical Fund is contributing an External Pledge.
+
+## Practical support
+
+This is how DARIA keeps tabs on logistical assistance funds may provide in the course of getting a patient to their abortion. For example, a bus ticket or a cab ride fall under practical support.
+
+## Pledge fulfillment
+
+When a clinic sends a remittance to indicate that a patient showed up to their appointment and used their pledge, DARIA expects you to enter that as a fulfillment.
+
+## Auditing
+
+When a fund team member has reviewed a record to confirm its accuracy, they can mark it `Fulfillment audited`. This will archive the record and delete personally identifiable information for the record shortly.
+
+## Archiving
+
+DARIA has a number of processes to remove personally identifiable information from patients when a fund indicates they no longer need it. This process removes name, phone number, and some other information, such that it reduces a patient to what's in the CSV export.
+

--- a/docs/user_guides/GLOSSARY.md
+++ b/docs/user_guides/GLOSSARY.md
@@ -8,7 +8,7 @@ Some funds divide their operations into multiple funnels, which we call lines. D
 
 ## Urgent cases
 
-Case managers can flag particular patients as `Urgent`, which will pull them into their own section on the call list view. Generally, this is to facilitate easier case manager handoff, though your fund may use it in a slightly different way.
+Case managers can flag particular patients as `Urgent`, which will pull them into their own section on the call list page. Generally, this is to facilitate easier case manager handoff, though your fund may use it in a slightly different way.
 
 Patients are automatically removed from this section if six days goes by without their information being changed, or if they're marked as resolved without fund assistance, or if they're marked as pledge sent.
 

--- a/docs/user_guides/README.md
+++ b/docs/user_guides/README.md
@@ -6,6 +6,6 @@ Please click on the document you'd like to review:
 
 * [Glossary of terms](GLOSSARY.md)
 * [Using DARIA as a Case Manager](CASE_MANAGERS.md)
-* [DARIA's data and analytics tools](ANALYTICS.md)
-* [Accounting functionality in DARIA](ACCOUNTANTS.md)
-* [Administering DARIA](ADMINS.md)
+<!-- * [DARIA's data and analytics tools](ANALYTICS.md) -->
+<!-- * [Accounting functionality in DARIA](ACCOUNTANTS.md) -->
+<!-- * [Administering DARIA](ADMINS.md) -->

--- a/docs/user_guides/README.md
+++ b/docs/user_guides/README.md
@@ -1,0 +1,11 @@
+# DARIA user guides
+
+These are guidances and reference manuals on using DARIA, either as a case manager, a data volunteer, or an administrator.
+
+Please click on the document you'd like to review:
+
+* [Glossary of terms](GLOSSARY.md)
+* [Using DARIA as a Case Manager](CASE_MANAGERS.md)
+* [DARIA's data and analytics tools](ANALYTICS.md)
+* [Accounting functionality in DARIA](ACCOUNTANTS.md)
+* [Administering DARIA](ADMINS.md)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We've needed accessible, neutral docs for a little while, so I'm checking some into github. This adds a CM guide; I'll soon add a data guide, accounting guide, an admin guide, and a sample shift doc, but wanted to stand this up and get it reviewed as soon as possible so we could share it with ext funds.

This pull request makes the following changes:
* Adds a user docs directory
* adds a glossary
* adds a quick walkthru on 

no issues 