### PR TITLE
Fix the build by remove the push to docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
           keys:
             - dcaf_case_management-{{ epoch }}
       - run: git push https://heroku:$HEROKU_API_KEY@git.heroku.com/dcaf-cmapp-staging.git master
-      - run: docker build -t colinxfleming/dcaf_case_management -f .docker/Dockerfile . && docker login -u "$DOCKERLOGIN" -p "$DOCKERPASS" && docker push colinxfleming/dcaf_case_management
 
 # general:
   # artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,6 @@ jobs:
       - image: circleci/ruby:2.6.6-node-browsers
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - restore_cache:
-          keys:
-            - dcaf_case_management-{{ epoch }}
       - run: git push https://heroku:$HEROKU_API_KEY@git.heroku.com/dcaf-cmapp-staging.git master
 
 # general:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* remove the deploy step that pushed docker

It relates to the following issue #s: 
* Fixes the build

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
