### PR TITLE
bump jquery-rails to squish a vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'sass-rails', '>= 6'
 gem 'bootstrap', '~> 4.3.1'
 gem 'bootstrap_form', '~> 4.2.0'
 gem 'coffee-rails', '~> 5.0.0'
-gem 'jquery-rails'
+gem 'jquery-rails', '~> 4.3.4'
 gem 'jquery-ui-rails'
 
 # Our database is MongoDB

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
     jaro_winkler (1.5.1)
-    jquery-rails (4.3.3)
+    jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -438,7 +438,7 @@ DEPENDENCIES
   figaro
   geokit
   i18n-tasks (~> 0.9.29)
-  jquery-rails
+  jquery-rails (~> 4.3.4)
   jquery-ui-rails
   js-routes
   kaminari (~> 1.1)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

jquery-rails has an id'd CVE that we need to deal with to get the build green again.

This pull request makes the following changes:
* pin `jquery-rails`
* `bundle i`

It relates to the following issue #s: 
none