### PR TITLE
Upgrade omniauth-google-oauth2 to 0.8.1, fixes #2141

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - run: bundle exec rake knapsack:minitest
       - run: brakeman --exit-on-warn .
       - run: bundle exec ruby-audit check
-      - run: bundle-audit update; bundle-audit check --ignore CVE-2015-9284
+      - run: bundle-audit update; bundle-audit check
       - run: bundle exec rails zeitwerk:check
       - store_artifacts:
           path: /home/circleci/abortioneering/tmp/capybara/

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,8 @@ gem 'paper_trail', '~> 10.3'
 gem 'paper_trail-globalid'
 
 # Our authentication library is devise, with oauth2 for google signin
-gem 'devise', '~> 4.7'
-gem 'omniauth-google-oauth2', '~> 0.8.0'
+gem 'devise', '~> 4.7.3'
+gem 'omniauth-google-oauth2', '~> 0.8.1'
 
 # We report errors with sentry
 gem 'sentry-raven'

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,9 @@ gem 'paper_trail', '~> 10.3'
 gem 'paper_trail-globalid'
 
 # Our authentication library is devise, with oauth2 for google signin
-gem 'devise', '~> 4.7.3'
+# This is a temporary solution until the new version of devise gets published (current version: 4.7.3)
+# https://github.com/heartcombo/devise/pull/5327
+gem 'devise', github: 'heartcombo/devise', branch: 'master'
 gem 'omniauth-google-oauth2', '~> 0.8.1'
 
 # We report errors with sentry

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'paper_trail-globalid'
 # Our authentication library is devise, with oauth2 for google signin
 gem 'devise', '~> 4.8.0'
 gem 'omniauth-google-oauth2', '~> 0.8.1'
+gem "omniauth-rails_csrf_protection", '~> 1.0'
 
 # We report errors with sentry
 gem 'sentry-raven'

--- a/Gemfile
+++ b/Gemfile
@@ -34,9 +34,7 @@ gem 'paper_trail', '~> 10.3'
 gem 'paper_trail-globalid'
 
 # Our authentication library is devise, with oauth2 for google signin
-# This is a temporary solution until the new version of devise gets published (current version: 4.7.3)
-# https://github.com/heartcombo/devise/pull/5327
-gem 'devise', github: 'heartcombo/devise', branch: 'master'
+gem 'devise', '~> 4.8.0'
 gem 'omniauth-google-oauth2', '~> 0.8.1'
 
 # We report errors with sentry

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'paper_trail', '~> 10.3'
 gem 'paper_trail-globalid'
 
 # Our authentication library is devise, with oauth2 for google signin
-gem 'devise', '~> 4.8.0'
+gem 'devise', '~> 4.8'
 gem 'omniauth-google-oauth2', '~> 0.8.1'
 gem "omniauth-rails_csrf_protection", '~> 1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     ast (2.4.1)
     autoprefixer-rails (10.0.1.0)
       execjs
-    bcrypt (3.1.15)
+    bcrypt (3.1.16)
     bootsnap (1.4.7)
       msgpack (~> 1.0)
     bootstrap (4.5.2)
@@ -114,7 +114,7 @@ GEM
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     database_cleaner (1.8.5)
-    devise (4.7.2)
+    devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -137,8 +137,11 @@ GEM
       railties (>= 5.0.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
-    faraday (1.0.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     ffi (1.13.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
@@ -169,7 +172,7 @@ GEM
     js-routes (1.4.9)
       railties (>= 4)
       sprockets-rails
-    jwt (2.2.1)
+    jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -245,16 +248,18 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.1)
+    omniauth (2.0.3)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-google-oauth2 (0.8.0)
+      rack-protection
+    omniauth-google-oauth2 (0.8.1)
       jwt (>= 2.0)
+      oauth2 (~> 1.1)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.6)
-    omniauth-oauth2 (1.6.0)
-      oauth2 (~> 1.1)
-      omniauth (~> 1.9)
+    omniauth-oauth2 (1.7.1)
+      oauth2 (~> 1.4)
+      omniauth (>= 1.9, < 3)
     orm_adapter (0.5.0)
     paper_trail (10.3.1)
       activerecord (>= 4.2)
@@ -289,6 +294,8 @@ GEM
     rack (2.2.3)
     rack-attack (5.4.2)
       rack (>= 1.0, < 3)
+    rack-protection (2.1.0)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -349,6 +356,7 @@ GEM
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
+    ruby2_keywords (0.0.4)
     ruby_audit (1.3.0)
       bundler-audit (~> 0.7.0)
     ruby_dep (1.5.0)
@@ -410,8 +418,8 @@ GEM
     tzinfo-data (1.2020.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
-    warden (1.2.8)
-      rack (>= 2.0.6)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -443,7 +451,7 @@ DEPENDENCIES
   codecov
   coffee-rails (~> 5.0.0)
   database_cleaner
-  devise (~> 4.7)
+  devise (~> 4.7.3)
   dotenv-rails
   enumerize
   factory_bot_rails
@@ -470,7 +478,7 @@ DEPENDENCIES
   mongoid-history (< 1.0)
   mongoid_userstamp!
   nokogiri (>= 1.11.1)
-  omniauth-google-oauth2 (~> 0.8.0)
+  omniauth-google-oauth2 (~> 0.8.1)
   paper_trail (~> 10.3)
   paper_trail-globalid
   pdf-inspector

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,18 @@ GIT
     mongoid_userstamp (0.4.0)
       mongoid (>= 3.0.4)
 
+GIT
+  remote: https://github.com/heartcombo/devise.git
+  revision: 0cd72a56f984a7ff089246f87a8b259120545edd
+  branch: master
+  specs:
+    devise (4.7.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -114,12 +126,6 @@ GEM
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     database_cleaner (1.8.5)
-    devise (4.7.3)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
     docile (1.3.5)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -451,7 +457,7 @@ DEPENDENCIES
   codecov
   coffee-rails (~> 5.0.0)
   database_cleaner
-  devise (~> 4.7.3)
+  devise!
   dotenv-rails
   enumerize
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,9 @@ GEM
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (1.0.0)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     paper_trail (10.3.1)
       activerecord (>= 4.2)
@@ -479,6 +482,7 @@ DEPENDENCIES
   mongoid_userstamp!
   nokogiri (>= 1.11.1)
   omniauth-google-oauth2 (~> 0.8.1)
+  omniauth-rails_csrf_protection (~> 1.0)
   paper_trail (~> 10.3)
   paper_trail-globalid
   pdf-inspector

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ DEPENDENCIES
   codecov
   coffee-rails (~> 5.0.0)
   database_cleaner
-  devise (~> 4.8.0)
+  devise (~> 4.8)
   dotenv-rails
   enumerize
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,18 +6,6 @@ GIT
     mongoid_userstamp (0.4.0)
       mongoid (>= 3.0.4)
 
-GIT
-  remote: https://github.com/heartcombo/devise.git
-  revision: 0cd72a56f984a7ff089246f87a8b259120545edd
-  branch: master
-  specs:
-    devise (4.7.3)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -126,6 +114,12 @@ GEM
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     database_cleaner (1.8.5)
+    devise (4.8.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
     docile (1.3.5)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -457,7 +451,7 @@ DEPENDENCIES
   codecov
   coffee-rails (~> 5.0.0)
   database_cleaner
-  devise!
+  devise (~> 4.8.0)
   dotenv-rails
   enumerize
   factory_bot_rails

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%#- if devise_mapping.omniauthable? %>
   <%#- resource_class.omniauth_providers.each do |provider| %>
-    <%#= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%#= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
   <%# end -%>
 <%# end -%>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%#- if devise_mapping.omniauthable? %>
   <%#- resource_class.omniauth_providers.each do |provider| %>
-    <%#= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%#= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
   <%# end -%>
 <%# end -%>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* upgrade omniauth-google-oauth2
* upgrade devise
* explicitly add new dependency: [omniauth-rails_csrf_protection](https://github.com/cookpad/omniauth-rails_csrf_protection) (reason: https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0#rails)

It relates to the following issue #s: 
* Fixes #2141 

For reviewer:
* When this is ready, I will remove the `WIP` prefix from the PR title and assign reviewers.
* I will create user accounts for the reviewers on sandbox.
* I will deploy this branch to sandbox, temporarily hijacking the normal release flow for testing purposes.
* Reviewers will try to sign in with Google to confirm that the change works.
