### PR TITLE
Remove misbehaving line ending config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-#Set default behavior to use Unix line endings so Docker on Windows doesn't fail
-* text eol=lf


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Specifying line ending `lf` caused unix systems to sporadically throw a fit and declare a bunch
of design docs to be changed and needed to be committed. Looks like we will need to do a bit more work to make Docker for Windows and Unix play nicely together.

This pull request makes the following changes:
* Removes misbehaving line ending config

It relates to the following issue #s: 
* Reverts #1907 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
