### PR TITLE
Enable coverage on circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       # - run: yarn audit
       - store_artifacts:
           path: /home/circleci/abortioneering/tmp/capybara/
+          path: coverage
       - store_test_results:
           path: test-results/
   predeploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       # - run: yarn audit
       - store_artifacts:
           path: /home/circleci/abortioneering/tmp/capybara/
+      - store_artifacts:
           path: coverage
       - store_test_results:
           path: test-results/


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Seeing if we can't get coverage up and running

This pull request makes the following changes:
* add coverage to the circle config
* 

It relates to the following issue #s: 
* Fixes #2024 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
