### PR TITLE
update render_async to use nonces by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.2.1)
     regexp_parser (1.7.1)
-    render_async (2.1.7)
+    render_async (2.1.8)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)

--- a/app/views/dashboards/_activity_log.html.erb
+++ b/app/views/dashboards/_activity_log.html.erb
@@ -4,6 +4,6 @@
   </h1>
 
   <div id="activity_log_content">
-    <%= render_async events_path, html_options: { nonce: true, 'data-turbolinks-track': 'reload' } %>
+    <%= render_async events_path, 'data-turbolinks-track': 'reload' %>
   </div>
 </div>

--- a/app/views/dashboards/_overview.html.erb
+++ b/app/views/dashboards/_overview.html.erb
@@ -5,6 +5,6 @@
   </h1>
 
   <div id="budget_bar">
-    <%= render_async budget_bar_path, html_options: { nonce: true, 'data-turbolinks-track': 'reload' }  %>
+    <%= render_async budget_bar_path, 'data-turbolinks-track': 'reload' %>
   </div>
 </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -8,7 +8,7 @@
   <div class="progress-bar progress-bar-striped"</div>
 </div>
  -->
-<%= render_async patients_report_path(timeframe: 'weekly'), nonce: true %>
-<%= render_async patients_report_path(timeframe: 'monthly'), nonce: true %>
-<%= render_async patients_report_path(timeframe: 'yearly'), nonce: true %>
+<%= render_async patients_report_path(timeframe: 'weekly') %>
+<%= render_async patients_report_path(timeframe: 'monthly') %>
+<%= render_async patients_report_path(timeframe: 'yearly') %>
 <%#= render partial: 'reports/fulfillment' -- Not functional yet %>

--- a/config/initializers/render_async.rb
+++ b/config/initializers/render_async.rb
@@ -1,3 +1,4 @@
 RenderAsync.configure do |config|
   config.jquery = true # This will render jQuery code, and skip Vanilla JS code
+  config.nonces = true # Use nonces by default
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

the `render_async` library has a feature in 2.1.8 that sets nonces by default on `render_async` partials. This sets that up so we don't have to think too hard about when to use nonces.

This pull request makes the following changes:
* bump `render_async` to 2.1.8
* use nonces by default in render_async partials

no views

no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
