### PR TITLE
bump codecov gem to try and kill mysterious build failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,10 +100,8 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     childprocess (3.0.0)
-    codecov (0.2.5)
-      colorize
-      json
-      simplecov
+    codecov (0.4.3)
+      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -122,7 +120,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    docile (1.3.2)
+    docile (1.3.5)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -171,7 +169,6 @@ GEM
     js-routes (1.4.9)
       railties (>= 4)
       sprockets-rails
-    json (2.3.1)
     jwt (2.2.1)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -380,10 +377,12 @@ GEM
       colorize (>= 0.8)
       rails (>= 4)
     shoulda-context (2.0.0)
-    simplecov (0.18.5)
+    simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

CI builds failing on the codecov step - let's see if bumping the lib fixes things

This pull request makes the following changes:
* `bundle update codecov`

no views
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
