### PR TITLE
Swap in `update` for `update_attributes`

### DIFF
--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -33,7 +33,7 @@ class ClinicsController < ApplicationController
   def edit; end
 
   def update
-    if @clinic.update_attributes clinic_params
+    if @clinic.update clinic_params
       flash[:notice] = t('flash.clinic_details_updated')
       redirect_to clinics_path
     else

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -63,7 +63,7 @@ class PatientsController < ApplicationController
 
   def update
     @patient.last_edited_by = current_user
-    if @patient.update_attributes patient_params
+    if @patient.update patient_params
       @patient.reload
       flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
     # i18n-tasks-use t('mongoid.attributes.user.password')
     # i18n-tasks-use t('mongoid.attributes.user.password_confirmation')
     # i18n-tasks-use t('mongoid.attributes.user.role')
-    if @user.update_attributes(user_params)
+    if @user.update user_params
       flash[:notice] = t('flash.user_update_success')
       redirect_to users_path
     else

--- a/test/models/audit_trail_test.rb
+++ b/test/models/audit_trail_test.rb
@@ -24,12 +24,12 @@ class AuditTrailTest < ActiveSupport::TestCase
   describe 'methods' do
     before do
       @clinic = create :clinic
-      @patient.update_attributes name: 'Yolo',
-                                 primary_phone: '123-456-9999',
-                                 appointment_date: Time.zone.now + 10.days,
-                                 city: 'Canada',
-                                 clinic: @clinic,
-                                 special_circumstances: ['A', '', 'C', '']
+      @patient.update name: 'Yolo',
+                      primary_phone: '123-456-9999',
+                      appointment_date: Time.zone.now + 10.days,
+                      city: 'Canada',
+                      clinic: @clinic,
+                      special_circumstances: ['A', '', 'C', '']
       @track = @patient.history_tracks.second
     end
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Pulling this out of the larger mongo -> pg work - Rails is deprecating update_attributes in favor of update per https://github.com/rails/rails/pull/31998 and this takes these out of our codebase in favor of `update`.

This pull request makes the following changes:
* replace `update_attributes` with just `update`

no view changes

It relates to the following issue #s: 
* stems from #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
