### PR TITLE
strip etag header because it breaks streaming if set

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -158,6 +158,7 @@ class PatientsController < ApplicationController
     headers["Content-disposition"] = "attachment; filename=\"#{filename}\""
     headers['X-Accel-Buffering'] = 'no'
     headers["Cache-Control"] = "no-cache"
+    headers[Rack::ETAG] = nil # Without this, data doesn't stream
     headers.delete("Content-Length")
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This resolves the problem we had with streaming the patients export to a file. Here is my working understanding:

* Rails 6.0.2 took a slightly more aggressive tack about including the `ETag` header; this was not previously included and now it is
* browsers interpret that as caching and it overrules streaming for some reason that is not terribly clear to me
* on our version of rack, it sets a digest to `ETag` unless certain circumstances are met. One of those is an existing key for `ETag` or a key for `Last-Modified`. Take a look at https://github.com/rack/rack/blob/v2.2.2/lib/rack/etag.rb#L29 for the exact lines of code
* we cheat by setting a nil key for `ETag`, which for a reason that is an absolute mystery to me, lets the browser interpret the request properly and start streaming to that file rather than synchronously downloading it

Supposedly there are rails configs that will work for this, but I don't really want to set them globally, and I had mixed results even so.

This is not a guarantee this will fix prod, but it's a good sign that it works the way it used to in a dev environment!

This pull request makes the following changes:
* set `ETag` header to nil for the CSV export endpt

no view changes

It relates to the following issue #s: 
* Fixes #1959
