### PR TITLE
Explicitly add MONGODB_URI as required config var

### DIFF
--- a/app.json
+++ b/app.json
@@ -53,6 +53,10 @@
       "description": "The PDF Pledge generator only works for DCAF for now",
       "value": "true"
     },
+    "MONGODB_URI": {
+      "description": "Connection string for the MongoDB cluster",
+      "value": ""
+    },
     "RAILS_LOG_TO_STDOUT": {
       "description": "set to true",
       "value": "true"


### PR DESCRIPTION
The application won't be able to connect to the database without setting this variable as part of the dyno creation process. There might be some other code changes needed to create the db, but I'll defer to you for that.