### PR TITLE
Unfreeze Gemfile and upgrade Ahab

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -38,9 +38,6 @@ RUN apt-get update && apt-get install yarn -y
 RUN bundle install
 RUN yarn install
 
-# throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
-
 # get version 12 of nodejs
 RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - && \
     apt-get install nodejs -y
@@ -51,7 +48,7 @@ RUN apt-get purge -y ${BUILD_DEPENDENCIES} && apt-get autoremove -y
 # Check docker base image for vulnerable packages, ignore non zero exit code (just informative)
 RUN mkdir /tmp/ahab && \
     cd /tmp/ahab && \
-    curl -o ahab -O -L https://github.com/sonatype-nexus-community/ahab/releases/download/v0.0.8/ahab-linux.amd64-v0.0.8 && \ 
+    curl -o ahab -O -L https://github.com/sonatype-nexus-community/ahab/releases/download/v0.2.3/ahab-linux.amd64-v0.2.3 && \ 
     chmod +x ahab && \
     update-ca-certificates && \
     dpkg-query --show --showformat='${Package} ${Version}\n' | ./ahab chase || true && \


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This unfreezes the Gemfile.lock and upgrades Ahab

This pull request makes the following changes:
* Unfreeze the Gemfile.lock
* Upgrade Ahab

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
