### PR TITLE
point codecov badge on readme to main + fix codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DARIA (DCAF Case Manager)
 
 [![CircleCI](https://circleci.com/gh/DCAFEngineering/dcaf_case_management.svg?style=shield)](https://circleci.com/gh/DCAFEngineering/dcaf_case_management)
-[![codecov](https://codecov.io/gh/DCAFEngineering/dcaf_case_management/branch/main/graph/badge.svg)](https://codecov.io/gh/DCAFEngineering/dcaf_case_management)
+[![codecov](https://codecov.io/gh/DCAFEngineering/dcaf_case_management/branch/main/graph/badge.svg?token=vnoVK0meeZ)](https://codecov.io/gh/DCAFEngineering/dcaf_case_management)
 [![](https://images.microbadger.com/badges/image/colinxfleming/dcaf_case_management.svg)](https://microbadger.com/images/colinxfleming/dcaf_case_management "Get your own image badge on microbadger.com")
 
 [A deployed demo version of what's in the main branch is at: https://sandbox.dcabortionfund.org/](https://sandbox.dcabortionfund.org/)  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,0 @@
-branches:
-  - main
-threshold: "1%"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'integration_helper'
 require 'rack/test'
 
 # CI only
-if ENV['CIRCLE_ARTIFACTS']
+if ENV['CIRCLECI']
   # Use knapsack to split up tests on CI nodes
   # To rerack the test divider, run:
   # KNAPSACK_GENERATE_REPORT=true bundle exec rake test test:system
@@ -24,10 +24,8 @@ if ENV['CIRCLE_ARTIFACTS']
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
-  # Save screenshots if integration tests fail
-  circle_path = ENV.fetch('CIRCLE_ARTIFACTS',
-                          Rails.root.join('tmp', 'capybara'))
-  Capybara.save_path = circle_path
+  # Save screenshots if system tests fail
+  Capybara.save_path = Rails.root.join('tmp', 'capybara')
 end
 
 DatabaseCleaner.clean_with :truncation


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

bumps a badge in the readme

This pull request makes the following changes:
* refresh readme badge in circleci

no view changes

It relates to the following issue #s: 
* Bumps #2024 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
