### PR TITLE
handle cases when patients get detached from call list entries

### DIFF
--- a/app/models/call_list_entry.rb
+++ b/app/models/call_list_entry.rb
@@ -17,4 +17,9 @@ class CallListEntry
 
   # Indices
   index line: 1
+
+  def self.destroy_orphaned_entries
+    includes(:patient).reject(&:patient)
+                      .each { |x| x.destroy }
+  end
 end

--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -73,6 +73,7 @@ module CallListable
                      .in(line: line)
                      .order_by(order_key: :asc)
                      .map(&:patient)
+                     .reject(&:nil?)
   end
 
   def recently_reached_by_user?(patient)

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -19,6 +19,9 @@ task nightly_cleanup: :environment do
   MongoidStore::Session.where(:updated_at.lte => 30.days.ago).delete_all  
   puts "#{Time.now} - removed old sessions"
 
+  CallListEntry.destroy_orphaned_entries
+  puts "#{Time.now} - removed orphaned call list entries"
+
   if Time.zone.now.monday?
     # Run these events weekly
     Clinic.update_all_coordinates

--- a/test/models/call_list_entry_test.rb
+++ b/test/models/call_list_entry_test.rb
@@ -37,4 +37,13 @@ class CallListEntryTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'methods' do
+    it 'should nuke call list entries that do not have a patient associated' do
+      @call_list_entry.update patient: nil
+      assert_difference 'CallListEntry.count', -1 do
+        CallListEntry.destroy_orphaned_entries
+      end
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -64,6 +64,11 @@ class UserTest < ActiveSupport::TestCase
       assert_equal 1, @user.call_list_patients('DC').count
     end
 
+    it 'should not fail if a patient gets unattached from the call list' do
+      @user.call_list_entries.where(line: 'DC').first.update patient: nil
+      assert_equal 1, @user.call_list_patients('DC').count
+    end
+
     it 'should clean calls when patient has been reached' do
       assert_equal 0, @user.recently_called_patients('DC').count
       @patient.calls.create attributes_for(:call, created_by: @user, status: 'Reached patient')


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Small unexpected bug around patients being in flight. I have no idea why this happened and why it wasn't handled by callbacks, but worth doing regardless.

This pull request makes the following changes:
* clean orphaned call list 
* add a safety check to pulling order call lists, to filter out anything detached on the spot

no view changes

It relates to the following issue #s: 
* Fixes #2125 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
