### PR TITLE
Remove unused CSS junk

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -48,7 +48,7 @@ a:hover, a:active, a:visited, a:focus {
 .navbar-inverse{
   background-color: #f5f5f5;
   border: none;
-  .navbar-header > a, .navbar-nav > li > a, .navbar-link{
+  .navbar-header > a, .navbar-nav > li > a {
     color: $daria-color;
     &:hover{
       color: lighten($daria-color, 20%);
@@ -357,10 +357,6 @@ $daria-color-lt : #825fb9;
 #flash {
   position: fixed;
 }
-
-// .input-group-prepend {
-//   @extend .input-group-addon;
-// }
 
 .form-check label {
   min-height: 20px;

--- a/app/assets/stylesheets/call_lists.scss
+++ b/app/assets/stylesheets/call_lists.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the call_lists controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/configs.scss
+++ b/app/assets/stylesheets/configs.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the configs controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -9,10 +9,6 @@
   border-radius: 50%;
 }
 
-.search_bar {
-  max-width: 35%;
-}
-
 #search_form {
   .search_form_input {
     width: 350px;

--- a/app/assets/stylesheets/external_pledges.scss
+++ b/app/assets/stylesheets/external_pledges.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the pledge controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/practical_supports.scss
+++ b/app/assets/stylesheets/practical_supports.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the practical_supports controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

In prep for moving SCSS to webpacker, clean up what we already have; delete some files with no entries and remove some style definitions that don't appear in our codebase any longer.

I suspect the search bar was just overtaken by a different style, and the navbar stuff is overtaken by bootstrap 4.

This pull request makes the following changes:
* delete empty sprockets scss files
* remove some styles that aren't used

no view changes, but here's the search bar on both a local and sandbox:

local:
![image](https://user-images.githubusercontent.com/3866868/77855782-abe82a00-71c0-11ea-91fa-c8f2118f8fc1.png)

sandbox:
![image](https://user-images.githubusercontent.com/3866868/77855792-b9051900-71c0-11ea-98d6-97c85df65f47.png)


It relates to the following issue #s: 
* Bumps #1854 
