### PR TITLE
Bumps autoprefixer-rails out of deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     afm (0.2.2)
     ast (2.4.1)
-    autoprefixer-rails (9.8.6.1)
+    autoprefixer-rails (10.0.1.0)
       execjs
     bcrypt (3.1.15)
     bootsnap (1.4.7)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

[ai/autoprefixer-rails](https://github.com/ai/autoprefixer-rails/pull/177) is no longer being deprecated! Bump past those deprecation warnings.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
