### PR TITLE
Creates Pronoun Field for Patients

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -109,7 +109,7 @@ class PatientsController < ApplicationController
 
   PATIENT_DASHBOARD_PARAMS = [
     :name, :last_menstrual_period_days, :last_menstrual_period_weeks,
-    :appointment_date, :primary_phone
+    :appointment_date, :primary_phone, :pronouns
   ].freeze
 
   PATIENT_INFORMATION_PARAMS = [

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -64,6 +64,7 @@ class Patient
   enumerize :line, in: LINES, default: LINES[0] # See config/initializers/env_vars.rb
 
   field :language, type: String
+  field :pronouns, type: String
   field :initial_call_date, type: Date
   field :urgent_flag, type: Boolean
   field :last_menstrual_period_weeks, type: Integer

--- a/app/views/patients/_patient_dashboard.html.erb
+++ b/app/views/patients/_patient_dashboard.html.erb
@@ -45,6 +45,12 @@
       </div>
 
       <div class="col">
+        <%= f.text_field :pronouns,
+                         value: patient.pronouns,
+                         autocomplete: 'off' %>
+      </div>
+
+      <div class="col mt-6">
         <p><strong><%= t 'patient.shared.status' %></strong> <span id='patient_status'><%= patient.status %></span> <%= tooltip_shell status_help_text(patient) %></p>
       </div>
 

--- a/app/views/patients/data_entry.html.erb
+++ b/app/views/patients/data_entry.html.erb
@@ -18,6 +18,9 @@
                    label: t('common.phone'),
                    autocomplete: 'off' %>
 
+  <%= f.text_field :pronouns,
+                   autocomplete: 'off' %>
+
   <%= f.text_field :other_contact,
                    label: t('patient.information.other_contact.name'),
                    autocomplete: 'off' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,7 +221,6 @@ en:
         initial_call_date: Initial call date
         insurance: Insurance
         language: Language
-        pronouns: Pronouns
         last_menstrual_period_days: Last menstrual period days
         last_menstrual_period_weeks: Last menstrual period weeks
         line: Line
@@ -236,6 +235,7 @@ en:
         pledge_sent_at: Pledge sent at
         primary_phone: Primary phone
         procedure_cost: Procedure cost
+        pronouns: Pronouns
         race_ethnicity: Race / Ethnicity
         referred_by: Referred by
         referred_to_clinic: Referred to clinic

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,7 @@ en:
         initial_call_date: Initial call date
         insurance: Insurance
         language: Language
+        pronouns: Pronouns
         last_menstrual_period_days: Last menstrual period days
         last_menstrual_period_weeks: Last menstrual period weeks
         line: Line

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -221,6 +221,7 @@ es:
         initial_call_date: Fecha de llamada inicial
         insurance: Seguro médico
         language: Idioma
+        pronouns: Pronombres
         last_menstrual_period_days: Últimos días del período menstrual
         last_menstrual_period_weeks: Últimas semanas del período menstrual
         line: Línea

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -221,7 +221,6 @@ es:
         initial_call_date: Fecha de llamada inicial
         insurance: Seguro médico
         language: Idioma
-        pronouns: Pronombres
         last_menstrual_period_days: Últimos días del período menstrual
         last_menstrual_period_weeks: Últimas semanas del período menstrual
         line: Línea
@@ -236,6 +235,7 @@ es:
         pledge_sent_at: Promesa enviada en
         primary_phone: Número de teléfono principal
         procedure_cost: Costo del procedimiento
+        pronouns: Pronombres
         race_ethnicity: Raza / Etnicidad
         referred_by: Referido por
         referred_to_clinic: Referido a la clínica

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -66,6 +66,7 @@ Patient.all.each do |patient|
   # Add example of patient with appointment one week from today && clinic selected
   if patient.name == 'Patient 2'
     patient.update! name: "Clinic and Appt - 2",
+                    pronouns: "she/they",
                     clinic: Clinic.first,
                     appointment_date: (2.days.from_now)
   end
@@ -79,6 +80,7 @@ Patient.all.each do |patient|
                     fund_pledge: 100,
                     pledge_sent: true,
                     patient_contribution: 100,
+                    pronouns: "ze/zir",
                     name: "Pledge submitted - 3"
   end
 
@@ -413,6 +415,7 @@ end
     city: "Washington",
     state: "DC",
     county: "Washington",
+    pronouns: "they/them",
     other_contact: "Susie Q.",
     other_phone: "555-6#{patient_number}0-0053",
     other_contact_relationship: "Mother",

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -19,6 +19,7 @@ class DataEntryTest < ApplicationSystemTestCase
       fill_in 'Initial Call Date', with: 2.days.ago.strftime('%m/%d/%Y')
       fill_in 'Name', with: 'Susie Everyteen'
       fill_in 'Phone', with: '111-222-3344'
+      fill_in 'Pronouns', with: 'she/they'
       fill_in 'Other contact name', with: 'Billy Everyteen'
       fill_in 'Other phone', with: '111-555-9999'
       fill_in 'Relationship to other contact', with: 'Friend'
@@ -59,6 +60,7 @@ class DataEntryTest < ApplicationSystemTestCase
         assert has_field? 'First and last name', with: 'Susie Everyteen'
         assert_equal '1', lmp_weeks.value
         assert_equal '2', lmp_days.value
+        assert has_field? 'Pronouns', with: 'she/they'
         assert has_text? "Called on: #{2.days.ago.strftime('%m/%d/%Y')}"
         assert has_field?('Appointment date',
                           with: 1.day.ago.strftime('%Y-%m-%d'))

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -116,6 +116,21 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         end
       end
     end
+
+    describe 'updating pronouns' do
+      before do
+        fill_in 'Pronouns', with: 'they/them'
+        click_away_from_field
+        wait_for_ajax
+        reload_page_and_click_link 'Patient Information'
+      end
+
+      it 'should update pronouns' do
+        within :css, '#patient_dashboard' do
+          assert has_field? 'Pronouns', with: 'they/them'
+        end
+      end
+    end
   end
 
   describe 'changing abortion information' do


### PR DESCRIPTION
We rule and have completed some work on Case Manager that's ready for review!

Adds the Patient field 'Pronouns' along with the changes in views, controller, tests.

This pull request makes the following changes:
* Adds pronoun field to Patient Model
* Allows pronoun param in Patient Controller
* Added pronoun field to Patient Dashboard View
* Added pronoun field to Data Entry
* Added new field tests for the above views
* Added English & Spanish i18n translations
* Added pronouns to various dev seed data

(If there are changes to the views, please include a screenshot so we know what to look for!)

Page |Before | After
-- | -- | --
Patient Dashboard | ![image](https://user-images.githubusercontent.com/6129479/92998500-0fa0ae00-f4e8-11ea-8e51-10c124750734.png) |  ![image](https://user-images.githubusercontent.com/6129479/92998478-f7309380-f4e7-11ea-9678-558ec96353b3.png)
Data Entry | ![image](https://user-images.githubusercontent.com/6129479/92998521-2941f580-f4e8-11ea-8edd-228477aa30cb.png) | ![image](https://user-images.githubusercontent.com/6129479/92998539-3e1e8900-f4e8-11ea-9577-33bfbbd7c263.png)


It relates to the following issue #s: 
* Fixes #2054 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
