### PR TITLE
Make webpack able to load SCSS; port over users.scss as proof of concept

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,8 +1,0 @@
-#user-list th[data-sort] {
-    cursor: pointer;
-}
-
-.user-row:hover {
-    background-color: #f1f1f1;
-    border: 2px solid gray;
-}

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -1,0 +1,4 @@
+// Webpack styles. This gets gets compiled and dropped into
+// <%= stylesheet_pack_tag 'application' %> in the main layout.
+
+@import '../styles/users';

--- a/app/javascript/packs/styles.scss
+++ b/app/javascript/packs/styles.scss
@@ -1,4 +1,4 @@
 // Webpack styles. This gets gets compiled and dropped into
-// <%= stylesheet_pack_tag 'application' %> in the main layout.
+// <%= stylesheet_pack_tag 'styles' %> in the main layout.
 
 @import '../styles/users';

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -1,0 +1,3 @@
+// Color variables in a single module.
+
+$light-gray: #f1f1f1;

--- a/app/javascript/styles/_colors.scss
+++ b/app/javascript/styles/_colors.scss
@@ -1,3 +1,3 @@
 // Color variables in a single module.
 
-$light-gray: #f1f1f1;
+$light-gray: #F1F1F1;

--- a/app/javascript/styles/users.scss
+++ b/app/javascript/styles/users.scss
@@ -1,0 +1,14 @@
+// Styling specific to users routes.
+
+@import './_colors';
+
+// Make data-sort elements in user list a pointer.
+#user-list th[data-sort] {
+  cursor: pointer;
+}
+
+// Highlight user-rows with a light gray.
+.user-row:hover {
+  background-color: $light-gray;
+  border: 2px solid gray;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,8 @@
 
     <%= stylesheet_link_tag :application, media: 'all' %>
 
-    <%= stylesheet_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true %>
+    <%= stylesheet_pack_tag 'styles', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
 
     <%= javascript_include_tag :application %>
     <%= content_for :render_async %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,9 @@
     <%= favicon_link_tag %>
 
     <%= stylesheet_link_tag :application, media: 'all' %>
-    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
+
+    <%= stylesheet_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true %>
 
     <%= javascript_include_tag :application %>
     <%= content_for :render_async %>

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -89,8 +89,5 @@ production:
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false
 
-  # Extract and emit a css file
-  extract_css: true
-
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

As noted, we want out of sprockets and into webpack - it's a technology more familiar to frontend people, and rails generally is going in that direction. It also opens up a lot of room for us to do cool stuff with js down the line, and move our bootstrap install into webpack.

The next step here is to port over as much of the individual stylesheets as we can, and then bootstrap. Hopefully this is less traumatic than the last time we made big changes to bootstrap.

To prove this works, head to the users index page and play around with the colors in `lines.scss` - change `$daria-gray` to `red` and see what happens. (You may have to `rm -rf node_modules/ && yarn` first)

This pull request makes the following changes:
* allow webpack to compile scss
* port over `users.scss` as a proof of concept
* put colors in a module, also as a proof of concept

no view changes

It relates to the following issue #s: 
* Fixes #1816 
* bumps #1854
