### PR TITLE
delete sessions older than 30 days in nightly_cleanup

### DIFF
--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -16,6 +16,9 @@ task nightly_cleanup: :environment do
   ArchivedPatient.archive_eligible_patients!
   puts "#{Time.now} -- archived patients for today"
 
+  MongoidStore::Session.where(:updated_at.lte => 30.days.ago).delete_all  
+  puts "#{Time.now} - removed old sessions"
+
   if Time.zone.now.monday?
     # Run these events weekly
     Clinic.update_all_coordinates


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I added to the nightly_cleanup to delete sessions older than 30 days.

This pull request makes the following changes:
* I've only changed nightly_cleanup.rake

It relates to the following issue #s: 
* Fixes #1975 

When testing the rake file, I get the following warning:
![image](https://user-images.githubusercontent.com/58662371/82287877-35210f00-996f-11ea-8b39-7d7dc4a0c9f9.png)
