### PR TITLE
add fund_pledged_at and textable to archived patients

### DIFF
--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -50,10 +50,12 @@ class ArchivedPatient
   field :patient_contribution, type: Integer
   field :naf_pledge, type: Integer
   field :fund_pledge, type: Integer
+  field :fund_pledged_at, type: Time
   field :pledge_sent, type: Boolean
   field :resolved_without_fund, type: Boolean
   field :pledge_generated_at, type: Time
   field :pledge_sent_at, type: Time
+  field :textable, type: Boolean
 
   # Indices
   index(line: 1)
@@ -110,11 +112,13 @@ class ArchivedPatient
       patient_contribution: patient.patient_contribution,
       naf_pledge: patient.naf_pledge,
       fund_pledge: patient.fund_pledge,
+      fund_pledged_at: patient.fund_pledged_at,
 
       pledge_sent: patient.pledge_sent,
       resolved_without_fund: patient.resolved_without_fund,
       pledge_generated_at: patient.pledge_generated_at,
       pledge_sent_at: patient.pledge_sent_at,
+      textable: patient.textable,
 
       pledge_generated_by: patient.pledge_generated_by,
       pledge_sent_by: patient.pledge_sent_by,


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

These fields aren't populating - I think it's because `archived patient` is missing a few fields. This adds two of them that I noticed, textable and fund_pledged_at.

This is blocking a deploy so I'm going to smash it.

This pull request makes the following changes:
* add some fields that patient has to archivedpatient

no view changes
no issues