### PR TITLE
Editable dates on data entry to allow for backdating

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -122,7 +122,8 @@ class PatientsController < ApplicationController
 
   ABORTION_INFORMATION_PARAMS = [
     :clinic_id, :resolved_without_fund, :referred_to_clinic, :completed_ultrasound,
-    :procedure_cost, :patient_contribution, :naf_pledge, :fund_pledge
+    :procedure_cost, :patient_contribution, :naf_pledge, :fund_pledge,
+    :fund_pledged_at, :pledge_sent_at
   ].freeze
 
   FULFILLMENT_PARAMS = [

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -293,7 +293,7 @@ class Patient
   end
 
   def update_fund_pledged_at
-    if fund_pledge_changed? && fund_pledge
+    if fund_pledge_changed? && fund_pledge && !fund_pledged_at
       self.fund_pledged_at = Time.zone.now
     elsif fund_pledge.blank?
       self.fund_pledged_at = nil

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -55,10 +55,20 @@
     <%#= notes.text_area :full_text, size: '20x5', placeholder: 'Enter notes here' %>
   <%# end %>
 
-  <%= f.number_field :fund_pledge,
-                     label: t('patient.abortion_information.cost_section.fund_pledge',
-                     fund: "#{FUND}"),
-                     autocomplete: 'off' %>
+
+  <div class="row">
+    <div class="col">
+      <%= f.number_field :fund_pledge,
+                         label: t('patient.abortion_information.cost_section.fund_pledge',
+                         fund: "#{FUND}"),
+                         autocomplete: 'off' %>
+    </div>
+    <div class="col">
+      <%= f.date_field :fund_pledged_at,
+                       label: t('patient.fund_pledged_at'),
+                       autocomplete: 'off' %>
+    </div>
+  </div>
 
   <%= f.number_field :age, autocomplete: 'off' %>
   <%= f.select :race_ethnicity,
@@ -111,7 +121,16 @@
                      autocomplete: 'off',
                      prepend: '$' %>
 
-  <%= f.check_box :pledge_sent, label: t('patient.status.key.pledge_sent') %>
+  <div class="row">
+    <div class="col">
+      <%= f.check_box :pledge_sent, label: t('patient.status.key.pledge_sent') %>
+    </div>
+    <div class="col">
+      <%= f.date_field :pledge_sent_at,
+                       label: t('patient.pledge_fulfillment.confirmation.pledge_sent_at'),
+                       autocomplete: 'off' %>
+    </div>
+  </div>
 
   <%= f.check_box :referred_to_clinic, label: t('patient.abortion_information.clinic_section.referred_to_clinic') %>
   <%= f.check_box :completed_ultrasound, label: t('patient.abortion_information.clinic_section.ultrasound_completed') %>

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -65,7 +65,7 @@
     </div>
     <div class="col">
       <%= f.date_field :fund_pledged_at,
-                       label: t('patient.fund_pledged_at'),
+                       label: t('mongoid.attributes.patient.fund_pledged_at'),
                        autocomplete: 'off' %>
     </div>
   </div>

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -45,7 +45,6 @@ class DataEntryTest < ApplicationSystemTestCase
       select 'Do not leave a voicemail', from: 'patient_voicemail_preference'
       check 'patient_referred_to_clinic'
       check 'patient_completed_ultrasound'
-      check 'patient_resolved_without_fund'
       check 'Pledge Sent'
       check 'fetal_patient_special_circumstances'
       check 'home_patient_special_circumstances'
@@ -101,7 +100,69 @@ class DataEntryTest < ApplicationSystemTestCase
         assert has_field? 'DCAF pledge', with: '100'
         assert has_checked_field? 'Referred to clinic'
         assert has_checked_field? 'Ultrasound completed?'
-        assert has_checked_field? 'Resolved without assistance from DCAF'
+      end
+    end
+
+    it 'should show new patients pledge in the budget bar' do
+      visit root_path
+
+      within :css, '#budget_bar' do
+        assert has_text? "$100 sent (1 patients)"
+        assert has_text? "$0 pledged (0 patients)"
+        refute has_text? "Susie Everyteen - appt on "
+      end
+    end
+  end
+
+  describe 'entering a new backdated patient' do
+    before do
+      # fill out the form
+      select 'DC', from: 'patient_line'
+      fill_in 'Initial Call Date', with: 90.days.ago.strftime('%m/%d/%Y')
+      fill_in 'Name', with: 'Susie Backdated'
+      fill_in 'Phone', with: '111-222-3345'
+      fill_in 'Other contact name', with: 'Billy Everyteen'
+      fill_in 'Other phone', with: '111-555-8888'
+      fill_in 'Relationship to other contact', with: 'Friend'
+      select '1 week', from: 'patient_last_menstrual_period_weeks'
+      select '2 days', from: 'patient_last_menstrual_period_days'
+      fill_in 'City', with: 'Washington'
+      select 'DC', from: 'patient_state'
+      fill_in 'County', with: 'Wash'
+      fill_in 'DCAF pledge', with: '99'
+      fill_in 'Fund pledged at', with: 80.days.ago.strftime('%m/%d/%Y')
+      fill_in 'Age', with: '30'
+      select 'Other', from: 'patient_race_ethnicity'
+      select @clinic.name, from: 'patient_clinic_id'
+      fill_in 'Appointment date', with: 70.days.ago.strftime('%m/%d/%Y')
+      select 'DC Medicaid', from: 'patient_insurance'
+      select '1', from: 'patient_household_size_adults'
+      select '2', from: 'patient_household_size_children'
+      select 'Student', from: 'patient_employment_status'
+      select 'Under $9,999 ($192/wk - $833/mo)', from: 'patient_income'
+      select 'Clinic', from: 'patient_referred_by'
+      fill_in 'Procedure Cost', with: '200'
+      fill_in 'Patient contribution', with: '51'
+      fill_in 'National Abortion Federation pledge', with: '50'
+      select 'English', from: 'patient_language'
+      select 'Do not leave a voicemail', from: 'patient_voicemail_preference'
+      check 'patient_referred_to_clinic'
+      check 'patient_completed_ultrasound'
+      check 'Pledge Sent'
+      fill_in 'Pledge sent at:', with: 75.days.ago.strftime('%m/%d/%Y')
+      check 'fetal_patient_special_circumstances'
+      check 'home_patient_special_circumstances'
+      click_button 'Create Patient'
+      has_text? 'Patient information' # wait for redirect
+    end
+
+    it 'should not show backdated new patient in the budget bar' do
+      visit root_path
+
+      within :css, '#budget_bar' do
+        assert has_text? "$0 sent (0 patients)"
+        assert has_text? "$0 pledged (0 patients)"
+        refute has_text? "$99 sent"
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds the option to manually set the dates of the fund pledge and fulfillment when using the `/data_entry` point, allowing for pledges to be properly back dated when entering a back log, and stopping them from showing up on the budget bar!

This pull request makes the following changes:
* allow params `fund_pledged_at` and `pledge_sent_at` on the patients controller
* update the automatic behavior that sets those fields to gracefully accept a param and otherwise fallback to previous behavior
* Add fields to `/data_entry`

<details><summary>Sandbox testing</summary>
Manual Testing: confirm the behavior when creating on `data_entry` once in sandbox

works | fund_pledged_at | pledge_sent_at | budget bar
-- | -- | -- | --
not tested | not set | not set | shows this pledge
not tested | not set | set to yesterday | shows this pledge
not tested | set to yesterday | set to last month | shows this pledge
not tested | set to last month | not set | shows this pledge
not tested | set to last month | set to last month | **does not show this pledge**

<details><summary> sandbox testing note: required fields</summary>
- initial call date (before appt date & testing dates)
- name
- phone
- DCAF pledge
- clinic name
- appointment date 
- proceedure cost
- patient contribution
- pledge sent
</details>
</details>

**UI changes**

section | before | after
 -- | -- | --
data entry - pledge  | ![image](https://user-images.githubusercontent.com/6129479/87233281-fa968a00-c393-11ea-8847-c550c39a7601.png) | ![image](https://user-images.githubusercontent.com/6129479/86987603-7611f480-c164-11ea-874d-c584136041fb.png)
data entry - fulfilled | ![image](https://user-images.githubusercontent.com/6129479/87233296-139f3b00-c394-11ea-90fa-732df41731af.png) | ![image](https://user-images.githubusercontent.com/6129479/86987625-7c07d580-c164-11ea-9709-0be80e65b3b7.png)

It relates to the following issue #s: 
* Fixes #2010 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
