### PR TITLE
State fields are now selectable dropdowns instead of text strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'kaminari', '~> 1.2'
 gem 'render_async', '~> 2.1' # load slow partials asynchronously
 gem 'prawn' # pledge pdf generation
 gem 'geokit' # clinic_finder service lat-lng
+gem 'state_geo_tools' # state list 
 
 # Stuff that we're targeting removal of
 gem 'figaro' # we handle secrets differently now

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,6 +384,7 @@ GEM
     sqreen (1.18.6)
       libsqreen (~> 0.3.0.0)
       sq_mini_racer (~> 0.2.4.sqreen2)
+    state_geo_tools (1.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
@@ -478,6 +479,7 @@ DEPENDENCIES
   shoulda-context
   simplecov
   sqreen
+  state_geo_tools
   timecop
   tzinfo-data
   webdrivers

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -116,7 +116,8 @@ module PatientsHelper
   def pledge_limit_help_text_options
     Config.find_or_create_by(config_key: 'pledge_limit_help_text').options
   end
-  def state_options
-    StateGeoTools.state_codes.map { |code| [code,code] }.unshift [nil, nil]
+  def state_options(current_state)
+    StateGeoTools.state_codes.map{ |code| [code,code] }.unshift( [nil, nil] )
+      .push( [current_state,current_state] ).uniq
   end
 end

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -1,4 +1,5 @@
 # Functions primarily related to populating selects on patient edit view.
+require 'state_geo_tools'
 module PatientsHelper
   def weeks_options
     (1..30).map { |i| [t('patient.helper.week', count: i), i] }.unshift [nil, nil]
@@ -114,5 +115,8 @@ module PatientsHelper
 
   def pledge_limit_help_text_options
     Config.find_or_create_by(config_key: 'pledge_limit_help_text').options
+  end
+  def state_options
+    StateGeoTools.state_codes.map { |code| [code,code] }.unshift [nil, nil]
   end
 end

--- a/app/views/clinics/_clinic_form.html.erb
+++ b/app/views/clinics/_clinic_form.html.erb
@@ -4,7 +4,8 @@
       <%= f.text_field :name, autocomplete: 'off' %>
       <%= f.text_field :street_address, autocomplete: 'off' %>
       <%= f.text_field :city, autocomplete: 'off' %>
-      <%= f.text_field :state, autocomplete: 'off' %>
+      <%= f.select :state, options_for_select(state_options,
+                                        state_options), autocomplete: 'off' %>
       <%= f.text_field :zip, autocomplete: 'off', help: t('clinics.form.zip_help') %>
       <%= f.text_field :phone,
                        autocomplete: 'off',

--- a/app/views/clinics/_clinic_form.html.erb
+++ b/app/views/clinics/_clinic_form.html.erb
@@ -5,7 +5,7 @@
       <%= f.text_field :street_address, autocomplete: 'off' %>
       <%= f.text_field :city, autocomplete: 'off' %>
       <%= f.select :state, options_for_select(state_options,
-                                        state_options), autocomplete: 'off' %>
+                                        clinic.state), autocomplete: 'off' %>
       <%= f.text_field :zip, autocomplete: 'off', help: t('clinics.form.zip_help') %>
       <%= f.text_field :phone,
                        autocomplete: 'off',

--- a/app/views/clinics/_clinic_form.html.erb
+++ b/app/views/clinics/_clinic_form.html.erb
@@ -4,8 +4,7 @@
       <%= f.text_field :name, autocomplete: 'off' %>
       <%= f.text_field :street_address, autocomplete: 'off' %>
       <%= f.text_field :city, autocomplete: 'off' %>
-      <%= f.select :state, options_for_select(state_options,
-                                        clinic.state), autocomplete: 'off' %>
+      <%= f.select :state, options_for_select(state_options(clinic.state), clinic.state), autocomplete: 'off' %>
       <%= f.text_field :zip, autocomplete: 'off', help: t('clinics.form.zip_help') %>
       <%= f.text_field :phone,
                        autocomplete: 'off',

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -36,7 +36,8 @@
             <%= f.text_field :city, autocomplete: 'off' %>
           </div>
           <div class="col-4">
-            <%= f.text_field :state, autocomplete: 'off' %>
+            <%= f.select :state, options_for_select(state_options,
+                                        state_options), autocomplete: 'off' %>
           </div>
         </div>
 

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -36,7 +36,7 @@
             <%= f.text_field :city, autocomplete: 'off' %>
           </div>
           <div class="col-4">
-            <%= f.select :state, options_for_select(state_options,
+            <%= f.select :state, options_for_select(state_options(patient.state),
                                         patient.state), autocomplete: 'off' %>
           </div>
         </div>

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -37,7 +37,7 @@
           </div>
           <div class="col-4">
             <%= f.select :state, options_for_select(state_options,
-                                        state_options), autocomplete: 'off' %>
+                                        patient.state), autocomplete: 'off' %>
           </div>
         </div>
 

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -44,7 +44,7 @@
   </div>
 
   <%= f.text_field :city, autocomplete: 'off' %>
-  <%= f.select :state, options_for_select(state_options), autocomplete: 'off' %>
+  <%= f.select :state, options_for_select(state_options(nil)), autocomplete: 'off' %>
   <%= f.text_field :county, autocomplete: 'off' %>
 
    <%= f.select :language, options_for_select(language_options), autocomplete: 'off' %>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -44,8 +44,7 @@
   </div>
 
   <%= f.text_field :city, autocomplete: 'off' %>
-  <%= f.select :state, options_for_select(state_options,
-                                        state_options), autocomplete: 'off' %>
+  <%= f.select :state, options_for_select(state_options), autocomplete: 'off' %>
   <%= f.text_field :county, autocomplete: 'off' %>
 
    <%= f.select :language, options_for_select(language_options), autocomplete: 'off' %>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -44,7 +44,8 @@
   </div>
 
   <%= f.text_field :city, autocomplete: 'off' %>
-  <%= f.text_field :state, autocomplete: 'off' %>
+  <%= f.select :state, options_for_select(state_options,
+                                        state_options), autocomplete: 'off' %>
   <%= f.text_field :county, autocomplete: 'off' %>
 
    <%= f.select :language, options_for_select(language_options), autocomplete: 'off' %>

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -91,4 +91,20 @@ class PatientsHelperTest < ActionView::TestCase
       end
     end
   end
+
+  describe 'state options' do
+    it 'should return all states and current value' do
+      expected_state_array = [[nil, nil], ["AL", "AL"], ["AK", "AK"], ["AZ", "AZ"], ["AR", "AR"],
+        ["CA", "CA"], ["CO", "CO"], ["CT", "CT"], ["DE", "DE"], ["DC", "DC"], ["FL", "FL"],
+        ["GA", "GA"], ["HI", "HI"], ["ID", "ID"], ["IL", "IL"], ["IN", "IN"], ["IA", "IA"],
+        ["KS", "KS"], ["KY", "KY"], ["LA", "LA"], ["ME", "ME"], ["MD", "MD"], ["MA", "MA"],
+        ["MI", "MI"], ["MN", "MN"], ["MS", "MS"], ["MO", "MO"], ["MT", "MT"], ["NE", "NE"],
+        ["NV", "NV"], ["NH", "NH"], ["NJ", "NJ"], ["NM", "NM"], ["NY", "NY"], ["NC", "NC"],
+        ["ND", "ND"], ["OH", "OH"], ["OK", "OK"], ["OR", "OR"], ["PA", "PA"], ["RI", "RI"],
+        ["SC", "SC"], ["SD", "SD"], ["TN", "TN"], ["TX", "TX"], ["UT", "UT"], ["VT", "VT"],
+        ["VA", "VA"], ["WA", "WA"], ["WV", "WV"], ["WI", "WI"], ["WY", "WY"], ["virginia","virginia"]]
+
+      assert_same_elements state_options("virginia"), expected_state_array
+    end
+  end
 end

--- a/test/system/clinic_management_test.rb
+++ b/test/system/clinic_management_test.rb
@@ -94,7 +94,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
     fill_in 'Name', with: new_clinic_name
     fill_in 'Street address', with: '123 Fake Street'
     fill_in 'City', with: 'Yolo'
-    fill_in 'State', with: 'TX'
+    select 'TX', from: 'clinic_state'
     fill_in 'ZIP', with: '12345'
     fill_in 'Phone', with: '281-330-8004'
     fill_in 'Fax', with: '222-333-4444'
@@ -111,7 +111,7 @@ class ClinicManagementTest < ApplicationSystemTestCase
     assert has_field? 'Name', with: 'Games Done Quick Throw a Benefit for DCAF'
     assert has_field? 'Street address', with: '123 Fake Street'
     assert has_field? 'City', with: 'Yolo'
-    assert has_field? 'State', with: 'TX'
+    assert_equal 'TX', find('#clinic_state').value
     assert has_field? 'ZIP', with: '12345'
     assert has_field? 'Phone', with: '281-330-8004'
     assert has_field? 'Fax', with: '222-333-4444'

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -25,7 +25,7 @@ class DataEntryTest < ApplicationSystemTestCase
       select '1 week', from: 'patient_last_menstrual_period_weeks'
       select '2 days', from: 'patient_last_menstrual_period_days'
       fill_in 'City', with: 'Washington'
-      fill_in 'State', with: 'DC'
+      select 'DC', from: 'patient_state'
       fill_in 'County', with: 'Wash'
       fill_in 'DCAF pledge', with: '100'
       fill_in 'Age', with: '30'
@@ -75,7 +75,7 @@ class DataEntryTest < ApplicationSystemTestCase
         assert has_field? 'Age', with: '30'
         assert_equal 'Other', find('#patient_race_ethnicity').value
         assert has_field? 'City', with: 'Washington'
-        assert has_field? 'State', with: 'DC'
+        assert_equal 'DC', find('#patient_state').value
         assert has_field? 'County', with: 'Wash'
         assert_equal 'English', find('#patient_language').text
         assert_equal 'no', find('#patient_voicemail_preference').value

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -181,7 +181,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
       fill_in 'City', with: 'Washington'
       wait_for_ajax
 
-      fill_in 'State', with: 'DC'
+      select 'DC', from: 'patient_state'
       fill_in 'County', with: 'Wash'
       select 'Voicemail OK', from: 'patient_voicemail_preference'
       check 'Textable?'
@@ -215,7 +215,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'Age', with: '24'
         assert_equal 'White/Caucasian', find('#patient_race_ethnicity').value
         assert has_field? 'City', with: 'Washington'
-        assert has_field? 'State', with: 'DC'
+        assert_equal 'DC', find('#patient_state').value
         assert has_field? 'County', with: 'Wash'
         assert_equal 'yes', find('#patient_voicemail_preference').value
         assert has_checked_field?('Textable?')


### PR DESCRIPTION
Cloning over the fork PR #2005 to see if I can get the CircleCI to run on the main fork :angry: 

---

I rule and have completed some work on Case Manager that's ready for review!

I wasn't sure how to test the data_entry edits (but the clinic and patient views work! see screenshots below) and I also couldn't get the tests to work, but I wrote some code based on what I saw in the files already, so hopefully it works? I haven't tested in Ruby before.

This pull request makes the following changes:
* I switched the state text field to a dropdown menu of state codes
* Switched tests to reflect the same select options

(If there are changes to the views, please include a screenshot so we know what to look for!)
![image](https://user-images.githubusercontent.com/58662371/85251965-b5340c00-b428-11ea-9f02-81e55048f1a4.png)
![image](https://user-images.githubusercontent.com/58662371/85252028-dd236f80-b428-11ea-87d3-a6541019c77c.png)

It relates to the following issue #s: 
* Fixes #1733 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
