### PR TITLE
Upgrade capybara to >= 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :test do
   gem 'timecop'
 
   # Systemtest related tools
-  gem 'capybara', '~> 2.17'
+  gem 'capybara'
   gem 'selenium-webdriver'
   gem 'capybara-screenshot'
   gem 'launchy' # open up capybara screenshots automatically with `save_and_open_screenshot`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,13 +88,14 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
     byebug (11.1.3)
-    capybara (2.18.0)
+    capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     capybara-screenshot (1.0.24)
       capybara (>= 1.0, < 4)
       launchy
@@ -280,7 +281,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -431,7 +432,7 @@ DEPENDENCIES
   bson_ext
   bundler-audit
   byebug
-  capybara (~> 2.17)
+  capybara
   capybara-screenshot
   codecov
   coffee-rails (~> 5.0.0)

--- a/test/system/filter_medicaid_clinics_test.rb
+++ b/test/system/filter_medicaid_clinics_test.rb
@@ -23,8 +23,8 @@ class FilterMedicaidClinicsTest < ApplicationSystemTestCase
       options_with_filter = find('#patient_clinic_id').all('option')
                                                       .map { |opt| { name: opt.text, disabled: opt['disabled'] } }
 
-      assert options_with_filter.find { |x| x[:name] == @non_medicaid_clinic.name }[:disabled]
-      refute options_with_filter.find { |x| x[:name] == @medicaid_clinic.name }[:disabled]
+      assert_equal 'true', options_with_filter.find { |x| x[:name] == @non_medicaid_clinic.name }[:disabled]
+      assert_equal 'false', options_with_filter.find { |x| x[:name] == @medicaid_clinic.name }[:disabled]
 
       # try to select and watch it not work
       select @non_medicaid_clinic.name, from: 'patient_clinic_id'

--- a/test/system/filter_naf_clinics_test.rb
+++ b/test/system/filter_naf_clinics_test.rb
@@ -23,8 +23,8 @@ class FilterNafClinicsTest < ApplicationSystemTestCase
       options_with_filter = find('#patient_clinic_id').all('option')
                                                       .map { |opt| { name: opt.text, disabled: opt['disabled'] } }
 
-      assert options_with_filter.find { |x| x[:name] == @nonnaf_clinic.name }[:disabled]
-      refute options_with_filter.find { |x| x[:name] == @naf_clinic.name }[:disabled]
+      assert_equal 'true', options_with_filter.find { |x| x[:name] == @nonnaf_clinic.name }[:disabled]
+      assert_equal 'false', options_with_filter.find { |x| x[:name] == @naf_clinic.name }[:disabled]
 
       # try to select and watch it not work
       select @nonnaf_clinic.name, from: 'patient_clinic_id'

--- a/test/system/pledge_fulfillment_test.rb
+++ b/test/system/pledge_fulfillment_test.rb
@@ -103,7 +103,7 @@ class PledgeFulfillmentTest < ApplicationSystemTestCase
       fill_in 'patient_fulfillment_check_number', with: ''
       assert has_checked_field? 'Pledge fulfilled'
 
-      fill_in 'patient_fulfillment_procedure_date', with: 'mm/dd/yyyy'
+      fill_in 'patient_fulfillment_procedure_date', with: ''
       select '', from: 'patient_fulfillment_gestation_at_procedure'
       assert has_no_checked_field? 'Pledge fulfilled'
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Removes version pin on capybara, bringing it into the present. Makes some insignificant adjustments to get build to pass again.

This pull request makes the following changes:
* capybara to >= v3
* adjustments to accommodate for the breaking changes in capybara v3

no view changes

It relates to the following issue #s: 
* Fixes #2062

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
