### PR TITLE
eager load clinic calls to avoid an n+1 on CSV export

### DIFF
--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -189,7 +189,7 @@ module Exportable
 
     def to_csv
       Enumerator.new do |y|
-        each do |export|
+        includes(:clinic).each do |export|
           row = CSV_EXPORT_FIELDS.values.map{ |field| export.get_field_value_for_serialization(field) }
           y << CSV.generate_line(row, encoding: 'utf-8')
         end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Eager load clinic to avoid an n+1 on CSV export. 

All the other stuff is embedded (which means it doesn't n+1, thankfully).

This pull request makes the following changes:
* eager load clinic

no view changes

It relates to the following issue #s: 
* Fixes #1957 (hopefully)
