### PR TITLE
port budget bar scss to webpacker

### DIFF
--- a/app/assets/stylesheets/budget_bar.scss
+++ b/app/assets/stylesheets/budget_bar.scss
@@ -1,5 +1,0 @@
-.expenditure-block {
-  border-right: 1px solid black;
-  color: black;
-  font-size: 14px;
-}

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -7,3 +7,4 @@
 @import '../styles/call_list';
 @import '../styles/devise';
 @import '../styles/users';
+@import '../styles/budget_bar';

--- a/app/javascript/styles/_variables.scss
+++ b/app/javascript/styles/_variables.scss
@@ -8,6 +8,7 @@ $grey-color: #525252;
 $soft-blue: #23527c;
 $dark-blue: #142B43;
 $white: #ffffff;
+$black: #000000;
 $phone-icon-blue: #337ab7;
 
 // Sizing

--- a/app/javascript/styles/budget_bar.scss
+++ b/app/javascript/styles/budget_bar.scss
@@ -6,6 +6,6 @@ $budget-bar-font-size: 14px;
 
 .expenditure-block {
   border-right: 1px solid $black;
-  color: $black;
+  color: $black !important;
   font-size: $budget-bar-font-size;
 }

--- a/app/javascript/styles/budget_bar.scss
+++ b/app/javascript/styles/budget_bar.scss
@@ -1,0 +1,11 @@
+// Styling related to the budget bar utility.
+
+@import './_variables';
+
+$budget-bar-font-size: 14px;
+
+.expenditure-block {
+  border-right: 1px solid $black;
+  color: $black;
+  font-size: $budget-bar-font-size;
+}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This ports over the budget bar CSS into webpacker.

In the process, fixes a small css bug - the black text wasn't bubbling up and it was making it hard to read, at least on firefox. (See screenshots.)

This pull request makes the following changes:
* ports budget_bar styling to webpacker
* enforces black text to avoid the color clash with an `!important` directive

Local: 

![image](https://user-images.githubusercontent.com/3866868/101452827-52fa9500-38fc-11eb-9dc5-0b9d2f859dfe.png)

Sandbox:

![image](https://user-images.githubusercontent.com/3866868/101452806-4b3af080-38fc-11eb-85be-60d82795f6ec.png)



It relates to the following issue #s: 
* Bumps #1859 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
