### PR TITLE
Updated URL handling in Configs

### DIFF
--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -9,12 +9,14 @@ class ConfigsController < ApplicationController
   def update
     @config = Config.find params[:id]
     @config.config_value = format_config_params(config_params)
+
     if @config.save
       flash[:notice] = t('flash.config_update_success')
       redirect_to configs_path
     else
-      flash[:danger] = t('flash.config_failed_update')
-      render 'index'
+      logger.info("@@@@ bad url; error: #{@config.errors.full_messages.to_sentence}")
+      flash[:danger] = t('flash.config_failed_update', error: @config.errors.full_messages.to_sentence)
+      redirect_to configs_path
     end
   end
 

--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -14,7 +14,6 @@ class ConfigsController < ApplicationController
       flash[:notice] = t('flash.config_update_success')
       redirect_to configs_path
     else
-      logger.info("@@@@ bad url; error: #{@config.errors.full_messages.to_sentence}")
       flash[:danger] = t('flash.config_failed_update', error: @config.errors.full_messages.to_sentence)
       redirect_to configs_path
     end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -2,6 +2,7 @@
 module FooterHelper
   def fax_service
     fax = Config.find_or_create_by(config_key: 'fax_service').options.try :first
-    link_to fax, fax, target: '_blank', rel: 'noopener nofollow' if fax
+    fax_uri = UriService.new(fax)
+    link_to fax_uri.uri, fax_uri.secure_scheme_uri!.to_s, target: '_blank', rel: 'noopener nofollow' if fax_uri.uri
   end
 end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -2,7 +2,6 @@
 module FooterHelper
   def fax_service
     fax = Config.find_or_create_by(config_key: 'fax_service').options.try :first
-    fax_uri = UriService.new(fax)
-    link_to fax_uri.uri, fax_uri.secure_scheme_uri!.to_s, target: '_blank', rel: 'noopener nofollow' if fax_uri.uri
+    link_to fax, fax, target: '_blank', rel: 'noopener nofollow' if fax
   end
 end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -3,6 +3,6 @@ module FooterHelper
   def fax_service
     fax = Config.find_or_create_by(config_key: 'fax_service').options.try :first
     fax_uri = UriService.new(fax)
-    link_to fax_uri.uri, fax_uri.secure_scheme_uri!.to_s, target: '_blank', rel: 'noopener nofollow' if fax_uri.uri
+    link_to fax_uri.uri, fax_uri.uri.to_s, target: '_blank', rel: 'noopener nofollow' if fax_uri.uri
   end
 end

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -1,9 +1,12 @@
 module NavbarHelper
   def cm_resources_link
-    url = Config.find_or_create_by(config_key: 'resources_url').options.first
+    maybe_url = Config.find_or_create_by(config_key: 'resources_url').options.first
+
+    # redundant UriService just for fallbackhelp
+    url = UriService.new(maybe_url).uri
 
     content_tag :li do
-      link_to t('navigation.cm_resources.label'), url, target: '_blank', class: 'nav-link'
+      link_to t('navigation.cm_resources.label'), url.to_s, target: '_blank', class: 'nav-link'
     end if url.present?
   end
 

--- a/app/helpers/practical_supports_helper.rb
+++ b/app/helpers/practical_supports_helper.rb
@@ -31,9 +31,12 @@ module PracticalSupportsHelper
   end
 
   def practical_support_guidance_link
-    url = Config.find_or_create_by(config_key: 'practical_support_guidance_url').options.first
+    maybe_url = Config.find_or_create_by(config_key: 'practical_support_guidance_url').options.first
+
+    url = UriService.new(maybe_url).uri
+
     return unless url.present?
-    link_to t('patient.practical_support.guidance_link', fund: FUND), url, target: '_blank'
+    link_to t('patient.practical_support.guidance_link', fund: FUND), url.to_s, target: '_blank'
     # "For guidance on practical support, view the #{link_content}."
   end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -82,7 +82,7 @@ class Config < ApplicationRecord
     
     url = UriService.new(maybe_url).uri
 
-    if not url
+    if !url
       errors.add :base, "\"#{maybe_url}\" is not a valid URL for #{config_key.humanize}."
     else
       config_value['options'] = [url]

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -81,6 +81,9 @@ class Config < ApplicationRecord
   def validate_urls
     url = options.try :last
 
+    # empty url is allowed
+    return if url.nil?
+
     if not url =~ /\A#{URI::regexp(['https'])}\z/
       errors.add :base, "\"#{url}\" is not a valid URL for #{config_key.humanize}."
     end
@@ -90,7 +93,10 @@ class Config < ApplicationRecord
   def clean_urls
     url = options.try :last
 
-    # don't have to do anything
+    # don't try to clean empty url
+    return if url.nil?
+
+    # don't have to do anything, already https
     return if url.start_with? 'https://'
 
     # convert http or // to https://

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -32,8 +32,16 @@ class Config < ApplicationRecord
     voicemail: 12,
   }
 
+  # which fields are URLs
+  Config_URLs = %w[fax_service practical_support_guidance_url resources_url]
+
+
   # Validations
+  # before_validation :clean_urls
+
   validates :config_key, uniqueness: true, presence: true
+
+  validate :validate_urls, if: -> { Config_URLs.include? config_key }
 
   # Methods
   def options
@@ -70,4 +78,49 @@ class Config < ApplicationRecord
     start ||= "monday"
     start.downcase.to_sym
   end
+
+
+  def validate_urls
+    url = options.try :last
+    logger.info("==== RUNNING VALIDATE ===== ")
+    logger.info(url)
+
+    if not url =~ /\A#{URI::regexp(['https'])}\z/
+      errors.add :base, "\"#{url}\" is not a valid URL for #{config_key.humanize}."
+    end
+  end
+
+
+  def clean_urls
+    # only run this for URL configs, above
+    return unless Config_URLs.include? config_key
+
+    logger.info("===== RUNNING CLEAN URLS =======")
+
+    logger.info("#{config_key}: #{options.try :last}")
+    logger.info("full val #{config_value}")
+
+    url = options.try :last
+
+    # don't have to do anything
+    return if url.start_with? 'https://'
+
+
+    return false
+
+    # # convert http or // to https://
+    # if url.start_with? /(http:)?\/\//
+    #     url = url.sub /(http:)?\/\//, 'https://'
+
+    # # convert no scheme to https://
+    # elsif not url.start_with? '/'
+    #     url = 'https://' + s
+    # end
+
+    # # set config back to what it was
+    # config_value['options'] = [url]
+
+    logger.info("===== END CLEAN URLS ===========")
+  end
+
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -78,6 +78,8 @@ class Config < ApplicationRecord
 
   def validate_urls
     maybe_url = options.last
+    return if maybe_url.blank?
+    
     url = UriService.new(maybe_url).uri
 
     if not url

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -82,7 +82,7 @@ class Config < ApplicationRecord
     url = options.try :last
 
     # empty url is allowed
-    return if url.nil?
+    return if url.blank?
 
     if not url =~ /\A#{URI::regexp(['https'])}\z/
       errors.add :base, "\"#{url}\" is not a valid URL for #{config_key.humanize}."
@@ -94,7 +94,7 @@ class Config < ApplicationRecord
     url = options.try :last
 
     # don't try to clean empty url
-    return if url.nil?
+    return if url.blank?
 
     # don't have to do anything, already https
     return if url.start_with? 'https://'

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -33,7 +33,7 @@ class Config < ApplicationRecord
   }
 
   # which fields are URLs (run special validation only on those)
-  Config_URLs = %w[fax_service practical_support_guidance_url resources_url]
+  CONFIG_URLS = %w[fax_service practical_support_guidance_url resources_url]
 
   # Validations
   validates :config_key, uniqueness: true, presence: true
@@ -76,8 +76,6 @@ class Config < ApplicationRecord
     start ||= "monday"
     start.downcase.to_sym
   end
-
-
   def validate_urls
     url = options.try :last
 

--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -9,7 +9,6 @@ class UriService
 
       if @uri.class == URI::Generic
         # probably missing https. raise error so we can try again
-        @uri = nil
         raise URI::InvalidURIError
       end
 

--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -2,25 +2,34 @@ class UriService
   attr_accessor :uri
 
   def initialize(uri)
-    return nil if uri.nil?
+    return nil if uri.blank?
 
     begin 
       @uri = URI.parse(uri)
+
+      if @uri.class == URI::Generic
+        # probably missing https. raise error so we can try again
+        @uri = nil
+        raise URI::InvalidURIError
+      end
+
     rescue URI::InvalidURIError
-      nil
+      # Maybe we forgot the scheme... try adding
+      begin
+        @uri = URI.parse("https://" + uri)
+      rescue URI::InvalidURIError
+        # nope!
+        @uri = nil
+        return
+      end
     end
+
+    # force https
+    secure_scheme_uri!
   end
 
   def secure_scheme_uri!
-    fix_leading_slashes
     @uri.scheme = "https"
-    @uri
-  end
-
-  def fix_leading_slashes
-    if @uri.scheme.nil? && @uri.host.nil? && @uri.path.present?
-      @uri.host = @uri.path
-      @uri.path = ""
-    end
+    return @uri
   end
 end

--- a/app/services/uri_service.rb
+++ b/app/services/uri_service.rb
@@ -5,7 +5,7 @@ class UriService
     return nil if uri.nil?
 
     begin 
-      @uri = URI.parse(URI.encode(uri))
+      @uri = URI.parse(uri)
     rescue URI::InvalidURIError
       nil
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,7 +166,7 @@ en:
     cant_lock_own_account: You can't lock your own account. Ask another admin.
     clinic_created: "%{clinic} created!"
     clinic_details_updated: Successfully updated clinic details
-    config_failed_update: Config failed to update
+    config_failed_update: Config failed to update - %{error}
     config_update_success: Config updated successfully
     demote_own_account_warn: For safety reasons, you are not allowed to change your role from an admin to a not-admin. Ask another admin to demote you.
     error_saving_clinic: Errors prevented this clinic from being saved - %{error}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -166,7 +166,7 @@ es:
     cant_lock_own_account: No puedes bloquear tu propia cuenta. Pregunte a otro administrador.
     clinic_created: "%{clinic} creado!"
     clinic_details_updated: Detalles de la clínica fueron exitosamente actualizados
-    config_failed_update: Config no pudo actualizar
+    config_failed_update: Config no pudo actualizar - %{error}
     config_update_success: Configuración actualizada correctamente
     demote_own_account_warn: Por razones de seguridad, no se le permite cambiar su función de administrador a no administrador. Pídale a otro administrador que lo degraden.
     error_saving_clinic: Algúnos errores evitaron que esta clínica se guardara - %{error}

--- a/test/helpers/navbar_helper_test.rb
+++ b/test/helpers/navbar_helper_test.rb
@@ -6,7 +6,7 @@ class NavbarHelperTest < ActionView::TestCase
   describe 'cm_resources_link' do
     before do
       @config = create :config, config_key: 'resources_url',
-                                config_value: { options: ['https://www.google.com'] }
+                                config_value: { options: ['http://www.google.com'] }
     end
 
     it 'should return nil if config is not set' do

--- a/test/helpers/practical_supports_helper_test.rb
+++ b/test/helpers/practical_supports_helper_test.rb
@@ -113,7 +113,7 @@ class PracticalSupportsHelperTest < ActionView::TestCase
   describe 'practical_support_guidance_link' do
     before do
       @config = create :config, config_key: :practical_support_guidance_url,
-                                config_value: { options: ['https://www.yahoo.com'] }
+                                config_value: { options: ['www.yahoo.com'] }
     end
 
     it 'should return nil if config is not set' do

--- a/test/services/uri_service_test.rb
+++ b/test/services/uri_service_test.rb
@@ -27,9 +27,16 @@ class UriServiceTest < ActiveSupport::TestCase
     end
 
     it 'can enforce leading slashes while enforcing scheme' do
+      # add scheme
       u = UriService.new("www.noleadingslashesurl.com")
      
-      assert_equal u.secure_scheme_uri!.to_s, "https://www.noleadingslashesurl.com"
+      assert_equal "https://www.noleadingslashesurl.com", u.uri.to_s
+      assert_equal "https", u.uri.scheme
+
+      # convert http to https
+      u = UriService.new("http://unsafe.biz/path")
+
+      assert_equal u.uri.to_s, "https://unsafe.biz/path"
       assert_equal u.uri.scheme, "https"
     end
   end

--- a/test/services/uri_service_test.rb
+++ b/test/services/uri_service_test.rb
@@ -2,16 +2,17 @@ require 'test_helper'
 
 class UriServiceTest < ActiveSupport::TestCase
   describe 'URI service utility' do
-    ## this is an invalid URL
-    # it 'instantiates a uri from string' do
-    #   uri = UriService.new("some yolo test uri").uri
-    #   puts uri
-    #   assert uri.is_a?(URI)
-    # end
+    it 'instantiates a uri from string' do
+      uri = UriService.new("example.net").uri
+      assert uri.is_a?(URI)
+    end
     
     it 'instantiates nil on invalidURIs' do
       uri = UriService.new(":::::::::::").uri
       assert_nil uri
+
+      uri = UriService.new("some yolo test uri").uri
+      refute uri.is_a?(URI)
     end
 
     it 'instantiates nil on nil' do
@@ -22,8 +23,6 @@ class UriServiceTest < ActiveSupport::TestCase
     it 'can force the scheme to use https' do
       u = UriService.new("http://www.someyolourl.com")
 
-      assert_equal u.uri.scheme, "http"
-      assert_equal u.secure_scheme_uri!.to_s, "https://www.someyolourl.com"
       assert_equal u.uri.scheme, "https"
     end
 

--- a/test/services/uri_service_test.rb
+++ b/test/services/uri_service_test.rb
@@ -2,10 +2,12 @@ require 'test_helper'
 
 class UriServiceTest < ActiveSupport::TestCase
   describe 'URI service utility' do
-    it 'instantiates a uri from string' do
-      uri = UriService.new("some yolo test uri").uri
-      assert uri.is_a?(URI)
-    end
+    ## this is an invalid URL
+    # it 'instantiates a uri from string' do
+    #   uri = UriService.new("some yolo test uri").uri
+    #   puts uri
+    #   assert uri.is_a?(URI)
+    # end
     
     it 'instantiates nil on invalidURIs' do
       uri = UriService.new(":::::::::::").uri

--- a/test/system/updating_configs_test.rb
+++ b/test/system/updating_configs_test.rb
@@ -160,7 +160,7 @@ class UpdatingConfigsTest < ApplicationSystemTestCase
 
     describe 'updating a config - fax service' do
       it 'should update and be available in the footer' do
-        fill_in 'config_options_fax_service', with: 'https://metallicarules.com'
+        fill_in 'config_options_fax_service', with: 'metallicarules.com'
         click_button 'Update options for Fax service'
 
         assert_equal 'https://metallicarules.com',


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Config URLs were previously not being handled in a super reliable way. Only `fax service` had any validation whatsoever, using the `UriService` class. I have revamped the URL validation (to do it at config-save time, rather than page-render time) and added it to all URLs.

This pull request makes the following changes:
* Removes usage of `UriService` (can probably delete this file)
* Adds a validator in the Config model for all fields that are tagged as URLs, using the built-in Ruby URI class.
* Converts all URLs into `https://`, and tries to add schemes to schemeless URLs (i.e. you can enter `www.example.com`, which is _technically_ not a valid URL, and makes it `https://www.example.com`.

It relates to the following issue #s: 
* Fixes #2088  and #2153 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
