### PR TITLE
Port Event model over to postgres

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < ApplicationController
 
   def index
     events = Event.where(line: current_line)
-                   .order_by(created_at: :desc)
+                  .order(created_at: :desc)
 
     @events = paginate_results(events)
     respond_to do |format|

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -27,6 +27,6 @@ module EventsHelper
 
   def event_string(event)
     return t('events.pledged', pledge_amount: event.pledge_amount) if event.event_type == 'pledged'
-    t("events.#{event.underscored_type}")
+    t("events.#{event.event_type}")
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -26,7 +26,7 @@ module EventsHelper
   end
 
   def event_string(event)
-    return t('events.pledged', pledge_amount: event.pledge_amount) if event.event_type == 'Pledged'
+    return t('events.pledged', pledge_amount: event.pledge_amount) if event.event_type == 'pledged'
     t("events.#{event.underscored_type}")
   end
 end

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -13,11 +13,13 @@ class Call
   field :status, type: String
 
   # Validations
-  allowed_statuses = ['Reached patient',
-                      'Left voicemail',
-                      "Couldn't reach patient"]
+  ALLOWED_STATUSES = {
+    'Reached patient' => :reached_patient,
+    'Left voicemail' => :left_voicemail,
+    "Couldn't reach patient" => :couldnt_reach_patient
+  }
   validates :status,  presence: true,
-                      inclusion: { in: allowed_statuses }
+                      inclusion: { in: ALLOWED_STATUSES.keys }
   validates :created_by_id, presence: true
 
   # History and auditing
@@ -38,7 +40,7 @@ class Call
 
   def event_params
     {
-      event_type:   status,
+      event_type:   ALLOWED_STATUSES[status],
       cm_name:      created_by&.name || 'System',
       patient_name: can_call.name,
       patient_id:   can_call.id,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,11 +25,6 @@ class Event < ApplicationRecord
     end
   end
 
-  # remove spaces and punctuation. A sin method because we did this as strs not syms.
-  def underscored_type
-    event_type.gsub(' ', '_').gsub(/\W/, '').downcase
-  end
-
   # Clean events older than three weeks
   def self.destroy_old_events
     Event.where('created_at < ?', 3.weeks.ago)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
     pledged: 3,
     unknown_action: 4
   }
+  # See config/initializers/_env_var_contants.rb
   enum line: LINES.map { |x| { x.to_sym => x.to_s } }.inject(&:merge)
 
   # Validations

--- a/app/models/mongo_event.rb
+++ b/app/models/mongo_event.rb
@@ -1,0 +1,61 @@
+# Object representing relevant actions taken by a case  manager
+class MongoEvent
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  extend Enumerize
+
+  EVENT_TYPES = [
+    'Reached patient',
+    "Couldn't reach patient",
+    'Left voicemail',
+    'Pledged',
+    'Unknown action'
+  ].freeze
+
+  # Fields
+  field :cm_name, type: String
+  enumerize :event_type,
+            in:      EVENT_TYPES.map(&:to_sym),
+            default: 'Unknown action'.to_sym
+  # See config/initializers/env_var_contants.rb
+  enumerize :line, in: LINES, default: LINES[0]
+  field :patient_name, type: String
+  field :patient_id, type: String
+  field :pledge_amount, type: Integer
+
+  # Indices
+  index(created_at: 1)
+
+  # Validations
+  validates :event_type, inclusion: { in: EVENT_TYPES }
+  validates :cm_name, :patient_name, :patient_id, :line, presence: true
+  validates :pledge_amount, presence: true, if: :pledged_type?
+
+  def icon
+    case event_type
+    when 'Pledged'
+      'thumbs-up'
+    when 'Reached patient'
+      'comment'
+    else
+      'phone-alt'
+    end
+  end
+
+  # remove spaces and punctuation. A sin method because we did this as strs not syms.
+  def underscored_type
+    event_type.gsub(' ', '_').gsub(/\W/, '').downcase
+  end
+
+  # Clean events older than three weeks
+  def self.destroy_old_events
+    Event.where(:created_at.lte => 3.weeks.ago)
+         .destroy_all
+  end
+
+  private
+
+  def pledged_type?
+    event_type == 'Pledged'
+  end
+end

--- a/app/models/mongo_event.rb
+++ b/app/models/mongo_event.rb
@@ -4,6 +4,8 @@ class MongoEvent
   include Mongoid::Timestamps
   extend Enumerize
 
+  store_in collection: 'events'
+
   EVENT_TYPES = [
     'Reached patient',
     "Couldn't reach patient",

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -175,7 +175,7 @@ class Patient
 
   def event_params
     {
-      event_type:    'Pledged',
+      event_type:    :pledged,
       cm_name:       updated_by&.name || 'System',
       patient_name:  name,
       patient_id:    id,

--- a/db/migrate/20201212010730_create_events.rb
+++ b/db/migrate/20201212010730_create_events.rb
@@ -1,0 +1,17 @@
+class CreateEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :events do |t|
+      t.string :cm_name
+      t.integer :event_type
+      t.string :line
+      t.string :patient_name
+      t.string :patient_id
+      t.integer :pledge_amount
+
+      t.timestamps
+    end
+
+    add_index :events, :created_at
+    add_index :events, :line
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_043840) do
+ActiveRecord::Schema.define(version: 2020_12_12_010730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,6 +22,19 @@ ActiveRecord::Schema.define(version: 2020_12_07_043840) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["config_key"], name: "index_configs_on_config_key"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string "cm_name"
+    t.integer "event_type"
+    t.string "line"
+    t.string "patient_name"
+    t.string "patient_id"
+    t.integer "pledge_amount"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_at"], name: "index_events_on_created_at"
+    t.index ["line"], name: "index_events_on_line"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -5,14 +5,37 @@ namespace :migrate_to_pg do
     mongo = MongoConfig
     migrate_model(pg, mongo)
   end
+
+  task event: :environment do
+    pg = Event
+    mongo = MongoEvent
+
+    extra_transform = Proc.new do |attrs|
+      event_type_mapping = {
+        "Reached patient" => :reached_patient,
+        "Couldn't reach patient" => :couldnt_reach_patient,
+        "Left voicemail" => :left_voicemail,
+        "Pledged" => :pledged,
+        "Unknown action" => :unknown_action
+      }
+      attrs['event_type'] = event_type_mapping[attrs['event_type']]
+      attrs
+    end
+
+    migrate_model(pg, mongo, extra_transform)
+  end
 end
 
 # Convenience function to slice attributes
-def migrate_model(pg_model, mongo_model)
+def migrate_model(pg_model, mongo_model, transform = nil)
   attributes = pg_model.attribute_names
   ActiveRecord::Base.transaction do
     mongo_model.collection.find.batch_size(100).each do |obj|
       pg_attrs = obj.slice(*attributes)
+
+      # If a model specific transform is required, do it here
+      pg_attrs = transform.call(pg_attrs) if transform.present?
+
       pg_model.create! pg_attrs
     end
 

--- a/test/factories/event.rb
+++ b/test/factories/event.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :event do
-    event_type { 'Reached patient' }
+    event_type { :reached_patient }
     cm_name { 'Yolorita' }
     patient_name { 'Susan Everyteen' }
     patient_id { 'sdfghjk' }

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class EventsHelperTest< ActionView::TestCase
   describe 'display_event' do
     it 'should render an event line - pledged' do
-      event = create :event, event_type: 'Pledged', pledge_amount: 100
+      event = create :event, event_type: :pledged, pledge_amount: 100
       expected = "<span class=\"far fa-thumbs-up event-item\" /> " \
                  "#{event.created_at.display_time} -- #{event.cm_name} sent a " \
                  "$100 pledge for <a href=\"/patients/#{event.patient_id}/edit\">" \

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -55,14 +55,6 @@ class EventTest < ActiveSupport::TestCase
         assert_equal 'phone-alt', build(:event, event_type: :left_voicemail).icon
       end
     end
-
-    # describe 'underscored_type' do
-    #   it 'should translate to type without punctuation, with underscores' do
-    #     assert_equal 'pledged', create(:event, event_type: :pledged, pledge_amount: 100).underscored_type
-    #     assert_equal 'left_voicemail', create(:event, event_type: :left_voicemail).underscored_type
-    #     assert_equal 'reached_patient', create(:event, event_type: :reached_patient).underscored_type
-    #   end
-    # end
   end
 
   describe 'cleaning old events' do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -16,11 +16,13 @@ class EventTest < ActiveSupport::TestCase
 
       [
         :reached_patient, :couldnt_reach_patient,
-        :left_voicemail, :pledged, :unknown_action
+        :left_voicemail, :unknown_action
       ].each do |status|
         @event.event_type = status
         assert @event.valid?
       end
+      @event.update event_type: :pledged, pledge_amount: 100
+      assert @event.valid?
     end
 
     it 'should only allow certain lines' do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -14,8 +14,10 @@ class EventTest < ActiveSupport::TestCase
         @event.valid?
       end
 
-      valid_types = [:reached_patient, :couldnt_reach_patient, :left_voicemail]
-      valid_types.each do |status|
+      [
+        :reached_patient, :couldnt_reach_patient,
+        :left_voicemail, :pledged, :unknown_action
+      ].each do |status|
         @event.event_type = status
         assert @event.valid?
       end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -9,20 +9,26 @@ class EventTest < ActiveSupport::TestCase
     end
 
     it 'should only allow certain statuses' do
-      [nil, 'not a status'].each do |bad_status|
-        @event.event_type = bad_status
-        refute @event.valid?
+      assert_raises ArgumentError do
+        @event.event_type = :notatype
+        @event.valid?
       end
 
-      valid_types = ['Reached patient', "Couldn't reach patient",
-                     'Left voicemail']
+      valid_types = [:reached_patient, :couldnt_reach_patient, :left_voicemail]
       valid_types.each do |status|
         @event.event_type = status
         assert @event.valid?
       end
     end
 
-    [:patient_name, :patient_id, :cm_name].each do |req_field|
+    it 'should only allow certain lines' do
+      assert_raises ArgumentError do
+        @event.line = :notaline
+        @event.valid?
+      end
+    end
+
+    [:patient_name, :patient_id, :cm_name, :event_type].each do |req_field|
       it "requires #{req_field}" do
         @event[req_field] = nil
         refute @event.valid?
@@ -30,7 +36,7 @@ class EventTest < ActiveSupport::TestCase
     end
 
     it 'requires a pledge amount if pledged type' do
-      @event.event_type = 'Pledged'
+      @event.event_type = :pledged
       refute @event.valid?
       @event.pledge_amount = 100
       assert @event.valid?
@@ -40,27 +46,23 @@ class EventTest < ActiveSupport::TestCase
   describe 'rendering methods' do
     describe 'icon' do
       it 'should render the correct icon' do
-        @event.event_type = "Couldn't reach patient"
-        assert_equal 'phone-alt', @event.icon
+        assert_equal 'phone-alt', build(:event, event_type: :couldnt_reach_patient).icon
 
-        @event.event_type = 'Reached patient'
-        assert_equal 'comment', @event.icon
+        assert_equal 'comment', build(:event, event_type: :reached_patient).icon
 
-        @event.event_type = 'Pledged'
-        assert_equal 'thumbs-up', @event.icon
+        assert_equal 'thumbs-up', build(:event, event_type: :pledged).icon
 
-        @event.event_type = 'Left voicemail'
-        assert_equal 'phone-alt', @event.icon
+        assert_equal 'phone-alt', build(:event, event_type: :left_voicemail).icon
       end
     end
 
-    describe 'underscored_type' do
-      it 'should translate to type without punctuation, with underscores' do
-        assert_equal 'pledged', create(:event, event_type: 'Pledged', pledge_amount: 100).underscored_type
-        assert_equal 'left_voicemail', create(:event, event_type: 'Left voicemail').underscored_type
-        assert_equal 'reached_patient', create(:event, event_type: 'Reached patient').underscored_type
-      end
-    end
+    # describe 'underscored_type' do
+    #   it 'should translate to type without punctuation, with underscores' do
+    #     assert_equal 'pledged', create(:event, event_type: :pledged, pledge_amount: 100).underscored_type
+    #     assert_equal 'left_voicemail', create(:event, event_type: :left_voicemail).underscored_type
+    #     assert_equal 'reached_patient', create(:event, event_type: :reached_patient).underscored_type
+    #   end
+    # end
   end
 
   describe 'cleaning old events' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This ports over the Event model into Postgres, including a rake task to get things out of Mongo.

To verify:

* check out main and do a fresh `rails db:seed`, then log in and head to the CM dashboard. Nice lookin' events there down at the bottom. Take a screencap of the first few for reference
* Check out this branch and do `rails db:migrate` to move to the new branch. Reload the CM dashboard and confirm that the events disappear
* Run `rails migrate_to_pg:event` to port over data cleanly, then reload the CM dashboard and see your events show back up
* Log a call on a patient by clicking the phone icon and then Left voicemail. Doesn't matter which one. Reload the page and observe the new event showing up - this proves that making new events works.

This pull request makes the following changes:
* Port Event model to postgres/ActiveRecord
* write migration rake task

No view changes

It relates to the following issue #s: 
* Bumps #2072

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
