### PR TITLE
Add login URL to account creation email

### DIFF
--- a/app/views/user_mailer/account_created.html.erb
+++ b/app/views/user_mailer/account_created.html.erb
@@ -1,5 +1,5 @@
 <p>Hi <%= @user.name %> --</p>
-<p>A DARIA account has been created for you! You can head <a href="<%= ENV.fetch('SITE_URL', 'https://www.google.com/?q=cats' %>">here</a> to log in.</p>
+<p>A DARIA account has been created for you! You can head <a href="<%= ENV.fetch('SITE_URL', 'https://www.google.com/?q=cats') %>">here</a> to log in.</p>
 <p>We recommend logging in with Google. If you don't log in with Google, you will need to reset your password.</p>
 <p>If you experience any difficulties, please reach out to your case management director or volunteer contact.</p>
 <p>Thanks for your service!</p>

--- a/app/views/user_mailer/account_created.html.erb
+++ b/app/views/user_mailer/account_created.html.erb
@@ -1,6 +1,6 @@
 <p>Hi <%= @user.name %> --</p>
-<p>A DARIA account has been created for you!</p>
+<p>A DARIA account has been created for you! You can head <a href="<%= ENV.fetch('SITE_URL', 'https://www.google.com/?q=cats' %>">here</a> to log in.</p>
 <p>We recommend logging in with Google. If you don't log in with Google, you will need to reset your password.</p>
-<p>If you don't know what website to go to, or if you experience any other difficulties, please reach out to your case management director or volunteer contact.</p>
+<p>If you experience any difficulties, please reach out to your case management director or volunteer contact.</p>
 <p>Thanks for your service!</p>
 <p>- Team <%= FUND %></p>

--- a/app/views/user_mailer/account_created.html.erb
+++ b/app/views/user_mailer/account_created.html.erb
@@ -1,6 +1,6 @@
 <p>Hi <%= @user.name %> --</p>
 <p>A DARIA account has been created for you!</p>
-<p>Please start by heading to the system and resetting your password.</p>
-<p>Email the CM Directors if you experience any difficulties.</p>
+<p>We recommend logging in with Google. If you don't log in with Google, you will need to reset your password.</p>
+<p>If you don't know what website to go to, or if you experience any other difficulties, please reach out to your case management director or volunteer contact.</p>
 <p>Thanks for your service!</p>
 <p>- Team <%= FUND %></p>

--- a/app/views/user_mailer/account_created.text.erb
+++ b/app/views/user_mailer/account_created.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @user.name %> --
 
-A DARIA account has been created for you! You can head here to log in: <%= ENV.fetch('SITE_URL', 'https://www.google.com/?q=cats' %>
+A DARIA account has been created for you! You can head here to log in: <%= ENV.fetch('SITE_URL', 'https://www.google.com/?q=cats') %>
 
 We recommend logging in with Google. If you don't log in with Google, you will need to reset your password.
 

--- a/app/views/user_mailer/account_created.text.erb
+++ b/app/views/user_mailer/account_created.text.erb
@@ -1,8 +1,10 @@
-Hi <%= @user.name %> -- A DARIA account has been created for you!
+Hi <%= @user.name %> --
+
+A DARIA account has been created for you! You can head here to log in: <%= ENV.fetch('SITE_URL', 'https://www.google.com/?q=cats' %>
 
 We recommend logging in with Google. If you don't log in with Google, you will need to reset your password.
 
-If you don't know what website to go to, or if you experience any other difficulties, please reach out to your case management director or volunteer contact.
+If you experience any difficulties, please reach out to your case management director or volunteer contact.
 
 Thanks for your service!
 

--- a/app/views/user_mailer/account_created.text.erb
+++ b/app/views/user_mailer/account_created.text.erb
@@ -1,8 +1,8 @@
 Hi <%= @user.name %> -- A DARIA account has been created for you!
 
-Please unlock it by heading to the system and resetting your password.
+We recommend logging in with Google. If you don't log in with Google, you will need to reset your password.
 
-Email the CM Directors if you experience any difficulties.
+If you don't know what website to go to, or if you experience any other difficulties, please reach out to your case management director or volunteer contact.
 
 Thanks for your service!
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

@verbingthenoun asked for this awhile ago - the new account creation welcome email is basically the same one we launched with, and doesn't really have a next step, so people need to have an additional touch with their volunteers. This tries to get ahead of that by including a URL to hit to log in.

The first commit sets things up to include 'reach out to your CM directors or volunteer lead' language, but the second commit includes the actual URL to go to (set as `SITE_URL` as an env var everywhere). 

I'd like @lomky 's opinion on sending the URL out in new account emails and @verbingthenoun 's opinion on the language here.

This pull request makes the following changes:
* bumps the new account email to include a next step (log in, and to email the CM director if you don't know the URL)
* includes a site url to go to

no view changes

It relates to the following issue #s: 
* Fixes #1897 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
