### PR TITLE
Remove an unused method + small unit test improvements

### DIFF
--- a/app/models/concerns/callable.rb
+++ b/app/models/concerns/callable.rb
@@ -13,22 +13,4 @@ module Callable
   def last_call
     calls.order(created_at: :desc).first
   end
-
-  class_methods do
-    def contacted_since(datetime)
-      patients_reached = []
-      all.each do |patient|
-        calls = patient.calls.select { |call| call.status == 'Reached patient' &&
-                                              call.created_at >= datetime }
-        patients_reached << patient if calls.present?
-      end
-
-      # Should we use this or first call?
-      first_contact = patients_reached.select { |patient| patient.initial_call_date >= datetime }
-
-      # hard coding in first_contacts and pledges_sent for now
-      { since: datetime, contacts: patients_reached.length,
-        first_contacts: first_contact.length, pledges_sent: 20 }
-    end
-  end
 end

--- a/test/models/external_pledge_test.rb
+++ b/test/models/external_pledge_test.rb
@@ -30,7 +30,7 @@ class ExternalPledgeTest < ActiveSupport::TestCase
   end
 
   describe 'validations' do
-    [:created_by, :source].each do |field|
+    [:created_by, :source, :amount].each do |field|
       it "should enforce presence of #{field}" do
         @pledge[field.to_sym] = nil
         refute @pledge.valid?
@@ -38,20 +38,20 @@ class ExternalPledgeTest < ActiveSupport::TestCase
     end
 
     it 'should scope source uniqueness to a particular document' do
-      patient = create :patient
-      other_patient = create :patient
-      patients = [patient, other_patient]
+      pledge = @patient.external_pledges
+                       .create attributes_for(:external_pledge,
+                                              amount: 200,
+                                              source: 'BWAH')
+      refute pledge.valid?
 
-      pledge = attributes_for :external_pledge, source: 'Same Fund'
-      other_pledge = attributes_for :external_pledge, source: 'Same Fund', amount: 123
+      pledge.source = 'Other Fund'
+      assert pledge.valid?
 
-      patients.each { |pt| pt.external_pledges.create pledge }
-      patients.each { |pt| assert_equal 1, pt.external_pledges.count }
-
-      invalid_pledge = patient.external_pledges.create other_pledge
-      patient.reload
-      refute patient.external_pledges.include? invalid_pledge
-      assert_equal 1, patient.external_pledges.count
+      pt_2 = create :patient
+      pledge2 = pt_2.external_pledges
+                    .create attributes_for(:external_pledge,
+                                           source: 'BWAH')
+      assert pledge2.valid?
     end
   end
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -400,14 +400,6 @@ class PatientTest < ActiveSupport::TestCase
       end
     end
 
-    describe 'contacted_since method' do
-      it 'should return a hash' do
-        datetime = 5.days.ago
-        hash = { since: datetime, contacts: 1, first_contacts: 1, pledges_sent: 20 }
-        assert_equal hash, Patient.contacted_since(datetime)
-      end
-    end
-
     describe 'destroy_associated_events method' do
       it 'should nuke associated events on patient destroy' do
         assert_difference 'Event.count', -1 do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -312,20 +312,6 @@ class PatientTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'scopes' do
-    before do
-      # DC patients created in initial before block
-      create :patient, line: 'MD'
-      create :patient, line: 'VA'
-    end
-
-    it 'should allow scoping for each line' do
-      assert_equal 2, Patient.dc.count
-      assert_equal 1, Patient.va.count
-      assert_equal 1, Patient.md.count
-    end
-  end
-
   describe 'methods' do
     describe 'urgent patients class method' do
       before do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Two iso'd and severable changed here from larger postgres work.

This pull request makes the following changes:
* `Patient#contacted_since` is no longer in the codebase and the method hasn't been touched in four years, which I'm guessing is when we moved everything to concerns. I can't think of a place where this is used so I think we can nuke it.
* simplifies `ExternalPledgeTest` around uniqueness in fund.
* remove an OBE `PatientTest` around line scoping.

no view changes

It relates to the following issue #s: 
* Bumps #2072  (loosely)

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
