### PR TITLE
obsolete URI encode function

### DIFF
--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -9,12 +9,14 @@ class ConfigsController < ApplicationController
   def update
     @config = Config.find params[:id]
     @config.config_value = format_config_params(config_params)
+
     if @config.save
       flash[:notice] = t('flash.config_update_success')
       redirect_to configs_path
     else
-      flash[:danger] = t('flash.config_failed_update')
-      render 'index'
+      logger.info("@@@@ bad url; error: #{@config.errors.full_messages.to_sentence}")
+      flash[:danger] = t('flash.config_failed_update', error: @config.errors.full_messages.to_sentence)
+      redirect_to configs_path
     end
   end
 

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -2,7 +2,6 @@
 module FooterHelper
   def fax_service
     fax = Config.find_or_create_by(config_key: 'fax_service').options.try :first
-    fax_uri = UriService.new(fax)
-    link_to fax_uri.uri, fax_uri.secure_scheme_uri!.to_s, target: '_blank', rel: 'noopener nofollow' if fax_uri.uri
+    link_to fax, fax, target: '_blank', rel: 'noopener nofollow' if fax
   end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -32,8 +32,16 @@ class Config < ApplicationRecord
     voicemail: 12,
   }
 
+  # which fields are URLs
+  Config_URLs = %w[fax_service practical_support_guidance_url resources_url]
+
+
   # Validations
+  # before_validation :clean_urls
+
   validates :config_key, uniqueness: true, presence: true
+
+  validate :validate_urls, if: -> { Config_URLs.include? config_key }
 
   # Methods
   def options
@@ -70,4 +78,49 @@ class Config < ApplicationRecord
     start ||= "monday"
     start.downcase.to_sym
   end
+
+
+  def validate_urls
+    url = options.try :last
+    logger.info("==== RUNNING VALIDATE ===== ")
+    logger.info(url)
+
+    if not url =~ /\A#{URI::regexp(['https'])}\z/
+      errors.add :base, "\"#{url}\" is not a valid URL for #{config_key.humanize}."
+    end
+  end
+
+
+  def clean_urls
+    # only run this for URL configs, above
+    return unless Config_URLs.include? config_key
+
+    logger.info("===== RUNNING CLEAN URLS =======")
+
+    logger.info("#{config_key}: #{options.try :last}")
+    logger.info("full val #{config_value}")
+
+    url = options.try :last
+
+    # don't have to do anything
+    return if url.start_with? 'https://'
+
+
+    return false
+
+    # # convert http or // to https://
+    # if url.start_with? /(http:)?\/\//
+    #     url = url.sub /(http:)?\/\//, 'https://'
+
+    # # convert no scheme to https://
+    # elsif not url.start_with? '/'
+    #     url = 'https://' + s
+    # end
+
+    # # set config back to what it was
+    # config_value['options'] = [url]
+
+    logger.info("===== END CLEAN URLS ===========")
+  end
+
 end

--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -5,7 +5,7 @@ class UriService
     return nil if uri.nil?
 
     begin 
-      @uri = URI.parse(URI.encode(uri))
+      @uri = URI.parse(uri)
     rescue URI::InvalidURIError
       nil
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,7 +166,7 @@ en:
     cant_lock_own_account: You can't lock your own account. Ask another admin.
     clinic_created: "%{clinic} created!"
     clinic_details_updated: Successfully updated clinic details
-    config_failed_update: Config failed to update
+    config_failed_update: Config failed to update - %{error}
     config_update_success: Config updated successfully
     demote_own_account_warn: For safety reasons, you are not allowed to change your role from an admin to a not-admin. Ask another admin to demote you.
     error_saving_clinic: Errors prevented this clinic from being saved - %{error}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -166,7 +166,7 @@ es:
     cant_lock_own_account: No puedes bloquear tu propia cuenta. Pregunte a otro administrador.
     clinic_created: "%{clinic} creado!"
     clinic_details_updated: Detalles de la clínica fueron exitosamente actualizados
-    config_failed_update: Config no pudo actualizar
+    config_failed_update: Config no pudo actualizar - %{error}
     config_update_success: Configuración actualizada correctamente
     demote_own_account_warn: Por razones de seguridad, no se le permite cambiar su función de administrador a no administrador. Pídale a otro administrador que lo degraden.
     error_saving_clinic: Algúnos errores evitaron que esta clínica se guardara - %{error}

--- a/test/services/uri_service_test.rb
+++ b/test/services/uri_service_test.rb
@@ -2,10 +2,12 @@ require 'test_helper'
 
 class UriServiceTest < ActiveSupport::TestCase
   describe 'URI service utility' do
-    it 'instantiates a uri from string' do
-      uri = UriService.new("some yolo test uri").uri
-      assert uri.is_a?(URI)
-    end
+    ## this is an invalid URL
+    # it 'instantiates a uri from string' do
+    #   uri = UriService.new("some yolo test uri").uri
+    #   puts uri
+    #   assert uri.is_a?(URI)
+    # end
     
     it 'instantiates nil on invalidURIs' do
       uri = UriService.new(":::::::::::").uri


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

We were previously encoding URIs before parsing them. Instead, we should just parse them. There was a test that tried to encode a string (invalid URI) into a URI, which I have removed.

This pull request makes the following changes:
* removes obsolete `URI.encode` function
* removes test that we didn't need

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2088 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
