### PR TITLE
Port clinic finder scss to webpack

### DIFF
--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -8,3 +8,4 @@
 @import '../styles/devise';
 @import '../styles/users';
 @import '../styles/budget_bar';
+@import '../styles/clinic_finder';

--- a/app/javascript/styles/clinic_finder.scss
+++ b/app/javascript/styles/clinic_finder.scss
@@ -1,19 +1,18 @@
-// Place all the styles related to the clinicfinders controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+// Styling related to the clinic finder utility.
+
+@import './_variables';
 
 .clinic_finder_container {
-  background-color: #ccc;
+  background-color: $grey-color;
   border-style: solid;
   border-color: black;
   border-width: thin;
-
 
   .button-right {
     float: right;
   }
   .display_button {
-    color:black;
+    color: black;
     text-decoration: none;
   }
 }


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Move the clinic finders css over to webpacker and out of sprockets. No significant changes necessary to get this to work. I changed a color hexcode to standardize the scheme a bit.

This pull request makes the following changes:
* Port the clinic finder SCSS into webpack

No view changes, as  hex ccc and hex 525252 are similar enough to not be disruptive.

It relates to the following issue #s: 
* Bumps #1854 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
