### PR TITLE
Changes mongodb logging from debug to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,6 +86,7 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
+  Mongo::Logger.logger.level = ::Logger::INFO
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Updates the mongodb logging level in prod from debug to info

Before:
```
[DEBUG] MONGODB | db:27017 req:1348 conn:1:2 sconn:3 | admin.endSessions | STARTED | {"endSessions"=>[{"id"=><BSON::Binary:0x47016580353280 type=uuid data=0xc707aeb153aa4491...>}], "$db"=>"admin"}
[DEBUG] MONGODB | db:27017 req:1348 | admin.endSessions | SUCCEEDED | 0.000s
[INFO ] Raven 3.0.0 configured not to capture errors: DSN not set
```
After:
```
[INFO ] Raven 3.0.0 configured not to capture errors: DSN not set
[INFO ] Raven 3.0.0 configured not to capture errors: DSN not set
```

It relates to the following issue #s: 
* Fixes #2032 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
