### PR TITLE
optional retry for flaky voicemail test

### DIFF
--- a/test/system/voicemail_preference_in_call_modal_test.rb
+++ b/test/system/voicemail_preference_in_call_modal_test.rb
@@ -2,12 +2,15 @@ require 'application_system_test_case'
 
 # Confirm display behavior around whether a patient should receive VMs
 class VoicemailPreferenceInCallModalTest < ApplicationSystemTestCase
+  extend Minitest::OptionalRetry
+
   before do
     @patient = create :patient, name: 'Susan Everyteen'
     @user = create :user
     log_in_as @user
   end
 
+  # this test is flaky
   describe 'different voicemail preferences and links' do
     describe 'no voicemail' do
       before do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Realized that #2117 is likely the same issue as #2099, so added the same retry fix.

This pull request makes the following changes:
* retries flaky tests in voicemail preferences
 
(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #X
* Bumps #Y

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
