### PR TITLE
Add steps to update to node 12

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -41,6 +41,10 @@ RUN yarn install
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
+# get version 12 of nodejs
+RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - && \
+    apt-get install nodejs -y
+
 # remove unnecessary build dependencies
 RUN apt-get purge -y ${BUILD_DEPENDENCIES} && apt-get autoremove -y 
 
@@ -54,8 +58,10 @@ RUN mkdir /tmp/ahab && \
     rm ahab && \
     cd -
 
-# remove unnecessary ahab dependencies
-RUN apt-get purge -y ${AHAB_DEPENDENCIES} && apt-get autoremove -y 
+# remove unnecessary ahab dependencies except ca-certificates, which is needed for nodejs
+RUN ahab_dep=${AHAB_DEPENDENCIES} && \
+    ahab_updated=${ahab_dep##ca-certificates} && \
+    apt-get purge -y ${ahab_updated} && apt-get autoremove -y
 
 # Move the rest of the app over
 COPY . ${DCAF_DIR}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Upgrades to the next LTS version of node (v12). 

This pull request makes the following changes:
* It runs the v12 setup, then installs it.
* It has a dependency on `ca-certificates`. Purging the ahab dependencies that include `ca-certificates` was causing it to remove nodejs as well.

There's no screenshot but locally I get:
```
docker-compose run --rm web node --version
Starting dcaf_case_management_db_1 ... done
v12.16.3
```

It relates to the following issue #s: 
* Fixes https://github.com/DCAFEngineering/dcaf_case_management/issues/1952
