### PR TITLE
Fix initial call date validation bug 1991

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -265,7 +265,7 @@ class Patient
   private
 
   def confirm_appointment_after_initial_call
-    if appointment_date.present? && initial_call_date > appointment_date
+    if appointment_date.present? && initial_call_date&.send(:>, appointment_date)
       errors.add(:appointment_date, 'must be after date of initial call')
     end
   end

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -247,12 +247,22 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
       @test_patient[:primary_phone] = ''
       assert_no_difference 'Patient.count' do
         post data_entry_create_path, params: { patient: @test_patient }
+        assert_response :success
       end
     end
 
     it 'should create an associated fulfillment object' do
       post data_entry_create_path, params: { patient: @test_patient }
       assert_not_nil Patient.find_by(name: 'Test Patient').fulfillment
+    end
+
+    it 'should fail to save if initial call date is nil' do
+      @test_patient[:initial_call_date] = nil
+      @test_patient[:appointment_date] = Date.tomorrow
+      assert_no_difference 'Patient.count' do
+        post data_entry_create_path, params: { patient: @test_patient }
+        assert_response :success
+      end
     end
   end
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -82,11 +82,17 @@ class PatientTest < ActiveSupport::TestCase
     end
 
     it 'should require appointment_date to be after initial_call_date' do
-      @patient.initial_call_date = '2016-06-01'
+      # when initial call date is nil
       @patient.appointment_date = '2016-05-01'
+      @patient.initial_call_date = nil
       refute @patient.valid?
+      # when initial call date is after appointment date
+      @patient.initial_call_date = '2016-06-01'
+      refute @patient.valid?
+      # when appointment date is nil
       @patient.appointment_date = nil
       assert @patient.valid?
+      # when appointment date is after initial call date
       @patient.appointment_date = '2016-07-01'
       assert @patient.valid?
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Prevents `Patient#confirm_appointment_after_initial_call` from erroring out when `initial_call_date` is `nil` but `appointment_date` is present.

This pull request makes the following changes:
* handles when `initial_call_date` is `nil`
* adds tests to patient controller and model

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/5728859/87808233-58f5b980-c827-11ea-8d2b-89cf9579afa1.png">
^^ note error message regarding initial_call_date while appointment_date is present

It relates to the following issue #s: 
* Fixes https://github.com/DCAFEngineering/dcaf_case_management/issues/1991

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
