### PR TITLE
Improve provisioning instructions

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,6 +41,10 @@
       "description": "domain you want emails to come from. Should be your fund's domain. e.g. dcabortionfund.org for DCAF",
       "value": ""
     },
+    "FUND_DOMAIN": {
+      "description": "Abortion fund's public site domain. Generally identical to fund mailer domain. e.g. dcabortionfund.org for DCAF",
+      "value": ""
+    },
     "DARIA_LINES": {
       "description": "Lines to divide calls into, separated by commas. If one line, just put Main",
       "value": "Main"
@@ -63,7 +67,7 @@
       "required": false
     },
     "SITE_URL": {
-      "description": "The app name you just selected plus .herokuapp.com . e.g. myfund.herokuapp.com",
+      "description": "The app name you just selected plus .herokuapp.com. e.g. daria-xaf.herokuapp.com",
       "value": ""
     },
     "SQREEN_TOKEN": {

--- a/app.json
+++ b/app.json
@@ -70,6 +70,11 @@
       "description": "The app name you just selected plus .herokuapp.com. e.g. daria-xaf.herokuapp.com",
       "value": ""
     },
+    "SQREEN_APP_NAME": {
+      "description": "daria-FUND, like in your site URL",
+      "value": "",
+      "required": false
+    },
     "SQREEN_TOKEN": {
       "description": "get it from Sqreen",
       "value": "",

--- a/docs/onboarding/SETTING_UP_A_NEW_INSTANCE.md
+++ b/docs/onboarding/SETTING_UP_A_NEW_INSTANCE.md
@@ -1,47 +1,46 @@
 # Setting up a new instance of DARIA
 
-These are detailed instructions in spinning up an instance in heroku on the DCAF pipeline. It assumes that you already have access set up and permissions on the following resources:
-
-* Heroku pipeline (for provisioning)
-* Google Cloud (for oauth and key)
-* Sentry (for keys)
-* Sqreen (for keys)
+These are detailed instructions in spinning up an instance in heroku on the DCAF pipeline. It assumes that you already have access set up and permissions on the resources we use.
 
 ## By the way
 
-If you're an abortion fund and NOT interested in worrying about servers, maintenance, and patching, DCAF already manages the infrastructure (what's referred to in this document as the `DCAF pipeline`) for several abortion funds. For your share of server costs (generally $25/month) our team will manage your instance, apply security patches, etc. Please reach out to us in slack if you're interested in skipping a lot of the tedious technical setup here.
+If you're an abortion fund and NOT interested in worrying about servers, maintenance, and patching, DCAF already manages the infrastructure (what's referred to in this document as the `DCAF pipeline`) for several abortion funds. For your share of server costs (generally $25/month) our team will manage your instance, apply security patches, etc. Please reach out to us in slack if you're interested in skipping a lot of the tedious technical setup here. If you are trying to use this, you'll likely need to make some on-the-fly adjustments as this guide assumes you have access to all the resources in here.
 
 ## Main steps
 
 ### Information gathering
 
-To provision an app, we'll need the following information. The DARIA team member requesting the provisioning should have all this information.
+To provision an app, we'll need the following information. The DARIA team member requesting the provisioning should provide all this information to you.
 
-* Short abbreviation of the fund (e.g. DCAF) - referred to as FUND
-* Name of the fund (e.g. DC Abortion Fund) - referred to as FUND_FULL
-* Phone number of the abortion fund (e.g. 202-000-1111) - referred to as FUND_PHONE
+* Short abbreviation of the fund (e.g. DCAF) - referred to as `FUND`
+* Name of the fund (e.g. DC Abortion Fund) - referred to as `FUND_FULL`
+* Phone number of the abortion fund (e.g. 202-000-1111) - referred to as `FUND_PHONE`
+* Website of the fund (e.g. dcabortionfund.org) - referred to as `FUND_DOMAIN`
 * Name and email of the fund admins (e.g. Susan Everyteen - susan@example.com) - we create initial admin accounts for these people
-* Website of the fund (e.g. dcabortionfund.org) - referred to as FUND_DOMAIN
 
 ### Gathering API tokens and secrets
 
-First, we generate some API tokens from services that DARIA uses.
+We also need to have some API tokens and such that we generate or dig up when we provision.
 
 * Generate Google OAuth configuration (for Login with Google):
-  * If you don't have one, set up a google project to administer this app (or choose an existing account you own - DCAF has one)
-  * Once logged in, navigate to https://console.developers.google.com/apis/dashboard and select your project
-  * Under "Credentials" follow prompts to "Create credentials" for "OAuth client ID"
-  * Configure your OAuth Consent screen:
-    * Make your application type public
-    * Add your app URL (`https://daria-FUND.herokuapp.com`) as the authorized domain
-    * Select "Web Application" when prompted to choose an application type
-    * Leave Authorized Javascript origins blank
-    * Set Authorized redirect URIs to https://daria-FUND.herokuapp.com/users/auth/google_oauth2/callback
-  * Generate a `GOOGLE_KEY` and a `GOOGLE_SECRET` - these values are `DARIA_GOOGLE_KEY` and `DARIA_GOOGLE_SECRET` respectively
-* Generate a Google API token (for the Clinic Finder):
-  * Enable the Geocoding API
-  * Create a Google API key, named `FUND Geocoding API Key`; restrict it to just the Geocoding API
-* Generate a [Sqreen](https://www.sqreen.io/) API token
+  * Go to our [GCP project](https://console.cloud.google.com/home/dashboard?project=dcaf-single-sign-on-production)
+  * On the left menu, `APIs & Services > Credentials > Create Credentials > OAuth Client ID` to create a new set of OAuth credentials
+  * Fill in the form as follows: Application type: Web Application, Name: FUND_FULL from above, Authorized Javascript origins: (leave blank), Authorized redirect URIs: https://daria-FUND.herokuapp.com/users/auth/google_oauth2/callback, then click Create
+  * Keep tabs on the generated the Client ID and Client secret; these are `DARIA_GOOGLE_KEY` and `DARIA_GOOGLE_SECRET`
+
+* Grab our Google API token:
+  * Go to our [GCP project](https://console.cloud.google.com/home/dashboard?project=dcaf-single-sign-on-production)
+  * On the left menu, `APIs & Services > Credentials`
+  * Copy the Key value of the `Google Geo API Key`; this is `GOOGLE_GEO_API_KEY`
+
+* Get the Sentry DSN key we use:
+  * Head to our [Sentry client keys](https://sentry.io/settings/dcaf-engineering/projects/daria/keys) and get the DSN value. This is `SENTRY_DSN`
+
+* Grab a Sqreen API token:
+  * Log in to [Sqreen](https://www.sqreen.io/)
+  * Near the top left, where it says `App Inventory`, click the dropdown and click `Connect a new application`
+  * Fill out as follows: Application name: daria-FUND, Language of the application: Ruby, Environment: production'. Click the `Show instructions` button
+  * Look for the value of `token` on the right side. `daria-FUND` is `SQREEN_APP_NAME` and the token is `SQREEN_TOKEN`
 
 ### Provision the instance in the heroku pipeline
 
@@ -94,8 +93,6 @@ When they do so, they should do the following to start:
 * Go to Admin > Clinic Management and enter info about clinics they work with
 * Go to Admin > Config Management and enter info about other funds they work with, insurance options they track, etc
 * Go to Admin > User Management and create other accounts.
-
-Please let us know if there's anything else to do on this front.
 ```
 
 ## All set!

--- a/docs/onboarding/SETTING_UP_A_NEW_INSTANCE.md
+++ b/docs/onboarding/SETTING_UP_A_NEW_INSTANCE.md
@@ -17,11 +17,11 @@ If you're an abortion fund and NOT interested in worrying about servers, mainten
 
 To provision an app, we'll need the following information. The DARIA team member requesting the provisioning should have all this information.
 
-* Name of the fund (e.g. DC Abortion Fund)
-* Short abbreviation of the fund (e.g. DCAF)
-* Phone number of the abortion fund (e.g. 202-000-1111)
+* Short abbreviation of the fund (e.g. DCAF) - referred to as FUND
+* Name of the fund (e.g. DC Abortion Fund) - referred to as FUND_FULL
+* Phone number of the abortion fund (e.g. 202-000-1111) - referred to as FUND_PHONE
 * Name and email of the fund admins (e.g. Susan Everyteen - susan@example.com) - we create initial admin accounts for these people
-* Website of the fund (e.g. dcabortionfund.org)
+* Website of the fund (e.g. dcabortionfund.org) - referred to as FUND_DOMAIN
 
 ### Gathering API tokens and secrets
 
@@ -41,28 +41,25 @@ First, we generate some API tokens from services that DARIA uses.
 * Generate a Google API token (for the Clinic Finder):
   * Enable the Geocoding API
   * Create a Google API key, named `FUND Geocoding API Key`; restrict it to just the Geocoding API
-* Optional but recommended: Generate a [Sqreen](https://www.sqreen.io/) API token -- this is a security service
+* Generate a [Sqreen](https://www.sqreen.io/) API token
 
-### Create a new heroku app
+### Provision the instance in the heroku pipeline
 
-[Click this here link to spin up a new app](https://heroku.com/deploy?template=https://github.com/DCAFEngineering/dcaf_case_management). This vastly simplifies new instance setup and automatically provisions the necessary Heroku add-ons for you:
+[Click this here link to spin up a new app](https://heroku.com/deploy?template=https://github.com/DCAFEngineering/dcaf_case_management). This vastly simplifies new instance setup and automatically provisions the necessary Heroku add-ons for you.
 
-* mLabs -- this is a mongodb data service (our database!)
-* Sendgrid -- this is used as the email service (our emailer!)
-* Logentries -- used for application logging
-* Scheduler -- used to run tasks on a cron schedule
+Fill in the form as follows (stuff in caps are variables you should have on hand):
 
-Follow the directions to fill out necessary environment variables and configuration for your DARIA instance. (Ask our slack channel if you have questions.) Clicking Deploy App will launch your DARIA instance! You now have an instance running, but there are still some followup tasks.
+* App name should be `daria-FUND`
+* App owner should be the `casemanager` team
+* Click `Add this app to a pipeline` and select `casemanager-pipeline`, then `production`
+* In the config vars section, fill in config variables based on what you have. Use defaults where applicable for fields like `CSP_VIOLATION_URI` and `DARIA_LINES`; the DARIA team member leading the onboarding will tell you if you need to change a default value. You should have the resour
 
-### If not within the DCAF pipeline
-
-- [ ] In Heroku, make sure someone other than you has access to the instance -- make sure you aren't the only member of your fund with Heroku panel access!
-- [ ] Confirm that you are using HTTPS with heroku ACM ([Automated Certificate Management](https://devcenter.heroku.com/articles/automated-certificate-management)). Note that this may require a paid heroku dyno. (For the love of god, do not enter real data into DARIA unless you have HTTPS set up.)
+Clicking Deploy App will launch the new DARIA instance! We should now have an instance running, but there are still some followup tasks to handle.
 
 ### Finish up service setup
 
-- [ ] Set up an uptime monitor (we recommend StatusCake!)
-- [ ] Go to Heroku, click on `Scheduler`, and add the nightly cleanup job: `$ rake nightly cleanup`, dyno size hobby, frequency daily, 08:00 UTC
+* Set up an uptime monitor for the new domain. (We generally use StatusCake for right now but will switch to a team monitor soon; use an existing monitor as a guide to configure.)
+* Go to the new app in Heroku, click on `Scheduler`, and add the nightly cleanup job: `$ rake nightly_cleanup`, dyno size hobby, frequency daily, 08:00 UTC
 
 ### Smoke test to confirm everything is working right 
 

--- a/docs/onboarding/SETTING_UP_A_NEW_INSTANCE.md
+++ b/docs/onboarding/SETTING_UP_A_NEW_INSTANCE.md
@@ -1,14 +1,29 @@
 # Setting up a new instance of DARIA
 
-These are detailed instructions in spinning up an instance in heroku. These assume some familiarity with the ideas and concepts and don't go into much detail, such as where to click, the mechanics involved, etc. You don't need to do this for routine development.
+These are detailed instructions in spinning up an instance in heroku on the DCAF pipeline. It assumes that you already have access set up and permissions on the following resources:
+
+* Heroku pipeline (for provisioning)
+* Google Cloud (for oauth and key)
+* Sentry (for keys)
+* Sqreen (for keys)
 
 ## By the way
 
-If you're an abortion fund and NOT interested in worrying about servers, maintenance, and patching, DCAF already manages the infrastructure (what's referred to in this document as the `DCAF pipeline`) for several abortion funds. For your share of server costs they will manage your instance, apply security patches, etc. Please reach out to us in slack if you're interested in skipping a lot of the tedious technical setup here.
+If you're an abortion fund and NOT interested in worrying about servers, maintenance, and patching, DCAF already manages the infrastructure (what's referred to in this document as the `DCAF pipeline`) for several abortion funds. For your share of server costs (generally $25/month) our team will manage your instance, apply security patches, etc. Please reach out to us in slack if you're interested in skipping a lot of the tedious technical setup here.
 
 ## Main steps
 
-### Preparation and gathering API tokens
+### Information gathering
+
+To provision an app, we'll need the following information. The DARIA team member requesting the provisioning should have all this information.
+
+* Name of the fund (e.g. DC Abortion Fund)
+* Short abbreviation of the fund (e.g. DCAF)
+* Phone number of the abortion fund (e.g. 202-000-1111)
+* Name and email of the fund admins (e.g. Susan Everyteen - susan@example.com) - we create initial admin accounts for these people
+* Website of the fund (e.g. dcabortionfund.org)
+
+### Gathering API tokens and secrets
 
 First, we generate some API tokens from services that DARIA uses.
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Too much of the new instance provisioning depends on what's in my head or having access to everything I do, so we're rewiring.

As part of this I'm removing the instructions for independent, non-DCAF pipeline setup. That's something we've been discouraging for awhile.

@xmunoz and co will take these for a spin this week, but I'll merge for now and if any changes are required they can pull request against that?

This pull request makes the following changes:
* bump setup instructions to assume much more minimal context
* bump app.json

It relates to the following issue #s: 
* Fixes #1982 
