### PR TITLE
turned list of options into a select!

### DIFF
--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -13,13 +13,9 @@
   <div class="col" id="<%= config.config_key.to_s %>_options_list">
     <% if Config::HELP_TEXT_OVERRIDES[config.config_key.to_sym] %>
     <% else %>
-      <label><%= t('configs.config.current_options') %></label>
-      <br />
-      <select>
-        <% public_send("#{config.config_key}_options").compact.each do |opt| %>
-          <option><%= opt.is_a?(Array) ? opt[0] : opt %></option>
-        <% end %>
-      </select>
+      <%= bootstrap_form_with model: config, inline: true, local: true do |f| %>
+        <%= f.select t('configs.config.current_options'), public_send("#{config.config_key}_options").compact %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -15,9 +15,11 @@
     <% else %>
       <label><%= t('configs.config.current_options') %></label>
       <br />
-      <% public_send("#{config.config_key}_options").each do |opt| %>
-        <%= opt %><br />
-      <% end %>
+      <select>
+        <% public_send("#{config.config_key}_options").compact.each do |opt| %>
+          <option><%= opt.is_a?(Array) ? opt[0] : opt %></option>
+        <% end %>
+      </select>
     <% end %>
   </div>
 </div>

--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -14,7 +14,10 @@
     <% if Config::HELP_TEXT_OVERRIDES[config.config_key.to_sym] %>
     <% else %>
       <%= bootstrap_form_with model: config, inline: true, local: true do |f| %>
-        <%= f.select t('configs.config.current_options'), public_send("#{config.config_key}_options").compact %>
+        <%= f.select :current, 
+              public_send("#{config.config_key}_options").compact,
+              { label: t('configs.config.current_options') },
+              { id: "current_options_#{config.config_key}" }  %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Rather than display config options as a list with weird arrays, now display them as selects.

This pull request makes the following changes:
* Displays options as a dropdown, not a text-list of items.
* For arrays (of the form `[display, internal]`) show only the first element. We don't care about internal representation here.
* Ignore `nil` elements (some fields allow empty values, but we don't need to show that here). 

For reference, this is what the new view code is:

```html
<div class="col" id="language_options_list">
      <label>Current options are:</label>
      <br>
      <select>
          <option>English</option>
          <option>Spanish</option>
          <option>French</option>
          <option>Korean</option>
      </select>
  </div>
```

(before it was just each option separated by `<br/>`)

Screenshot:

![Screen Shot 2021-03-11 at 21 30 08](https://user-images.githubusercontent.com/7085805/110883221-20708780-82b1-11eb-9796-c1cf156cc720.png)

It relates to the following issue #s: 
* Fixes #1990 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.

