### PR TITLE
add instructions so we can start making writing the notification emails easier

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -14,6 +14,8 @@ It relates to the following issue #s:
 * Bumps #Y
 
 For reviewer:
-* Tag this PR `feature` if it contains a feature, fix, or similar; adjust the title to explain what it does for the notification email to the listserv.
-* Tag this PR `dependencies` if it contains library upgrades or similar
+* Adjust the title to explain what it does for the notification email to the listserv.
+* Tag this PR:
+  * `feature` if it contains a feature, fix, or similar; 
+  * `dependencies` if it contains library upgrades or similar
 * If it contains neither, no need to tag this PR

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -16,6 +16,6 @@ It relates to the following issue #s:
 For reviewer:
 * Adjust the title to explain what it does for the notification email to the listserv.
 * Tag this PR:
-  * `feature` if it contains a feature, fix, or similar; 
-  * `dependencies` if it contains library upgrades or similar
-* If it contains neither, no need to tag this PR
+  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
+  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
+* If it contains neither, no need to tag this PR.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -12,3 +12,8 @@ This pull request makes the following changes:
 It relates to the following issue #s: 
 * Fixes #X
 * Bumps #Y
+
+For reviewer:
+* Tag this PR `feature` if it contains a feature, fix, or similar; adjust the title to explain what it does for the notification email to the listserv.
+* Tag this PR `dependencies` if it contains library upgrades or similar
+* If it contains neither, no need to tag this PR

--- a/docs/administering/NOTIFYING_LISTSERV.md
+++ b/docs/administering/NOTIFYING_LISTSERV.md
@@ -1,0 +1,37 @@
+# Notifying the listserv of updates
+
+We have a google group set up to let funds know about DARIA updates and other important matters. Generally we email them as a courtesy when deploying updates, so they're aware of new features, security patches, etc. This is a guide to assembling the notification email.
+
+## You can copy this part
+
+> Hi, we're deploying the following updates to DARIA shortly:
+
+### And then we get the bullets of specific updates
+
+* Go to the Heroku dashboard to figure out when the last deploy to production was
+* Go to [the list of merged PRs](https://github.com/DCAFEngineering/dcaf_case_management/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc) to see what PRs have been merged since then. We'll include them as follows:
+  * For PRs tagged `feature`, include the title of the PR as a bullet
+  * If there are any PRs tagged `dependencies`, include one bullet as follows: 'Routine maintenance, library patches, etc.'
+  * You do not need to include PRs that are not tagged
+
+#### Example
+
+Assuming these PRs tagged `feature` have been merged since the last deploy:
+
+* Fix bug around accountants search
+* Add ability to configure clinics list
+
+And these PRs tagged `dependencies` have been merged since the last deploy:
+
+* Upgrade rails to 6.0.3
+* Fight with JQuery to squash a vulnerability
+
+You would send the following email to the listserv when you deployed:
+
+```
+Hi, we're deploying the following updates to DARIA shortly:
+
+* Fix bug around accountants search
+* Add ability to configure clinics list
+* Routine maintenance, library patches, etc.
+```


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Since people sending the notification emails, doing deploys, etc will be fairly low context pretty soon, let's write up a guide. What I'm thinking is in the PR. I'd like to get buy in on this from @lomky and @harumhelmy .

This pull request makes the following changes:
* Add doc providing guidance on how to write the email
* Bump pull request template to remind reviewer to tag and retitle pull request if necessary
 
no views

no issues