### PR TITLE
Bump ruby to 2.6.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     parallelism: 4
     working_directory: ~/abortioneering
     docker:
-      - image: circleci/ruby:2.6.5-node-browsers
+      - image: circleci/ruby:2.6.6-node-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -46,7 +46,7 @@ jobs:
   predeploy:
     working_directory: ~/abortioneering
     docker:
-      - image: circleci/ruby:2.6.0-node-browsers
+      - image: circleci/ruby:2.6.6-node-browsers
     steps:
       - checkout
       # - restore_cache:
@@ -65,7 +65,7 @@ jobs:
   deploy:
     working_directory: ~/abortioneering
     docker:
-      - image: circleci/ruby:2.6.5-node-browsers
+      - image: circleci/ruby:2.6.6-node-browsers
     steps:
       - checkout
       - setup_remote_docker:

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-slim-buster
+FROM ruby:2.6.6-slim-buster
 MAINTAINER Colin Fleming <c3flemin@gmail.com>
 
 # configure environment variable

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.5'
+ruby '2.6.6'
 
 # Standard rails
 gem 'rails', '~> 6.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,7 @@ GEM
       rake
     launchy (2.4.3)
       addressable (~> 2.3)
+    libsqreen (0.3.0.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -380,8 +381,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sq_mini_racer (0.2.4.sqreen3)
-    sqreen (1.17.0)
+    sq_mini_racer (0.2.5.0.1.beta3)
+    sqreen (1.18.6)
+      libsqreen (~> 0.3.0.0)
       sq_mini_racer (~> 0.2.4.sqreen2)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -483,7 +485,7 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.6.6p146
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Bump ruby version to 2.6.6. This will squelch a minor vuln that is failing builds.

In the process, the sqreen gem needs an update - one of its deps was failing.

This pull request makes the following changes:
* ruby 2.6.5 -> 2.6.6
* bundle update sqreen

no views
no issues
