### PR TITLE
add shareable intro blurb

### DIFF
--- a/docs/INTRO_BLURB.md
+++ b/docs/INTRO_BLURB.md
@@ -1,0 +1,17 @@
+# An intro blurb to DARIA
+
+@colinxfleming wrote this as a quick intro to what the project was and where
+
+## The blurb
+
+DARIA is software for abortion funds by abortion funders, and friends of abortion funders. The DC Abortion Fund used to do case management out of a spreadsheet, and found that it was hard to focus on conversations with people seeking abortion care when fighting with Excel. So a team of abortion fund volunteers, engineers, and designers came up with DARIA as a way for abortion fund volunteers to keep tabs on important information without the limitations and difficulties of spreadsheets. DARIA went into service in July 2016 and is now used by several abortion funds up and down the east coast.
+
+It's an open source application deployed to Heroku, where funds can use it as a regular SaaS product. Our product decisions are made by a leadership team working together, and things we want to do are turned into Github Issues, which serve as the project's to-do list.
+
+All told, we've found that contributing to DARIA is a great way to leverage engineering and design skills to help abortion funds work, and by extension assist people seeking abortion care who are in a real tight spot.
+
+* The DARIA codebase (and its README, and Issues list): https://github.com/DCAFEngineering/dcaf_case_management
+* Join the code for DC slack here: https://codefordc.org/slack (we're in the channel #dcaf_case_management, and tend to be pretty responsive)
+* Stack-wise: It's a Rails application that mostly hews to rails defaults (though we use mongodb instead of postgres). We have a docker build if you'd rather not deal with installing stuff. There's relatively little fancy stuff in it. More particular directions are in the README.
+
+We look forward to having you!


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Wrote up this quick blurb as something we could easily share as a kind of handout - a 'my friend is interested in DARIA, what can I tell them about your project?' kinda blurb. Thought it would be useful to check into git in case we ever needed it again.

@KatSDC @lomky and @susanjw please review the copy if you don't mind!

This pull request makes the following changes:
* add blurb to docs

no views
no issues