### PR TITLE
Swap accountants search to use activerecord calls because they handle nulls more gracefully

### DIFF
--- a/app/controllers/accountants_controller.rb
+++ b/app/controllers/accountants_controller.rb
@@ -10,8 +10,6 @@ class AccountantsController < ApplicationController
   end
 
   def search
-    # We're doing it janky because we implemented search to return an array,
-    # not an activerecord object. some room for improvement.
     @results = if params[:search].present?
                  Patient.where(pledge_sent: true)
                         .order_by(pledge_sent_at: :desc)

--- a/app/controllers/accountants_controller.rb
+++ b/app/controllers/accountants_controller.rb
@@ -13,9 +13,9 @@ class AccountantsController < ApplicationController
     # We're doing it janky because we implemented search to return an array,
     # not an activerecord object. some room for improvement.
     @results = if params[:search].present?
-                 Patient.search(params[:search])
-                        .select(&:pledge_sent?)
-                        .sort_by(&:pledge_sent_at).reverse
+                 Patient.where(pledge_sent: true)
+                        .order_by(pledge_sent_at: :desc)
+                        .search(params[:search])
                else
                  pledged_patients
                end

--- a/test/controllers/accountants_controller_test.rb
+++ b/test/controllers/accountants_controller_test.rb
@@ -66,6 +66,25 @@ class AccountantsControllerTest < ActionDispatch::IntegrationTest
           assert_response :unauthorized
         end
       end
+
+      it 'should account for edge cases around empty times' do
+        create :patient, name: 'susan everyteen',
+                         appointment_date: 4.days.from_now,
+                         fund_pledge: 500,
+                         pledge_sent: true,
+                         pledge_sent_at: nil,
+                         clinic: create(:clinic)
+        create :patient, name: 'susan everyteen 2',
+                         appointment_date: 4.days.from_now,
+                         fund_pledge: 500,
+                         pledge_sent: true,
+                         pledge_sent_at: 4.days.from_now,
+                         clinic: create(:clinic)
+        user = create :user, role: :data_volunteer
+        sign_in user
+        post accountant_search_path, params: { search: 'susan' }, xhr: true
+        assert_response :success
+      end
     end
   end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We got a sentry error from the accountants panel - there's an edge case where data can get into such a state where `pledge_sent` is true but there's no `pledge_sent_at` value.

The accountants controller fails in that case because the `sort_by` is trying to compare nils with a real timezone. Mongoid does that a lot better, so we move it to an activerecord call instead.

This pull request makes the following changes:
* handle cases where pledge_sent_at is null for some reason
* add a test

no view change

It relates to the following issue #s: 
* Fixes #1970
