### PR TITLE
Load clinic medicaid/naf info on page load rather than through api call

### DIFF
--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -1,6 +1,6 @@
 # Clinic-related functionality.
 class ClinicsController < ApplicationController
-  before_action :confirm_admin_user, except: [:index]
+  before_action :confirm_admin_user
   before_action :find_clinic, only: [:update, :edit]
   rescue_from Mongoid::Errors::DocumentNotFound, with: -> { head :bad_request }
 
@@ -8,7 +8,6 @@ class ClinicsController < ApplicationController
     @clinics = Clinic.all.sort_by { |c| [c.name] }
     respond_to do |format|
       format.html
-      format.json { render json: @clinics }
     end
   end
 

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -117,13 +117,17 @@ module PatientsHelper
                               { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
                             ]}
                             .unshift nil
-    inactive_clinics = clinics.reject(&:active)
-                              .map { |clinic| [
-                                t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: FUND, clinic_name: clinic.name),
-                                clinic.id,
-                                { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
-                              ]}
-                              .unshift ["--- #{t('patient.abortion_information.clinic_section.inactive_clinics').upcase} ---", nil, { disabled: true }]
+    inactive_clinics = if clinics.reject(&:active).count > 0
+                         clinics.reject(&:active)
+                           .map { |clinic| [
+                             t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: FUND, clinic_name: clinic.name),
+                             clinic.id,
+                             { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
+                           ]}
+                           .unshift ["--- #{t('patient.abortion_information.clinic_section.inactive_clinics').upcase} ---", nil, { disabled: true }]
+                       else
+                         []
+                       end
     active_clinics | inactive_clinics
   end
 

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -117,17 +117,18 @@ module PatientsHelper
                               { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
                             ]}
                             .unshift nil
-    inactive_clinics = if clinics.reject(&:active).count > 0
-                         clinics.reject(&:active)
-                           .map { |clinic| [
-                             t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: FUND, clinic_name: clinic.name),
-                             clinic.id,
-                             { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
-                           ]}
-                           .unshift ["--- #{t('patient.abortion_information.clinic_section.inactive_clinics').upcase} ---", nil, { disabled: true }]
-                       else
-                         []
-                       end
+
+    # Map inactives; if there are any, put in a breaker
+    inactive_clinics = clinics.reject(&:active)
+                              .map { |clinic| [
+                                t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: FUND, clinic_name: clinic.name),
+                                clinic.id,
+                                { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
+                              ]}
+    if inactive_clinics.count > 0
+      inactive_clinics.unshift ["--- #{t('patient.abortion_information.clinic_section.inactive_clinics').upcase} ---", nil, { disabled: true }]
+    end
+
     active_clinics | inactive_clinics
   end
 

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -111,11 +111,19 @@ module PatientsHelper
   def clinic_options
     clinics = Clinic.all.sort_by(&:name)
     active_clinics = clinics.select(&:active)
-                            .map { |clinic| [clinic.name, clinic.id] }
+                            .map { |clinic| [
+                              clinic.name,
+                              clinic.id,
+                              { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
+                            ]}
                             .unshift nil
     inactive_clinics = clinics.reject(&:active)
-                              .map { |clinic| [t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: FUND, clinic_name: clinic.name), clinic.id] }
-                              .unshift ["--- #{t('patient.abortion_information.clinic_section.inactive_clinics').upcase} ---", nil]
+                              .map { |clinic| [
+                                t('patient.abortion_information.clinic_section.not_currently_working_with_fund', fund: FUND, clinic_name: clinic.name),
+                                clinic.id,
+                                { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
+                              ]}
+                              .unshift ["--- #{t('patient.abortion_information.clinic_section.inactive_clinics').upcase} ---", nil, { disabled: true }]
     active_clinics | inactive_clinics
   end
 

--- a/app/javascript/src/clinics.js
+++ b/app/javascript/src/clinics.js
@@ -1,24 +1,12 @@
-const getClinics = () => $.get('/clinics', (data, status) => {
-  if (status === 'success') {
-    $.when(data);
-  }
-}, 'json');
-
+// Filter clinics to just whether they accept medicaid/naf
+// when checking boxes in patient edit view, by graying out
+// select options.
 const filterClinicsByNAF = () => {
   const checked = $('#patient_naf_filter').prop('checked');
   $('#patient_clinic_id > option').each((_index, element) => {
     if ($(element).attr('data-naf') === 'false') {
       $(element).attr('disabled', checked);
     }
-  });
-};
-
-const mapNAFtoClinic = (clinics) => {
-  clinics.forEach((clinic) => {
-    // eslint-disable-next-line no-underscore-dangle
-    const id = clinic._id.$oid;
-    const acceptsNAF = clinic.accepts_naf;
-    $(`#patient_clinic_id > option[value='${id}']`).attr('data-naf', acceptsNAF);
   });
 };
 
@@ -31,30 +19,13 @@ const filterClinicsByMedicaid = () => {
   });
 };
 
-const mapMedicaidToClinic = (clinics) => {
-  clinics.forEach((clinic) => {
-    // eslint-disable-next-line no-underscore-dangle
-    const id = clinic._id.$oid;
-    const acceptsMedicaid = clinic.accepts_medicaid;
-    $(`#patient_clinic_id > option[value='${id}']`).attr('data-medicaid', acceptsMedicaid);
-  });
-};
-
 const ready = () => {
   $(document).on('click', '#patient_naf_filter', () => {
-    const attr = $('#patient_clinic_id > option').last().attr('data-naf');
-    if (typeof attr === 'undefined') {
-      return getClinics().then(mapNAFtoClinic).then(filterClinicsByNAF);
-    }
-    return filterClinicsByNAF();
+    filterClinicsByNAF();
   });
 
   $(document).on('click', '#patient_medicaid_filter', () => {
-    const attr = $('#patient_clinic_id > option').last().attr('data-medicaid');
-    if (typeof attr === 'undefined') {
-      return getClinics().then(mapMedicaidToClinic).then(filterClinicsByMedicaid);
-    }
-    return filterClinicsByMedicaid();
+    filterClinicsByMedicaid();
   });
 };
 

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -72,10 +72,12 @@ class PatientsHelperTest < ActionView::TestCase
     end
 
     it 'should return all clinics' do
-      expected_clinic_array = [nil,
-                               [@active.name, @active.id],
-                               ['--- INACTIVE CLINICS ---', nil],
-                               ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id]]
+      expected_clinic_array = [
+        nil,
+       [@active.name, @active.id, { data: { naf: false, medicaid: false }}],
+       ['--- INACTIVE CLINICS ---', nil, { disabled: true }],
+       ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
+     ]
 
       assert_same_elements clinic_options, expected_clinic_array
     end

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -68,16 +68,25 @@ class PatientsHelperTest < ActionView::TestCase
   describe 'clinic options' do
     before do
       @active = create :clinic, name: 'active clinic', active: true
-      @inactive = create :clinic, name: 'closed clinic', active: false
     end
 
     it 'should return all clinics' do
+      @inactive = create :clinic, name: 'closed clinic', active: false
       expected_clinic_array = [
         nil,
-       [@active.name, @active.id, { data: { naf: false, medicaid: false }}],
-       ['--- INACTIVE CLINICS ---', nil, { disabled: true }],
-       ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
-     ]
+        [@active.name, @active.id, { data: { naf: false, medicaid: false }}],
+        ['--- INACTIVE CLINICS ---', nil, { disabled: true }],
+        ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
+      ]
+
+      assert_same_elements clinic_options, expected_clinic_array
+    end
+
+    it 'should skip inactive clinics section if there are not any' do
+      expected_clinic_array = [
+        nil,
+        [@active.name, @active.id, { data: { naf: false, medicaid: false }}]
+      ]
 
       assert_same_elements clinic_options, expected_clinic_array
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Small quality of life improvement here getting extracted from mongo/pg - rather than making an api call and mapping results on checkbox click, do it in view, assign as data attributes, and then read those data attributes on the fly.

This pull request makes the following changes:
* take out the calls to clinics index endpoint
* instead, load up medicaid/naf as data attributes on selects
* for good measure, make it so you can't select the INACTIVE option

no real view changes

It relates to the following issue #s: 
* stems from #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
