### PR TITLE
extract another round of diffs from pg PR

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,13 +4,14 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery prepend: true, with: :exception
 
+  prepend_before_action :authenticate_user!
+  prepend_before_action :confirm_user_not_disabled!, unless: :devise_controller?
+
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :prevent_caching_via_headers
   before_action :set_locale
   before_action :set_raven_context
    # before_action :set_paper_trail_whodunnit # Turn on when user model is in pg 
-   prepend_before_action :authenticate_user!
-  prepend_before_action :confirm_user_not_disabled!, unless: :devise_controller?
 
   # whitelists attributes in devise
   def configure_permitted_parameters

--- a/app/models/concerns/paper_trailable.rb
+++ b/app/models/concerns/paper_trailable.rb
@@ -8,10 +8,18 @@ module PaperTrailable
   end
 
   def created_by
-    versions.first&.actor
+    versions.last&.actor
   end
 
   def created_by_id
     created_by&.id
+  end
+
+  def updated_by
+    versions.first&.actor
+  end
+
+  def updated_by_id
+    updated_by&.id
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,4 +1,4 @@
-# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
 
 en:
   devise:
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: ""
+      unauthenticated: "" # Don't want to display this msg on redirect
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
@@ -23,6 +23,10 @@ en:
         subject: "Reset password instructions"
       unlock_instructions:
         subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
@@ -38,10 +42,11 @@ en:
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
     sessions:
-      signed_in: ""
+      signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
     unlocks:

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -46,7 +46,7 @@ es:
       locked: Tu cuenta está bloqueada.
       not_found_in_database: "%{authentication_keys} o contraseña inválidos."
       timeout: Tu sesión expiró. Por favor, inicia sesión nuevamente para continuar.
-      unauthenticated: Tienes que iniciar sesión o registrarte para poder continuar.
+      unauthenticated: "" # Don't want to display this msg on redirect
       unconfirmed: Tienes que confirmar tu cuenta para poder continuar.
     mailer:
       confirmation_instructions:

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -21,7 +21,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should create and save a new call' do
-      assert_difference 'Patient.find(@patient).calls.count', 1 do
+      assert_difference 'Patient.find(@patient.id).calls.count', 1 do
         post patient_calls_path(@patient), params: { call: @call }, xhr: true
       end
     end
@@ -41,7 +41,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     it 'should not save and flash an error if status is blank or bad' do
       [nil, 'not a real status'].each do |bad_status|
         call = attributes_for :call, status: bad_status
-        assert_no_difference 'Patient.find(@patient).calls.count' do
+        assert_no_difference 'Patient.find(@patient.id).calls.count' do
           post patient_calls_path(@patient), params: { call: call }, xhr: true
         end
         assert_response :bad_request
@@ -49,7 +49,8 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should log the creating user' do
-      assert_equal Patient.find(@patient).calls.last.created_by, @user
+      assert_equal Patient.find(@patient.id).calls.last.created_by,
+                   @user
     end
   end
 
@@ -57,7 +58,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     it 'should destroy a call' do
       @patient.calls.create attributes_for(:call, created_by: @user)
       call = @patient.calls.first
-      assert_difference 'Patient.find(@patient).calls.count', -1 do
+      assert_difference 'Patient.find(@patient.id).calls.count', -1 do
         delete patient_call_path(@patient, call), params: { id: call.id },
                                                   xhr: true
       end
@@ -66,7 +67,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     it 'should not allow user to destroy calls created by others' do
       @patient.calls.create attributes_for(:call, created_by: create(:user))
       call = @patient.calls.first
-      assert_no_difference 'Patient.find(@patient).calls.count' do
+      assert_no_difference 'Patient.find(@patient.id).calls.count' do
         delete patient_call_path(@patient, call), params: { id: call.id },
                                                   xhr: true
       end
@@ -77,7 +78,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
       @patient.calls.create attributes_for(:call, created_by: @user,updated_at: Time.zone.now - 1.day)
       call = @patient.calls.first
 
-      assert_no_difference 'Patient.find(@patient).calls.count' do
+      assert_no_difference 'Patient.find(@patient.id).calls.count' do
         delete patient_call_path(@patient, call), params: { id: call.id },
                                                   xhr: true
       end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -14,7 +14,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should create and save a new note' do
-      assert_difference 'Patient.find(@patient).notes.count', 1 do
+      assert_difference 'Patient.find(@patient.id).notes.count', 1 do
         post patient_notes_path(@patient), params: { note: @note }, xhr: true
       end
     end
@@ -24,12 +24,12 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should log the creating user' do
-      assert_equal Patient.find(@patient).notes.first.created_by, @user
+      assert_equal Patient.find(@patient.id).notes.first.created_by, @user
     end
 
     it 'should alert failure if there is not text or an associated patient' do
       @note[:full_text] = nil
-      assert_no_difference 'Patient.find(@patient).notes.count' do
+      assert_no_difference 'Patient.find(@patient.id).notes.count' do
         post patient_notes_path(@patient), params: { note: @note }, xhr: true
       end
       assert_response :bad_request

--- a/test/controllers/practical_supports_controller_test.rb
+++ b/test/controllers/practical_supports_controller_test.rb
@@ -17,7 +17,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
 
     it 'should create and save a new support record' do
       @support[:support_type] = 'different'
-      assert_difference 'Patient.find(@patient).practical_supports.count', 1 do
+      assert_difference 'Patient.find(@patient.id).practical_supports.count', 1 do
         post patient_practical_supports_path(@patient), params: { practical_support: @support }, xhr: true
       end
     end
@@ -33,7 +33,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should log the creating user' do
-      assert_equal Patient.find(@patient).practical_supports.last.created_by,
+      assert_equal Patient.find(@patient.id).practical_supports.last.created_by,
                    @user
     end
   end
@@ -87,7 +87,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should destroy a support record' do
-      assert_difference 'Patient.find(@patient).practical_supports.count', -1 do
+      assert_difference 'Patient.find(@patient.id).practical_supports.count', -1 do
         delete patient_practical_support_path(@patient, @support), xhr: true
       end
     end

--- a/test/helpers/change_log_helper_test.rb
+++ b/test/helpers/change_log_helper_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class ChangeLogHelperTest < ActionView::TestCase
   describe 'safe_join_fields convenience method' do
     before do
-      pt = create :patient, name: 'Old name'
-      pt.update name: 'New name', city: 'Canada'
-      @changeset = pt.history_tracks.last
+      patient = create :patient, name: 'Old name'
+      patient.update name: 'New name', city: 'Canada'
+      @changeset = patient.history_tracks.last
     end
 
     it 'should work' do

--- a/test/models/call_list_entry_test.rb
+++ b/test/models/call_list_entry_test.rb
@@ -22,7 +22,7 @@ class CallListEntryTest < ActiveSupport::TestCase
       call_list_user = @call_list_entry.user_id
 
       entry = build :call_list_entry, patient_id: call_list_pt,
-                                          user_id: call_list_user
+                                      user_id: call_list_user
       refute entry.valid?
       assert_equal 'Patient is already taken',
                    entry.errors.full_messages.first

--- a/test/models/external_pledge_test.rb
+++ b/test/models/external_pledge_test.rb
@@ -37,7 +37,7 @@ class ExternalPledgeTest < ActiveSupport::TestCase
       end
     end
 
-    it 'should scope source uniqueness to a particular document' do
+    it 'should scope source uniqueness to a patient' do
       pledge = @patient.external_pledges
                        .create attributes_for(:external_pledge,
                                               amount: 200,

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -55,7 +55,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         @patient.update language: 'Spanish'
-          assert_equal @patient.preferred_language, 'Spanish'
+        assert_equal @patient.preferred_language, 'Spanish'
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Some gentle, non-feature-y diffs from the great postgresizing.

This pull request makes the following changes:
* non-essential changes from postgres conversion - lots of cleanup and quality of life changes

no view changes

It relates to the following issue #s: 
* stems from #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
