### PR TITLE
move shared mime info

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Colin Fleming <c3flemin@gmail.com>
 # configure environment variable
 # note: move this to three ARG commands when CircleCI updates their docker
 ENV DCAF_DIR=/usr/src/app \
-    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig postgresql libpq-dev shared-mime-info" \
-    APP_DEPENDENCIES="nodejs yarn git sudo sassc" \
+    BUILD_DEPENDENCIES="build-essential libxml2-dev gnupg2 libxslt-dev fontconfig postgresql libpq-dev" \
+    APP_DEPENDENCIES="nodejs yarn git sudo sassc shared-mime-info" \
     AHAB_DEPENDENCIES="ca-certificates curl" \
     FONTCONFIG_PATH=/etc/fonts \
     NODE_ENV=development \


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

`shared-mime-info` needs to be an APP dependency not BUILD, in dockerfile.

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #2158 
* Bumps #Y

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
