### PR TITLE
port (most) globals to their own webpacker file

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -25,16 +25,24 @@ $spacers: map-merge(
 );
 
 @import "bootstrap";
-@charset "utf-8";
+
 
 $daria-color: #5D3E8D;
 $grey-color: #525252;
 $font-size: 17px;
 $soft-blue: #23527c;
 $dark-blue: #142B43;
+ 
+// Have to duplicate these globals until we take bootstrap out because of some 
+html {
+  font-size: $font-size;
+}
 
-// Override to the global link style.
-// TODO do this with a bootstrap global, or move it to general styling.
+body {
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: $font-size;
+}
+
 a {
   color: $soft-blue;
   text-decoration: none;
@@ -44,6 +52,7 @@ a:hover, a:active, a:visited, a:focus {
   color: $dark-blue;
   text-decoration: underline;
 }
+// End duplicated styles
 
 //override the bootstrap form-text and btn-danger defaults for accessible color contrast
 .form-text {
@@ -76,12 +85,6 @@ a:hover, a:active, a:visited, a:focus {
   .navbar-text-alt {
     color: $grey-color;
   }
-}
-
-/* GENERAL GLOBAL STYLING */
-body {
-  font-family: 'Source Sans Pro', sans-serif;
-  font-size: $font-size;
 }
 
 .form-error {
@@ -154,12 +157,6 @@ body {
   transition-duration: .5s;
 }
 
-// General styling artifacts
-// make all images responsive by default
-img {
-  @extend .img-fluid;
-  margin: 0 auto;
-  }
 // override for the 'Home' navigation link
 .navbar-brand {
   font-size: inherit;
@@ -185,37 +182,8 @@ img {
 // apply styles to HTML elements
 // to make views framework-neutral
 
-html {
-  font-size: $font-size;
-}
-main {
-  background-color: #ffffff;
-  padding-bottom: 80px;
-  width: 100%;
-  margin-top: 51px; // accommodate the navbar
-}
 
-h1.title {
-  font-weight: 100;
-  margin-bottom: 20px;
-  letter-spacing: 1.5px;
-  font-size: 3rem;
-  span {
-    letter-spacing: .25px;
-  }
-}
-h2 {
-  font-size: 2.215rem;
-}
-h3 {
-  font-size: 1.625rem;
-}
-h4 {
-  font-size: 1.375rem;
-}
-h5 {
-  font-size: 1.125rem;
-}
+
 
 
 // Styles for form views
@@ -270,11 +238,7 @@ $daria-color-lt : #825fb9;
     background-color: $daria-color-lt;
     }
   }
-
 }
-
-
-
 
 .btn-warning {
   color: black;
@@ -362,15 +326,6 @@ $daria-color-lt : #825fb9;
 // TOOLTIPS
 .tooltip-inner {
   font-size: 12px;
-}
-
-// Form styling
-label {
-  font-weight: 700;
-}
-
-form {
-  line-height: 1.0;
 }
 
 // This is necessary because of a vendored multimodal plugin that we should aim to deprecate

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -33,7 +33,8 @@ $font-size: 17px;
 $soft-blue: #23527c;
 $dark-blue: #142B43;
  
-// Have to duplicate these globals until we take bootstrap out because of some 
+// Have to duplicate these globals until we take bootstrap out of sprockets
+// because of some styling clash
 html {
   font-size: $font-size;
 }

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -4,6 +4,7 @@
 
 @import '~bootstrap';
 
+@import '../styles/globals';
 @import '../styles/call_list';
 @import '../styles/devise';
 @import '../styles/users';

--- a/app/javascript/styles/_variables.scss
+++ b/app/javascript/styles/_variables.scss
@@ -9,6 +9,7 @@ $daria-color: #5D3E8D;
 $daria-color-lt : #825fb9;
 $soft-blue: #337ab7;
 $dark-blue: #142B43;
+$link-blue: #23527c;
 $white: #ffffff;
 $black: #000000;
 $phone-icon-blue: #337ab7;

--- a/app/javascript/styles/globals.scss
+++ b/app/javascript/styles/globals.scss
@@ -1,0 +1,74 @@
+// Global styling patterns.
+
+@import './_variables';
+
+@charset "utf-8";
+
+html {
+  font-size: $font-size;
+}
+
+body {
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: $font-size;
+}
+
+main {
+  background-color: #ffffff;
+  padding-bottom: 80px;
+  width: 100%;
+  margin-top: 51px; // accommodate the navbar
+}
+
+// Make all images responsive by default
+img {
+  @extend .img-fluid;
+  margin: 0 auto;
+}
+
+// Headers
+h1.title {
+  font-weight: 100;
+  margin-bottom: 20px;
+  letter-spacing: 1.5px;
+  font-size: 3rem;
+  span {
+    letter-spacing: .25px;
+  }
+}
+
+h2 {
+  font-size: 2.215rem;
+}
+
+h3 {
+  font-size: 1.625rem;
+}
+
+h4 {
+  font-size: 1.375rem;
+}
+
+h5 {
+  font-size: 1.125rem;
+}
+
+// Forms
+form {
+  line-height: 1.0;
+}
+
+label {
+  font-weight: 700;
+}
+
+// Links
+a {
+  color: $link-blue;
+  text-decoration: none;
+}
+
+a:hover, a:active, a:visited, a:focus {
+  color: $dark-blue;
+  text-decoration: underline;
+}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Make a dent in the application.scss file by porting over some of the top-level element styling like html/body/main.

There are a couple spots where this smashes into bootstrap global styles; I figure easiest strategy is to duplicate them for now in both places, mark them as duplicative, and then take them out when we finally remove bootstrap from sprockets. 

This pull request makes the following changes:
* move the global styles out of 
* dupe a few global styles that have to stick around for bootstrap reasons

View diff:

![image](https://user-images.githubusercontent.com/3866868/104996954-cb25a180-59f6-11eb-81d5-b0e3d0bda8dd.png)

(Note that text styling for h1, general text, and link coloring is the same.)

It relates to the following issue #s: 
* Bumps #1854 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
