### PR TITLE
add border color to danger button

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -51,6 +51,7 @@ a:hover, a:active, a:visited, a:focus {
 }
 .btn-danger {
   background-color: #A42823 !important;
+  border-color: #A42823 !important;
 }
 
 /* NAVBAR */


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)
I added the border color from @lomky 's suggestion in #2051 . 

Also looked into "No patients found" color contrast and looks like the text isn't isn't #777777 anymore. Not sure how, but now it is #212529:
![image](https://user-images.githubusercontent.com/58662371/92861277-4d59e580-f3c7-11ea-85d0-c20b68ec37b2.png)


This pull request makes the following changes:
* Add border color over-ride

(If there are changes to the views, please include a screenshot so we know what to look for!)
new and improved button border!
![image](https://user-images.githubusercontent.com/58662371/92861620-b80b2100-f3c7-11ea-858a-b252b8e70244.png)
![image](https://user-images.githubusercontent.com/58662371/92348458-2aff5980-f0a1-11ea-9d8e-d1adec82722c.png)


It relates to the following issue #s: 
* Completes #1704 (hopefully)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
