### PR TITLE
Remove refs to dockerhub from build steps and docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
           keys:
             - dcaf_case_management-{{ epoch }}
       - run: git push https://heroku:$HEROKU_API_KEY@git.heroku.com/dcaf-cmapp-staging.git master
-      - run: docker build -t colinxfleming/dcaf_case_management -f .docker/Dockerfile . && docker login -u "$DOCKERLOGIN" -p "$DOCKERPASS" && docker push colinxfleming/dcaf_case_management
 
 # general:
   # artifacts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       context: .
       dockerfile: .docker/Dockerfile
     command: ["./scripts/start_rails.sh"]
-    image: colinxfleming/dcaf_case_management:latest
     volumes:
       - .:/usr/src/app
     ports:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Once upon a time we would push to a docker remote every time we'd rebuild. We did this because in the very beginning this was faster than docker building every time! But then we (read: @DarthHater ) made us better at docker, and nobody's really setting up or refreshing this codebase with `docker pull` anymore. So let's take out this (very long) buildstep and save ourselves some time.

This pull request makes the following changes:
* remove docker remote refs from circleci build steps and from docker-compose

no view changes

no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
