### PR TITLE
PG: Substitute PaperTrail in for mongo AuditTrail

### DIFF
--- a/app/lib/paper_trail_version.rb
+++ b/app/lib/paper_trail_version.rb
@@ -1,5 +1,7 @@
 # Extensions to base class of PaperTrail.
 class PaperTrailVersion < PaperTrail::Version
+  # Relations
+  belongs_to :user, foreign_key: :whodunnit, optional: true
 
   IRRELEVANT_FIELDS = %w[
     id
@@ -19,43 +21,48 @@ class PaperTrailVersion < PaperTrail::Version
   ].freeze
 
   # convenience methods for clean view display
-  # def date_of_change
-  #   created_at.display_date
-  # end
+  def date_of_change
+    created_at.display_date
+  end
 
-  # def has_changed_fields?
-  #   modified.reject { |x| IRRELEVANT_FIELDS.include? x }.present?
-  # end
+  def has_changed_fields?
+    object_changes.keys.reject { |x| IRRELEVANT_FIELDS.include? x }.present?
+  end
 
-  # def changed_by_user
-  #   actor&.name || 'System'
-  # end
+  def changed_by_user
+    user&.name || 'System'
+  end
 
-  # def shaped_changes
-  #   changeset.reject { |field| IRRELEVANT_FIELDS.include? field }
-  #            .reduce({}) do |acc, x|
-  #              key = x[0]
-  #              acc.merge({ key => { original: format_fieldchange(key, x[1][0]),
-  #                                   modified: format_fieldchange(key, x[1][1]) }})
-  #            end
-  # end
+  def shaped_changes
+    changeset.reject { |field| IRRELEVANT_FIELDS.include? field }
+             .reduce({}) do |acc, x|
+               key = x[0]
+               acc.merge({ key => { original: format_fieldchange(key, x[1][0]),
+                                    modified: format_fieldchange(key, x[1][1]) }})
+             end
+  end
 
-  # private
+  private
 
-  # def format_fieldchange(key, value)
-  #   shaped_value = if value.blank?
-  #                    '(empty)'
-  #                  elsif DATE_FIELDS.include? key
-  #                    value.display_date
-  #                  elsif value.is_a? Array # special circumstances, for example
-  #                    value.reject(&:blank?).join(', ')
-  #                  elsif key == 'clinic_id'
-  #                    Clinic.find(value).name
-  #                  elsif key == 'pledge_generated_by_id'
-  #                    ::User.find(value).name # Use the User model instead of the Userstamp namespace
-  #                  else
-  #                    value
-  #                  end
-  #   shaped_value
-  # end
+  def marked_urgent?
+    object_changes['marked_urgent']&.last == true
+  end
+
+  def format_fieldchange(key, value)
+    shaped_value = if value.blank?
+                     '(empty)'
+                   elsif DATE_FIELDS.include? key
+                     year, month, day = value.split('-')
+                     "#{month.rjust(2, 0)}/#{day.rjust(2, 0)}/#{year}"
+                   elsif value.is_a? Array # special circumstances, for example
+                     value.reject(&:blank?).join(', ')
+                   elsif key == 'clinic_id'
+                     Clinic.find(value).name
+                   elsif key == 'pledge_generated_by_id'
+                     ::User.find(value).name # Use the User model instead of the Userstamp namespace
+                   else
+                     value
+                   end
+    shaped_value
+  end
 end

--- a/app/models/concerns/history_trackable.rb
+++ b/app/models/concerns/history_trackable.rb
@@ -3,10 +3,20 @@ module HistoryTrackable
   extend ActiveSupport::Concern
 
   def assemble_audit_trails
-    history_tracks.includes(:created_by).sort_by(&:created_at).reverse
+    # This is only used in one place and should be killable after we port Patient over
+    if try(:superclass) == ApplicationRecord
+      versions
+    else
+      history_tracks.includes(:created_by).sort_by(&:created_at).reverse
+    end
   end
 
   def recent_history_tracks
-    history_tracks.select { |ht| ht.updated_at > 6.days.ago }
+    if try(:superclass) == ApplicationRecord
+      versions.where(updated_at: 6.days.ago..)
+    else
+      # Mongo compatibility
+      history_tracks.select { |ht| ht.updated_at > 6.days.ago }
+    end
   end
 end

--- a/app/models/concerns/paper_trailable.rb
+++ b/app/models/concerns/paper_trailable.rb
@@ -8,10 +8,18 @@ module PaperTrailable
   end
 
   def created_by
-    versions.first&.actor
+    versions.last&.user
   end
 
   def created_by_id
     created_by&.id
+  end
+
+  def updated_by
+    versions.last&.user
+  end
+
+  def updated_by_id
+    updated_by&.id
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,7 +6,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include IntegrationHelper
   include OmniauthMocker
 
-  before { Capybara.reset_sessions! }
+  before do
+    Capybara.reset_sessions!
+    PaperTrail.enabled = true
+    PaperTrail.request.enabled = true
+  end
+
+  after do
+    PaperTrail.enabled = false
+    PaperTrail.request.enabled = false
+  end
 
   # if in CI, run system tests headlessly.
   browser = ENV['GITHUB_WORKFLOW'] ? :headless_chrome : :chrome

--- a/test/models/paper_trail_version_test.rb
+++ b/test/models/paper_trail_version_test.rb
@@ -72,9 +72,11 @@ class PaperTrailVersionTest < ActiveSupport::TestCase
     end
 
     it "should attach versions to config" do
-      assert @config.versions.count == 1
+      assert_equal 1, @config.versions.count
       assert_difference '@config.versions.count', 1 do
-        @config.update config_value: ['Metallica']
+        with_versioning do
+          @config.update config_value: ['Metallica']
+        end
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We start here by subbing in PaperTrail, the versioning system, for Mongo's AuditTrail.

Tests require a few dependent objects (user and patient specifically) so I did not turn on the tests, but this is as good a place to start as any.

I don't think there's a good way to try this out or otherwise test drive it, so I would recommend reviewing just by looking at the code.

This pull request makes the following changes:
* Remove mongo AuditTrail
* Integrate PaperTrail in as much as we can without having papertrailable stuff yet

no view change

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
