### PR TITLE
Add and configure postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,18 @@ jobs:
           BUNDLE_PATH: vendor/bundle
           RAILS_ENV: test
           TESTOPTS: "--ci-dir=test-results"
+          PGUSER: circleci
+          PGHOST: localhost
+          PGDATABASE: dcaf_case_management_test
       - image: circleci/mongo:latest
+      - image: circleci/postgres:latest
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: dcaf_case_management_test
+          POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
-      - run: sudo apt-get install libfontconfig
+      - run: sudo apt-get install libfontconfig postgresql-client
       - run: gem install bundler # Update bundler
       - run: sudo gem update --system # Update rubygems
       - restore_cache:
@@ -26,6 +34,7 @@ jobs:
       - run: bundle check || bundle install
       - run: yarn install
       - run: NODE_ENV=test bundle exec rails webpacker:compile
+      - run: RAILS_ENV=test bundle exec rails db:create db:migrate
       - run: gem install --no-document brakeman
       - run: gem install --no-document ruby_audit
       - run: gem install --no-document bundler-audit

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Colin Fleming <c3flemin@gmail.com>
 # configure environment variable
 # note: move this to three ARG commands when CircleCI updates their docker
 ENV DCAF_DIR=/usr/src/app \
-    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig" \
+    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig postgresql libpq-dev" \
     APP_DEPENDENCIES="nodejs yarn git sudo sassc" \
     AHAB_DEPENDENCIES="ca-certificates curl" \
     FONTCONFIG_PATH=/etc/fonts \

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ cacert.pem
 .redcar/
 .sass-cache
 /config/config.yml
-/config/database.yml
 /coverage.data
 /coverage/
 /db/*.javadb/

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,12 @@ gem 'mongoid_userstamp', git: 'https://github.com/DCAFEngineering/mongoid_userst
                          branch: 'master' # adds created_by and updated_by timestamps
 gem 'mongo_session_store', '>= 3.1.0' # stores sessions in database for security
 gem 'enumerize' # Mongoid doesn't have enum out of the box, so we get it here
-gem 'mongoid_rails_migrations' # Mongoid also does not have migrations out of the box, so we get that here
+# gem 'mongoid_rails_migrations' # Mongoid also does not have migrations out of the box, so we get that here
+
+# ...but hopefully soon it will be postgres
+gem 'pg', '~> 1.2'
+gem 'paper_trail', '~> 10.3'
+gem 'paper_trail-globalid'
 
 # Our authentication library is devise, with oauth2 for google signin
 gem 'devise', '~> 4.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,12 +232,6 @@ GEM
       easy_diff
       mongoid (>= 3.0)
       mongoid-compatibility (>= 0.5.1)
-    mongoid_rails_migrations (1.2.1)
-      activesupport (>= 4.2.0)
-      bundler (>= 1.0.0)
-      mongoid (>= 4.0.0)
-      rails (>= 4.2.0)
-      railties (>= 4.2.0)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -262,6 +256,12 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
     orm_adapter (0.5.0)
+    paper_trail (10.3.1)
+      activerecord (>= 4.2)
+      request_store (~> 1.1)
+    paper_trail-globalid (0.2.0)
+      globalid
+      paper_trail (>= 3.0.0)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -274,6 +274,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
+    pg (1.2.3)
     popper_js (1.16.0)
     prawn (2.3.0)
       pdf-core (~> 0.8.1)
@@ -328,6 +329,8 @@ GEM
     rdoc (6.2.1)
     regexp_parser (1.7.1)
     render_async (2.1.7)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -461,11 +464,13 @@ DEPENDENCIES
   mongo_session_store (>= 3.1.0)
   mongoid (~> 7.0.0, < 8)
   mongoid-history (< 1.0)
-  mongoid_rails_migrations
   mongoid_userstamp!
   nokogiri (>= 1.10.5)
   omniauth-google-oauth2 (~> 0.8.0)
+  paper_trail (~> 10.3)
+  paper_trail-globalid
   pdf-inspector
+  pg (~> 1.2)
   prawn
   pry
   puma (~> 4.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,8 @@ class ApplicationController < ActionController::Base
   before_action :prevent_caching_via_headers
   before_action :set_locale
   before_action :set_raven_context
-  prepend_before_action :authenticate_user!
+   # before_action :set_paper_trail_whodunnit # Turn on when user model is in pg 
+   prepend_before_action :authenticate_user!
   prepend_before_action :confirm_user_not_disabled!, unless: :devise_controller?
 
   # whitelists attributes in devise

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,4 @@
+# Abstract class pg models inherit from.
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,9 +6,9 @@ require File.expand_path('../boot', __FILE__)
 
 require "rails"
 # Pick the frameworks you want:
-# require "active_model/railtie"
+require "active_model/railtie"
 # require "active_job/railtie"
-# require "active_record/railtie"
+require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
@@ -43,7 +43,7 @@ module DcafCaseManagement
     # config.i18n.default_locale = :de
 
     config.generators do |g|
-      g.orm :mongoid
+      g.orm :active_record
     end
 
     # Throttling protection

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,20 @@
+# Db
+development:
+  adapter: postgresql
+  encoding: unicode
+  url: <%= ENV.fetch('pg_url', 'postgres://localhost') %>
+  database: dcaf_case_management_development
+  pool: 5
+
+test:
+  adapter: postgresql
+  encoding: unicode
+  url: <%= ENV.fetch('pg_url', 'postgres://localhost') %>
+  database: dcaf_case_management_test
+  pool: 5
+
+production:
+  adapter: postgresql
+  encoding: unicode
+  url: <%= ENV['DATABASE_URL'] %>
+  pool: 10

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -260,3 +260,11 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 end
+
+# Hack to prevent some devise goofiness around having both activerecord
+# and mongoid. Removable when we move user class to pg.
+Devise.module_eval do 
+  def self.activerecord51?
+    false
+  end
+end

--- a/db/migrate/20201119043849_install_pgcrypto.rb
+++ b/db/migrate/20201119043849_install_pgcrypto.rb
@@ -1,0 +1,6 @@
+# This migration sets up pgcrypto, which lets us use uuids.
+class InstallPgcrypto < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20201120043849_create_versions.rb
+++ b/db/migrate/20201120043849_create_versions.rb
@@ -1,0 +1,37 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.0]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, {:null=>false}
+      t.integer  :item_id,   null: false, limit: 8
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.json     :object
+      t.json     :object_changes
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 2020_11_20_043849) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "versions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,34 +1,29 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151222011145) do
+ActiveRecord::Schema.define(version: 2020_11_20_043849) do
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.json "object"
+    t.json "object_changes"
+    t.datetime "created_at"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,20 @@ services:
       - "3000:3000"
     links:
       - db
+      - pg
     environment:
       mongohost: db
+      pg_url: postgres://postgres:postgres@pg
     env_file:
       - .docker/web-variables.env
   db:
     image: mongo
     ports:
       - "27017:27017"
+  pg:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,7 +64,10 @@ We're on Webpacker, which requires an additional setup step, but which lets us w
 ### Then, Postgres dependencies
 We use Postgres around these parts. Installation will differ based on your OS.
 
-* Install Postgres (`brew install postgres` on MacOS, or [linux instructions](https://www.postgresql.org/download/)
+* Install Postgres
+  * MacOS: `brew install postgres`
+  * Ubuntu: install `postgresql`, `libpq-dev`, and `postgresql-client`
+  * Other [linux instructions](https://www.postgresql.org/download/) (server and developer libraries needed)
 * Run the command `rails db:create && rails db:migrate` to set up the tables
 
 ### Then, showtime

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -61,6 +61,12 @@ We're on Webpacker, which requires an additional setup step, but which lets us w
 * Install Yarn locally (`brew install yarn`, or the [setup instructions](https://yarnpkg.com/en/docs/install)).
 * Install JS packages: `yarn install`
 
+### Then, Postgres dependencies
+We use Postgres around these parts. Installation will differ based on your OS.
+
+* Install Postgres (`brew install postgres` on MacOS, or [linux instructions](https://www.postgresql.org/download/)
+* Run the command `rails db:create && rails db:migrate` to set up the tables
+
 ### Then, showtime
 After that:
 * run `rake db:seed` to populate your database with test data

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -17,7 +17,7 @@ For the rest of the setup, you have two options: Docker, or installing everythin
 We've dockerized this app, to manage the dependencies and save us some headache. If you've got [Docker installed already](https://docs.docker.com/engine/installation/), you can be up and running with three commands:
 
 * `docker-compose build # (this may say 'uses an image, skipping' a few times, that's OK)`
-* `docker-compose run --rm web rake db:seed # to populate the database`
+* `docker-compose run --rm web rails db:create db:migrate db:seed # to populate the database`
 * `docker-compose up`
 
 The last command will take a moment and should print a number of things. When it's ready

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,7 @@ if ENV['CIRCLECI']
 end
 
 DatabaseCleaner.clean_with :truncation
+ DatabaseCleaner[:mongoid].clean_with :truncation
 
 # Convenience methods around config creation, and database cleaning
 class ActiveSupport::TestCase
@@ -78,6 +79,19 @@ class ActiveSupport::TestCase
   def create_fax_service_config
     create :config, config_key: 'fax_service',
                     config_value: { options: ['http://www.yolofax.com'] }
+  end
+
+  def with_versioning
+    was_enabled = PaperTrail.enabled?
+    was_enabled_for_request = PaperTrail.request.enabled?
+    PaperTrail.enabled = true
+    PaperTrail.request.enabled = true
+    begin
+      yield
+    ensure
+      PaperTrail.enabled = was_enabled
+      PaperTrail.request.enabled = was_enabled_for_request
+    end
   end
 end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Start the process to roll out postgres by installing pg gems and constructing a migration.

This is pretty much the bare minimum we can do to postgresify, and is intended to separate out the devopsy stuff from actual app work. Everything in here is basically a noop - it adds a postgres instance and a table that is not set up to get used yet. So pretty safe, from a risk perspective.

I added a hobby postgres db to test this on in sandbox. I am not sure how to do the db:create / db:migrate as part of deployment, or if we _should_ do that. Likely when we roll this out for real it should be on grown-up paid dbs though.

This pull request makes the following changes:
* install and configure pg in code
* set up a table (papertrail's `versions` table) to prove migration works
* configure CI/docker

no view changes

It relates to the following issue #s: 
* Bumps #2072

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
