### PR TITLE
Execute db:migrate on release phase in heroku + app.json bump

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: rails db:migrate
 web: bundle exec puma -p $PORT -C ./config/puma.rb

--- a/app.json
+++ b/app.json
@@ -100,7 +100,7 @@
       "plan": "logentries"
     },
     {
-      "plan": "mongolab"
+      "plan": "heroku-postgresql:hobby-basic"
     },
     {
       "plan": "scheduler"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Heroku has a nice feature: in the procfile you can define a release action. We make that `rails db:migrate` here to exec any pending db migrations so the release phase doesn't fail.

We also bump app.json to be postgres instead of mongo. Appropriate since mlab is gone forever. This will only affect new instances.

This pull request makes the following changes:
* run `rails db:migrate` on deploy to heroku
* bump app.json to add pg

no view changes

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
