### PR TITLE
Fix broken links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ git push -u origin main
 ```
 
 ## Project description
-This project is a case management system for the [DC Abortion Fund](http://dcabortionfund.org/) (DCAF), an all-volunteer, 501(c)(3) non-profit organization that gives grants to people in DC, Maryland, and Virginia who cannot afford the full cost of abortion care. Its primary goal is to simplify routine case management processes, such as keeping track of patient data, pledges, and contact information.
+This project is a case management system for the [DC Abortion Fund](https://dcabortionfund.org/) (DCAF), an all-volunteer, 501(c)(3) non-profit organization that gives grants to people in DC, Maryland, and Virginia who cannot afford the full cost of abortion care. Its primary goal is to simplify routine case management processes, such as keeping track of patient data, pledges, and contact information.
 
 Before this app went into production at DCAF, a team of 75 case managers were inputting around 3,500 calls a year into shared Excel sheets. This app replaces that with a nice, clean, useable and shareable rails system that ditches spreadsheets forever! This lets DCAF and other funds continue to operate at a fast pace, and prevents volunteers from getting frustrated with shared Excel sheets.
 
 In addition, other abortion funds doing similar work in other places can adopt this system to their use. It follows DCAF's workflow, but several other abortion funds with similar workflows have also adopted it to great success.
 
-Get started with the how-and-why of the project by [checking out DCAF](http://dcabortionfund.org), checking out [DCAF Case Manager Lisa's explanation of DCAF's business logic](docs/DCAF_101.md), reading the [Code of Conduct](CODE_OF_CONDUCT.md), and reading the `#dcaf_case_management` [channel on Slack](https://codefordc.slack.com/messages/dcaf_case_management/files). You can also check out [some of the other buzz](docs/PRESS.md) or [read about how it's impacted DCAF](docs/IMPACT_ON_DCAF.md).
+Get started with the how-and-why of the project by [checking out DCAF](https://dcabortionfund.org), checking out [DCAF Case Manager Lisa's explanation of DCAF's business logic](docs/DCAF_101.md), reading the [Code of Conduct](CODE_OF_CONDUCT.md), and reading the `#dcaf_case_management` [channel on Slack](https://codefordc.slack.com/messages/dcaf_case_management/files). You can also check out [some of the other buzz](docs/PRESS.md) or [read about how it's impacted DCAF](docs/IMPACT_ON_DCAF.md).
 
 There's still work to do, but generally we're pretty stable these days. Our general administration/maintenance plan is [here](docs/ADMINISTRATION_AND_MAINTENANCE_PLAN.md).
 

--- a/docs/ADMINISTRATION_AND_MAINTENANCE_PLAN.md
+++ b/docs/ADMINISTRATION_AND_MAINTENANCE_PLAN.md
@@ -17,6 +17,6 @@ This roadmap outlines responsibilities for administration of funds in the DCAF-a
 
 ## Getting new funds on DARIA
 
-* The (relatively easy!) instructions for setting up new instances are [here](https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/SETTING_UP_A_NEW_INSTANCE.md#by-the-way)
+* The (relatively easy!) instructions for setting up new instances are [here](https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/administering/SETTING_UP_A_NEW_INSTANCE.md#by-the-way)
 * New funds interested in adopting DARIA will be pointed toward the DARIA project lead, who will work with them to figure out whether or not this software is a good fit.
 * The DARIA project lead will serve as a liaison between the board, engineering team, and the new fund.

--- a/docs/ADOPTING_DARIA.md
+++ b/docs/ADOPTING_DARIA.md
@@ -34,7 +34,7 @@ https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/SECURITY.
 
 Data migration is a manual process using a custom data entry form within DARIA. Funds should migrate data as close to the go-live date as possible. Plan to have a team of volunteers in your fund complete the migration. One person should be able to migrate approximately 200 patients over a weekend.
 
-We have a more comprehensive guide located at: https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/MIGRATING_YOUR_DATA.md
+We have a more comprehensive guide located at: https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/onboarding/MIGRATING_YOUR_DATA.md
 
 ## Costs
 

--- a/docs/HOW_LINES_WORK.md
+++ b/docs/HOW_LINES_WORK.md
@@ -23,7 +23,7 @@ Note that this requires an engineer or someone with heroku access to complete.
 
 ## What this means for engineers
 
-In [config/initializers/env_var_constants.rb](../config/initializers/env_var_constants.rb),
+In [config/initializers/_env_var_constants.rb](../config/initializers/_env_var_constants.rb),
 we set an array of the lines `LINES`. (We default it to the DCAF use case, which operates
 lines for DC, MD, and VA.) It reads from the environment variable `DARIA_LINES` -- this
 value defines the lines for an instance.

--- a/docs/PRESS.md
+++ b/docs/PRESS.md
@@ -6,7 +6,7 @@
 
 2017-07-26 [Tech Meets Abortion Access With the Help of the D.C. Abortion Fund and Abortion Access Hackathon](https://www.themarysue.com/tech-meets-abortion-access/) in the Mary Sue
 
-2017-04-26 [Who Can Afford to Have Sex? (aka Babies)](http://panoply.fm/podcasts/badwithmoney/episodes/11ieZsrbNEO6YM8yMACgWu) in the Bad with Money podcast, discusses the fund and how it works
+2017-04-26 [Who Can Afford to Have Sex? (aka Babies)](https://omny.fm/shows/bad-with-money-with-gaby-dunn/who-can-afford-to-have-sex-aka-babies) in the Bad with Money podcast, discusses the fund and how it works
 
 2017-04-05 [Coding for Abortion Access](http://www.newyorker.com/tech/elements/coding-for-abortion-access) in the New Yorker.
 
@@ -16,4 +16,4 @@
 
 2017-02-01 [Abortion Access Hackathon to Help Find Tech-Based Solutions for Abortion Advocates](http://www.teenvogue.com/story/abortion-access-hackathon-to-help-find-tech-based-solutions-for-abortion-advocates) in Teen Vogue.
 
-2016-09-12 [How we shipped a community-built project for reproductive justice](https://codefordc.org/blog/2016/09/12/code-for-dcaf.html), a post by the team leads on the Code for DC Blog.
+2016-09-12 [How we shipped a community-built project for reproductive justice](https://codefordc.github.io/blog/2016/09/12/code-for-dcaf.html), a post by the team leads on the Code for DC Blog.

--- a/docs/SECURITY_INTRO.md
+++ b/docs/SECURITY_INTRO.md
@@ -43,7 +43,7 @@ If you need to generate a random token, for a reset password email for example, 
 
 #### More reading:
 
-Checkout [this document]( https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) on basic Ruby on Rails security.
+Checkout [this document]( https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/SECURITY.md) on basic Ruby on Rails security.
 
 [Ruby on Rails Security Guide](http://guides.rubyonrails.org/security.html)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -96,4 +96,4 @@ After that:
 
 ## Security
 
-Check out [this document](https://github.com/DCAFEngineering/dcaf_case_management/docs/SECURITY_INTRO.md) on Ruby on Rails security, which contains some guidelines on developing safely. (Note that we review code before merging, so a second human will be checking that things are safe, not just you!)
+Check out [this document](https://github.com/DCAFEngineering/dcaf_case_management/blob/main/docs/SECURITY_INTRO.md) on Ruby on Rails security, which contains some guidelines on developing safely. (Note that we review code before merging, so a second human will be checking that things are safe, not just you!)

--- a/docs/TECH_STACK_INTRO.md
+++ b/docs/TECH_STACK_INTRO.md
@@ -32,8 +32,8 @@ We love tests! All the tests can be found in the test directory, and it's a grea
 
 ## Intro to DCAF!!
 We love our case managers and the UX team that figures out how we can help them be more happy and more efficient. Check out these resources for more context about the hows and whys of this app:
-* [The DCAF website](http://dcabortionfund.org)
-* [DCAF 101](DCAF-101.md), and explanation of how case managers use the app
+* [The DCAF website](https://dcabortionfund.org)
+* [DCAF 101](DCAF_101.md), and explanation of how case managers use the app
 * Join and read through the `#dcaf_case_management` [channel on Slack](https://codefordc.slack.com/messages/dcaf_case_management/files/)
-* Read this [blog post about how we're using agile-ish](http://codefordc.org/blog/2016/09/12/code-for-dcaf.html)
+* Read this [blog post about how we're using agile-ish](https://codefordc.github.io/blog/2016/09/12/code-for-dcaf.html).
 * Read [the README](https://github.com/DCAFEngineering/dcaf_case_management/) (if you haven't already) :sparkling_heart:


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
Fixes broken links identified by https://github.com/tcort/markdown-link-check

It relates to the following issue #s: 
* No issue number, just noticed some broken links as I was preparing to onboard a new fund.

For reviewer:
* Just make sure the links look good!
