### PR TITLE
change zipcode to string + validate

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -134,7 +134,10 @@ class Patient
   validates_associated :fulfillment
 
   # validation for standard US zipcodes
-  validates :zipcode, format: /\d{5}/, length: {is: 5}, allow_blank: true
+  # allow ZIP (NNNNN) or ZIP+4 (NNNNN-NNNN)
+  validates :zipcode, format: /\A\d{5}(-\d{4})?\z/,
+            length: {minimum: 5, maximum: 10},
+            allow_blank: true
 
   # History and auditing
   track_history on: fields.keys + [:updated_by_id],

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -75,7 +75,7 @@ class Patient
   field :city, type: String
   field :state, type: String
   field :county, type: String
-  field :zipcode, type: Integer
+  field :zipcode, type: String
   field :race_ethnicity, type: String
   field :employment_status, type: String
   field :household_size_children, type: Integer
@@ -132,6 +132,9 @@ class Patient
   validate :pledge_sent, :pledge_info_presence, if: :updating_pledge_sent?
 
   validates_associated :fulfillment
+
+  # validation for standard US zipcodes
+  validates :zipcode, format: /\d{5}/, length: {is: 5}, allow_blank: true
 
   # History and auditing
   track_history on: fields.keys + [:updated_by_id],

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -290,6 +290,9 @@ class Patient
     name.strip! if name
     other_contact.strip! if other_contact
     other_contact_relationship.strip! if other_contact_relationship
+
+    # add dash if needed
+    zipcode.gsub!(/(\d{5})(\d{4})/, '\1-\2') if zipcode
   end
 
   def initialize_fulfillment

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -42,7 +42,8 @@
         </div>
 
         <%= f.text_field :county, autocomplete: 'off' %>
-        <%= f.text_field :zipcode, autocomplete: 'off', pattern: '\d{5}'%>
+        <%= f.text_field :zipcode, autocomplete: 'off',
+                          pattern: '^\d{5}(-?\d{4})?$'%>
 
         <h3><%= t 'patient.information.other_contact.title' %></h3>
         <%= f.text_field :other_contact,

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -43,7 +43,7 @@
 
         <%= f.text_field :county, autocomplete: 'off' %>
         <%= f.text_field :zipcode, autocomplete: 'off',
-                          pattern: '^\d{5}(-?\d{4})?$'%>
+                          pattern: '\d{5}(-?\d{4})?'%>
 
         <h3><%= t 'patient.information.other_contact.title' %></h3>
         <%= f.text_field :other_contact,

--- a/app/views/patients/_patient_information.html.erb
+++ b/app/views/patients/_patient_information.html.erb
@@ -42,7 +42,7 @@
         </div>
 
         <%= f.text_field :county, autocomplete: 'off' %>
-        <%= f.number_field :zipcode, autocomplete: 'off' %>
+        <%= f.text_field :zipcode, autocomplete: 'off', pattern: '\d{5}'%>
 
         <h3><%= t 'patient.information.other_contact.title' %></h3>
         <%= f.text_field :other_contact,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,7 +81,7 @@ Config.create config_key: :start_of_week,
   when 2
     # appointment one week from today && clinic selected
     patient.update! name: 'Clinic and Appt - 2',
-                    zipcode: 20_009,
+                    zipcode: "20009",
                     pronouns: 'she/they',
                     clinic: Clinic.first,
                     appointment_date: 2.days.from_now
@@ -94,7 +94,7 @@ Config.create config_key: :start_of_week,
                     fund_pledge: 100,
                     pledge_sent: true,
                     patient_contribution: 100,
-                    zipcode: 20_005,
+                    zipcode: "06222",
                     pronouns: 'ze/zir',
                     name: 'Pledge submitted - 3'
   when 4
@@ -371,7 +371,7 @@ end
     city: 'Washington',
     state: 'DC',
     county: 'Washington',
-    zipcode: 20_009,
+    zipcode: "20009",
     pronouns: 'they/them',
     other_contact: 'Susie Q.',
     other_phone: "555-6#{patient_number}0-0053",

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -143,6 +143,20 @@ class PatientTest < ActiveSupport::TestCase
       @patient.zipcode = 'Z6B 1A7'
       refute @patient.valid?
 
+      ## zip +4
+      @patient.zipcode = '00000-1111'
+      assert @patient.valid?
+
+      @patient.zipcode = '123456789'
+      assert @patient.valid?
+      assert_equal '12345-6789', @patient.zipcode
+
+      @patient.zipcode = '00000-111'
+      refute @patient.valid?
+
+      @patient.zipcode = '00000-11111'
+      refute @patient.valid?
+
       @patient.zipcode = '12345'
       @patient.save
       assert @patient.valid?

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -133,6 +133,20 @@ class PatientTest < ActiveSupport::TestCase
 
       assert_not_equal error1, error2
     end
+
+    it 'should validate zipcode format' do
+      # wrong len
+      @patient.zipcode = '000'
+      refute @patient.valid?
+
+      # disallowed characters
+      @patient.zipcode = 'Z6B 1A7'
+      refute @patient.valid?
+
+      @patient.zipcode = '12345'
+      @patient.save
+      assert @patient.valid?
+    end
   end
 
   describe 'pledge_summary' do

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -198,7 +198,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
 
       select 'DC', from: 'patient_state'
       fill_in 'County', with: 'Wash'
-      fill_in 'Zipcode', with: '20009'
+      fill_in 'Zipcode', with: '200091002'
       select 'Voicemail OK', from: 'patient_voicemail_preference'
       check 'Textable?'
       wait_for_ajax
@@ -233,7 +233,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'City', with: 'Washington'
         assert_equal 'DC', find('#patient_state').value
         assert has_field? 'County', with: 'Wash'
-        assert has_field? 'Zipcode', with: '20009'
+        assert has_field? 'Zipcode', with: '20009-1002'
         assert_equal 'yes', find('#patient_voicemail_preference').value
         assert has_checked_field?('Textable?')
         assert_equal 'Spanish', find('#patient_language').value


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Patient zipcode field is now a string; validation has been added to prevent issues.

This pull request makes the following changes:
* Changed zipcode datatype
* Added frontend + backend validation
* Added test to the patient model

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2131 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
