### PR TITLE
remove jquery-rails from gemfile, in favor of webpacker

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
 //= require popper
 //= require jquery_ujs
 //= require jquery-ui

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,11 +9,11 @@
     <%= csp_meta_tag %>
     <%= favicon_link_tag %>
 
-    <%= stylesheet_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_link_tag :application, media: 'all' %>
-
     <%= javascript_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag :application %>
+
+    <%= stylesheet_pack_tag 'application', 'data-search-pseudo-elements': true, 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag :application, media: 'all' %>
 
     <%= content_for :render_async %>
   </head>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I spent some time this wknd working on our js/css assets, and had a lot of problems with 'jquery is in two places' at the center of it, which was leading to some truly buckwild behavior. This straightens that out.

This pull request makes the following changes:
* limit jquery's in webpacker, and take it out of the sprockets asset pipeline

no view changes

It relates to the following issue #s: 
* TK

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
