### PR TITLE
update mime gem to avoid a rails left-pad style mess

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Colin Fleming <c3flemin@gmail.com>
 # configure environment variable
 # note: move this to three ARG commands when CircleCI updates their docker
 ENV DCAF_DIR=/usr/src/app \
-    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig postgresql libpq-dev" \
+    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig postgresql libpq-dev shared-mime-info" \
     APP_DEPENDENCIES="nodejs yarn git sudo sassc" \
     AHAB_DEPENDENCIES="ca-certificates curl" \
     FONTCONFIG_PATH=/etc/fonts \

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ gem 'js-routes' # Not sure if this is used anymore
 gem 'loofah', '>= 2.3.1'
 gem 'rails-html-sanitizer', '>= 1.0.4'
 
+# Stuff hardsetting because of a rails dependency mess
+gem 'mimemagic', '>= 0.3.7'
+
 group :development do
   gem 'i18n-tasks', '~> 0.9.29' # check and clean i18n keys
   gem 'rails-i18n', '~> 6.0' # dependency of i18n-tasks, hardset to a rails-6-compat version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,8 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.8)
+      nokogiri (~> 1)
     mini_backtrace (0.1.3)
       minitest (> 1.2.0)
       rails (>= 2.3.3)
@@ -462,6 +463,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   loofah (>= 2.3.1)
+  mimemagic (>= 0.3.7)
   mini_backtrace
   minitest-ci
   minitest-optional_retry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     links:
       - db
       - pg
+      - webpacker
     environment:
       mongohost: db
       pg_url: postgres://postgres:postgres@pg

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -50,7 +50,8 @@ If you prefer a local environment, totally cool! We recommend the following:
 ### Zeroth, system dependencies
 * Install:
   * Git, python2, & openssl-dev
-  * Ubuntu: `sudo apt install git python2 openssl libssl-dev`
+  * Ubuntu: `sudo apt install git python2 openssl libssl-dev shared-mime-info`
+  * Mac: `brew install git python2 openssl shared-mime-info`
 
 ### First, ruby dependencies
 * Make sure you have a ruby version manager installed; we recommend either [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/).


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This happened: https://dev.to/cseeman/what-s-up-with-mimemagic-breaking-everything-he1 
and as a result the mimemagic version we were on got yanked. This moves to a version that exists. The version that exists unfortunately requires pulling in an external dependency, so we adjust the setup instructions too.

This pull request makes the following changes:
* `bundle update mimemagic`
* adjusts setup instructions / dockerfile to add an extra dependency

no view changes

fixes #2154 along the way 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
