### PR TITLE
PG: port patient model

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -3,7 +3,7 @@ class PatientsController < ApplicationController
   before_action :confirm_admin_user, only: [:destroy]
   before_action :confirm_data_access, only: [:index]
   before_action :find_patient, only: [:edit, :update, :download, :destroy]
-  rescue_from Mongoid::Errors::DocumentNotFound,
+  rescue_from ActiveRecord::DocumentNotFound,
               with: -> { redirect_to root_path }
 
   def index
@@ -54,9 +54,9 @@ class PatientsController < ApplicationController
   end
 
   def edit
-    # i18n-tasks-use t('mongoid.attributes.practical_support.confirmed')
-    # i18n-tasks-use t('mongoid.attributes.practical_support.source')
-    # i18n-tasks-use t('mongoid.attributes.practical_support.support_type')
+    # i18n-tasks-use t('activerecord.attributes.practical_support.confirmed')
+    # i18n-tasks-use t('activerecord.attributes.practical_support.source')
+    # i18n-tasks-use t('activerecord.attributes.practical_support.support_type')
     @note = @patient.notes.new
     @external_pledge = @patient.external_pledges.new
   end
@@ -80,7 +80,6 @@ class PatientsController < ApplicationController
 
   def data_entry_create
     @patient = Patient.new patient_params
-    @patient.created_by = current_user
 
     if @patient.save
       flash[:notice] = t('flash.patient_save_success', patient: @patient.name, fund: FUND)

--- a/app/helpers/change_log_helper.rb
+++ b/app/helpers/change_log_helper.rb
@@ -10,7 +10,7 @@ module ChangeLogHelper
   # Map changelog entries to a html string
   def changelog_entry_display(shaped_changes)
     shaped_changes.map do |entry|
-      field = t("mongoid.attributes.patient.#{entry[0]}")
+      field = t("activerecord.attributes.patient.#{entry[0]}")
       field = content_tag('strong') { "#{field}:" }.freeze
       orig = entry[1][:original]
       separator = '->'.freeze

--- a/app/models/concerns/patient_searchable.rb
+++ b/app/models/concerns/patient_searchable.rb
@@ -7,62 +7,20 @@ module PatientSearchable
   class_methods do
     # Case insensitive and phone number format agnostic!
     def search(name_or_phone_str, lines = LINES)
-      # lines should be an array of symbols
-      name_regexp = /#{Regexp.escape(name_or_phone_str)}/i
+      wildcard_name = "%#{name_or_phone_str}%"
       clean_phone = name_or_phone_str.gsub(/\D/, '')
-      phone_regexp = /#{Regexp.escape(clean_phone)}/
-      identifier_regexp = /#{Regexp.escape(name_or_phone_str)}/i
 
-      all_matching_names = find_name_matches name_regexp, lines
-      all_matching_phones = find_phone_matches phone_regexp, lines
-      all_matching_identifiers = find_identifier_matches(identifier_regexp)
-
-      sort_and_limit_patient_matches(all_matching_names, all_matching_phones, all_matching_identifiers)
-    end
-
-    private
-
-    def sort_and_limit_patient_matches(*matches)
-      all_matches = matches.reduce do |results, matches_of_type|
-        results | matches_of_type
+      base = Patient.where(line: lines)
+      matches = base.where('name ilike ?', wildcard_name)
+                    .or(base.where('other_contact ilike ?', wildcard_name))
+                    .or(base.where('identifier ilike ?'), wildcard_name)
+      if clean_phone.present?
+        clean_phone = "%#{clean_phone}%"
+        matches = matches.or(base.where('primary_phone like ?', clean_phone))
+                         .or(base.where('other_phone like ?', clean_phone))
       end
 
-      all_matches.sort { |a, b|
-        b.updated_at <=> a.updated_at
-      }.first(SEARCH_LIMIT)
-    end
-
-    def find_name_matches(name_regexp, lines = LINES)
-      if nonempty_regexp? name_regexp
-        primary_names = Patient.in(line: lines).where name: name_regexp
-        other_names = Patient.in(line: lines).where other_contact: name_regexp
-        return (primary_names | other_names)
-      end
-      []
-    end
-
-    def find_identifier_matches(identifier_regexp)
-      if nonempty_regexp? identifier_regexp
-        identifier = Patient.where identifier: identifier_regexp
-        return identifier
-      end
-      []
-    end
-
-    def find_phone_matches(phone_regexp, lines = LINES)
-      if nonempty_regexp? phone_regexp
-        primary_phones = Patient.in(line: lines).where(primary_phone: phone_regexp)
-        other_phones = Patient.in(line: lines).where(other_phone: phone_regexp)
-        return (primary_phones | other_phones)
-      end
-      []
-    end
-
-    def nonempty_regexp?(regexp)
-      # Escaped regexes are always present, so check presence
-      # after stripping out standard stuff
-      # (opening stuff to semicolon, closing parenthesis)
-      regexp.to_s.gsub(/^.*:/, '').chop.present?
+      matches.order(updated_at: :desc).limit(SEARCH_LIMIT)
     end
   end
 end

--- a/app/models/concerns/patient_searchable.rb
+++ b/app/models/concerns/patient_searchable.rb
@@ -13,7 +13,7 @@ module PatientSearchable
       base = Patient.where(line: lines)
       matches = base.where('name ilike ?', wildcard_name)
                     .or(base.where('other_contact ilike ?', wildcard_name))
-                    .or(base.where('identifier ilike ?'), wildcard_name)
+                    .or(base.where('identifier ilike ?', wildcard_name))
       if clean_phone.present?
         clean_phone = "%#{clean_phone}%"
         matches = matches.or(base.where('primary_phone like ?', clean_phone))

--- a/app/models/mongo_patient.rb
+++ b/app/models/mongo_patient.rb
@@ -1,7 +1,14 @@
 # Object representing core patient information and demographic data.
-class Patient < ApplicationRecord
-  # Concerns
-  include PaperTrailable
+class MongoPatient
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Userstamp
+  include Mongoid::History::Trackable
+
+  store_in collection: 'patients'
+
+  # The following are concerns, or groupings of domain-related methods
+  # This blog post is a good intro: https://vaidehijoshi.github.io/blog/2015/10/13/stop-worrying-and-start-being-concerned-activesupport-concerns/
   include Urgency
   include Callable
   include Notetakeable
@@ -13,52 +20,119 @@ class Patient < ApplicationRecord
   include Statusable
   include Exportable
   include EventLoggable
+  extend Enumerize
 
-  # Enums
-  enum line: LINES.map { |x| {x.to_sym => x.to_s} }.inject(&:merge)
+  LINES.each do |line|
+    scope line.downcase.to_sym, -> { where(:line.in => [line]) }
+  end
 
-  # Callbacks
   before_validation :clean_fields
   before_save :save_identifier
   before_update :update_pledge_sent_by_sent_at
   before_save :update_fund_pledged_at
   after_create :initialize_fulfillment
   after_update :confirm_still_urgent, if: :urgent_flag?
-  after_update :update_call_list_lines, if: :saved_change_to_line?
+  after_update :update_call_list_lines, if: :line_changed?
   after_destroy :destroy_associated_events
 
   # Relationships
-  has_many :call_list_entries, dependent: :destroy
-  has_many :users, through: :call_list_entries
-  belongs_to :clinic, optional: true
-  has_one :fulfillment, as: :can_fulfill
-  has_many :calls, as: :can_call
-  has_many :external_pledges, as: :can_pledge
-  has_many :practical_supports, as: :can_support
-  has_many :notes
-  belongs_to :pledge_generated_by, class_name: 'User', inverse_of: nil, optional: true
-  belongs_to :pledge_sent_by, class_name: 'User', inverse_of: nil, optional: true
-  belongs_to :last_edited_by, class_name: 'User', inverse_of: nil, optional: true
+  has_and_belongs_to_many :users, inverse_of: :patients
+  belongs_to :clinic
+  embeds_one :fulfillment, as: :can_fulfill
+  embeds_many :calls, as: :can_call
+  embeds_many :external_pledges, as: :can_pledge
+  embeds_many :practical_supports, as: :can_support
+  embeds_many :notes
+  belongs_to :pledge_generated_by, class_name: 'User', inverse_of: nil
+  belongs_to :pledge_sent_by, class_name: 'User', inverse_of: nil
+  belongs_to :last_edited_by, class_name: 'User', inverse_of: nil
 
   # Enable mass posting in forms
   accepts_nested_attributes_for :fulfillment
+
+  # Fields
+  # Searchable info
+  field :name, type: String # strip
+  field :primary_phone, type: String
+  field :other_contact, type: String
+  field :other_phone, type: String
+  field :other_contact_relationship, type: String
+  field :identifier, type: String
+
+  # Contact-related info
+  field :voicemail_preference, type: String, default: 'not_specified'
+
+  field :line
+  enumerize :line, in: LINES, default: LINES[0] # See config/initializers/env_vars.rb
+
+  field :language, type: String
+  field :pronouns, type: String
+  field :initial_call_date, type: Date
+  field :urgent_flag, type: Boolean
+  field :last_menstrual_period_weeks, type: Integer
+  field :last_menstrual_period_days, type: Integer
+
+  # Program analysis related or NAF eligibility related info
+  field :age, type: Integer
+  field :city, type: String
+  field :state, type: String
+  field :county, type: String
+  field :zipcode, type: String
+  field :race_ethnicity, type: String
+  field :employment_status, type: String
+  field :household_size_children, type: Integer
+  field :household_size_adults, type: Integer
+  field :insurance, type: String
+  field :income, type: String
+  field :special_circumstances, type: Array, default: []
+  field :referred_by, type: String
+  field :referred_to_clinic, type: Boolean
+  field :completed_ultrasound, type: Boolean
+
+  # Status and pledge related fields
+  field :appointment_date, type: Date
+  field :procedure_cost, type: Integer
+  field :patient_contribution, type: Integer
+  field :naf_pledge, type: Integer
+  field :fund_pledge, type: Integer
+  field :fund_pledged_at, type: Time
+  field :pledge_sent, type: Boolean
+  field :resolved_without_fund, type: Boolean
+  field :pledge_generated_at, type: Time
+  field :pledge_sent_at, type: Time
+  field :textable, type: Boolean
+
+  # Indices
+  index({ primary_phone: 1 }, unique: true)
+  index(other_contact_phone: 1)
+  index(name: 1)
+  index(other_contact: 1)
+  index(urgent_flag: 1)
+  index(line: 1)
+  index(identifier: 1)
 
   # Validations
   validates :name,
             :primary_phone,
             :initial_call_date,
+            :created_by_id,
             :line,
             presence: true
   validates :primary_phone, format: /\d{10}/,
                             length: { is: 10 }
+
   validate :confirm_unique_phone_number
+
   validates :other_phone, format: /\d{10}/,
                           length: { is: 10 },
                           allow_blank: true
   validates :appointment_date, format: /\A\d{4}-\d{1,2}-\d{1,2}\z/,
                                allow_blank: true
+
   validate :confirm_appointment_after_initial_call
+
   validate :pledge_sent, :pledge_info_presence, if: :updating_pledge_sent?
+
   validates_associated :fulfillment
 
   # validation for standard US zipcodes
@@ -67,24 +141,30 @@ class Patient < ApplicationRecord
             length: {minimum: 5, maximum: 10},
             allow_blank: true
 
+  # History and auditing
+  track_history on: fields.keys + [:updated_by_id],
+                version_field: :version,
+                track_create: true,
+                track_update: true,
+                track_destroy: true
+  mongoid_userstamp user_model: 'User'
+
   # Methods
   def self.pledged_status_summary(line)
     plucked_attrs = [:fund_pledge, :pledge_sent, :id, :name, :appointment_date, :fund_pledged_at]
     start_of_period = Config.start_day.downcase.to_s == "monthly" ? Time.zone.today.beginning_of_month.in_time_zone
                                                                   : Time.zone.today.beginning_of_week(Config.start_day).in_time_zone
     # Get patients who have been pledged this week, as a simplified hash
-    base = Patient.where(line: line,
-                         resolved_without_fund: [false, nil])
-                  .where.not(fund_pledge: [0, nil])
-
-    patients = base.where(pledge_sent_at: start_of_period..)
-                   .or(base.where(fund_pledged_at: start_of_period..))
-                   .order(fund_pledged_at: :asc)
-                   .select(*plucked_attrs)
-
+    patients = Patient.in(line: line)
+                      .where(:fund_pledge.nin => [0, nil, ''])
+                      .or({:pledge_sent_at.gte => start_of_period}, {:fund_pledged_at.gte => start_of_period})
+                      .where(:resolved_without_fund.in => [false, nil])
+                      .order_by(fund_pledged_at: :asc)
+                      .pluck(*plucked_attrs)
+                      .map { |att| plucked_attrs.zip(att).to_h }
     # Divide people up based on whether pledges have been sent or not
     patients.each_with_object(sent: [], pledged: []) do |patient, summary|
-      if patient.pledge_sent?
+      if patient[:pledge_sent]
         summary[:sent] << patient
       else
         summary[:pledged] << patient
@@ -103,7 +183,7 @@ class Patient < ApplicationRecord
 
   def event_params
     {
-      event_type:    'pledged',
+      event_type:    :pledged,
       cm_name:       updated_by&.name || 'System',
       patient_name:  name,
       patient_id:    id,
@@ -117,8 +197,8 @@ class Patient < ApplicationRecord
   end
 
   def destroy_associated_events
-    Event.where(patient_id: id).destroy_all
-    CallListEntry.where(patient_id: id).destroy_all
+    Event.where(patient_id: id.to_s).destroy_all
+    CallListEntry.where(patient_id: id.to_s).destroy_all
   end
 
   def update_call_list_lines
@@ -218,7 +298,7 @@ class Patient < ApplicationRecord
   end
 
   def initialize_fulfillment
-    build_fulfillment.save
+    build_fulfillment(created_by_id: created_by_id).save
   end
 
   def update_pledge_sent_by_sent_at

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -15,6 +15,7 @@ class Patient < ApplicationRecord
   include EventLoggable
 
   # Enums
+  # turns the LINES env array into the DB friendly structure: { :line1 => "line1", :line2 => "line2", ... }
   enum line: LINES.map { |x| {x.to_sym => x.to_s} }.inject(&:merge)
 
   # Callbacks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,47 @@ en:
         state: State
         street_address: Street address
         zip: ZIP
+      patient:
+        age: Age
+        appointment_date: Appointment date
+        city: City
+        clinic_id: Clinic_Id
+        completed_ultrasound: Completed ultrasound?
+        county: County
+        employment_status: Employment status
+        fund_pledge: Fund pledge
+        fund_pledged_at: Fund pledged at
+        household_size_adults: Adults in household
+        household_size_children: Minors in household
+        income: Income
+        initial_call_date: Initial call date
+        insurance: Insurance
+        language: Language
+        last_menstrual_period_days: Last menstrual period days
+        last_menstrual_period_weeks: Last menstrual period weeks
+        line: Line
+        naf_pledge: NAF pledge
+        name: Name
+        other_contact: Other contact
+        other_contact_relationship: Other contact relationship
+        other_phone: Other phone
+        patient_contribution: Patient contribution
+        pledge_generated_at: Pledge generated at
+        pledge_sent: Pledge sent
+        pledge_sent_at: Pledge sent at
+        primary_phone: Primary phone
+        procedure_cost: Procedure cost
+        pronouns: Pronouns
+        race_ethnicity: Race / Ethnicity
+        referred_by: Referred by
+        referred_to_clinic: Referred to clinic
+        resolved_without_fund: Resolved without fund
+        special_circumstances: Special circumstances
+        state: State
+        textable: Textable
+        urgent_flag: Urgent flag
+        voicemail_preference: Voicemail preference
+        zipcode: Zipcode
       user:
         current_password: Current password
         email: Email
@@ -214,47 +255,6 @@ en:
       what_line: What line are you working on?
   mongoid:
     attributes:
-      patient:
-        age: Age
-        appointment_date: Appointment date
-        city: City
-        clinic_id: Clinic_Id
-        completed_ultrasound: Completed ultrasound?
-        county: County
-        employment_status: Employment status
-        fund_pledge: Fund pledge
-        fund_pledged_at: Fund pledged at
-        household_size_adults: Adults in household
-        household_size_children: Minors in household
-        income: Income
-        initial_call_date: Initial call date
-        insurance: Insurance
-        language: Language
-        last_menstrual_period_days: Last menstrual period days
-        last_menstrual_period_weeks: Last menstrual period weeks
-        line: Line
-        naf_pledge: NAF pledge
-        name: Name
-        other_contact: Other contact
-        other_contact_relationship: Other contact relationship
-        other_phone: Other phone
-        patient_contribution: Patient contribution
-        pledge_generated_at: Pledge generated at
-        pledge_sent: Pledge sent
-        pledge_sent_at: Pledge sent at
-        primary_phone: Primary phone
-        procedure_cost: Procedure cost
-        pronouns: Pronouns
-        race_ethnicity: Race / Ethnicity
-        referred_by: Referred by
-        referred_to_clinic: Referred to clinic
-        resolved_without_fund: Resolved without fund
-        special_circumstances: Special circumstances
-        state: State
-        textable: Textable
-        urgent_flag: Urgent flag
-        voicemail_preference: Voicemail preference
-        zipcode: Zipcode
       practical_support:
         confirmed: Confirmed
         source: Source

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -29,6 +29,47 @@ es:
         state: Estado
         street_address: Dirección
         zip: Código postal
+      patient:
+        age: Edad
+        appointment_date: Día de la cita
+        city: Ciudad
+        clinic_id: ID de la clínica
+        completed_ultrasound: Ultrasonido completado
+        county: Condado
+        employment_status: Estatus de empleo
+        fund_pledge: Promesa de fondos
+        fund_pledged_at: Fondo prometido en
+        household_size_adults: Adultos en el Hogar
+        household_size_children: Menores en el Hogar
+        income: Ingresos
+        initial_call_date: Fecha de llamada inicial
+        insurance: Seguro médico
+        language: Idioma
+        last_menstrual_period_days: Últimos días del período menstrual
+        last_menstrual_period_weeks: Últimas semanas del período menstrual
+        line: Línea
+        naf_pledge: Promesa de la NAF
+        name: Nombre
+        other_contact: Otro contacto
+        other_contact_relationship: Otra relacion de contacto
+        other_phone: Otro teléfono
+        patient_contribution: Contribución del paciente
+        pledge_generated_at: Promesa generada en
+        pledge_sent: Promeso enviada
+        pledge_sent_at: Promesa enviada en
+        primary_phone: Número de teléfono principal
+        procedure_cost: Costo del procedimiento
+        pronouns: Pronombres
+        race_ethnicity: Raza / Etnicidad
+        referred_by: Referido por
+        referred_to_clinic: Referido a la clínica
+        resolved_without_fund: Resuelto sin ayuda de fondo
+        special_circumstances: Circunstancias Especiales
+        state: Estado
+        textable: Textable
+        urgent_flag: Bandera urgente
+        voicemail_preference: Preferencia de correo de voz
+        zipcode: Código postal
       user:
         current_password: Contraseña actual
         email: Correo Electrónico/Email
@@ -214,47 +255,6 @@ es:
       what_line: "¿En cuál línea estás trabajando?"
   mongoid:
     attributes:
-      patient:
-        age: Edad
-        appointment_date: Día de la cita
-        city: Ciudad
-        clinic_id: ID de la clínica
-        completed_ultrasound: Ultrasonido completado
-        county: Condado
-        employment_status: Estatus de empleo
-        fund_pledge: Promesa de fondos
-        fund_pledged_at: Fondo prometido en
-        household_size_adults: Adultos en el Hogar
-        household_size_children: Menores en el Hogar
-        income: Ingresos
-        initial_call_date: Fecha de llamada inicial
-        insurance: Seguro médico
-        language: Idioma
-        last_menstrual_period_days: Últimos días del período menstrual
-        last_menstrual_period_weeks: Últimas semanas del período menstrual
-        line: Línea
-        naf_pledge: Promesa de la NAF
-        name: Nombre
-        other_contact: Otro contacto
-        other_contact_relationship: Otra relacion de contacto
-        other_phone: Otro teléfono
-        patient_contribution: Contribución del paciente
-        pledge_generated_at: Promesa generada en
-        pledge_sent: Promeso enviada
-        pledge_sent_at: Promesa enviada en
-        primary_phone: Número de teléfono principal
-        procedure_cost: Costo del procedimiento
-        pronouns: Pronombres
-        race_ethnicity: Raza / Etnicidad
-        referred_by: Referido por
-        referred_to_clinic: Referido a la clínica
-        resolved_without_fund: Resuelto sin ayuda de fondo
-        special_circumstances: Circunstancias Especiales
-        state: Estado
-        textable: Textable
-        urgent_flag: Bandera urgente
-        voicemail_preference: Preferencia de correo de voz
-        zipcode: Código postal
       practical_support:
         confirmed: Confirmado
         source: Fuente

--- a/db/migrate/20210410151149_create_patients.rb
+++ b/db/migrate/20210410151149_create_patients.rb
@@ -1,0 +1,69 @@
+class CreatePatients < ActiveRecord::Migration[6.0]
+  def change
+    create_table :patients do |t|
+      t.string :name, null: false
+      t.string :primary_phone, null: false
+      t.string :other_contact
+      t.string :other_phone
+      t.string :other_contact_relationship
+      t.string :identifier
+
+      t.string :voicemail_preference, default: 'not_specified'
+      t.string :line, null: false
+
+      t.string :language
+      t.string :pronouns
+      t.date :initial_call_date, null: false
+      t.boolean :urgent_flag
+      t.integer :last_menstrual_period_weeks
+      t.integer :last_menstrual_period_days
+
+      t.integer :age
+      t.string :city
+      t.string :state
+      t.string :county
+      t.integer :zipcode
+      t.string :race_ethnicity
+      t.string :employment_status
+      t.integer :household_size_children
+      t.integer :household_size_adults
+      t.string :insurance
+      t.string :income
+      t.string :special_circumstances, array: true, default: []
+      t.string :referred_by
+      t.boolean :referred_to_clinic
+      t.boolean :completed_ultrasound
+
+      t.date :appointment_date
+      t.integer :procedure_cost
+      t.integer :patient_contribution
+      t.integer :naf_pledge
+      t.integer :fund_pledge
+      t.datetime :fund_pledged_at
+      t.boolean :pledge_sent
+      t.boolean :resolved_without_fund
+      t.datetime :pledge_generated_at
+      t.datetime :pledge_sent_at
+      t.boolean :textable
+
+      t.references :clinic, foreign_key: true
+      t.references :pledge_generated_by, foreign_key: { to_table: :users }
+      t.references :pledge_sent_by, foreign_key: { to_table: :users }
+      t.references :last_edited_by, foreign_key: { to_table: :users }
+
+      # Scratch field - temporary BSON ID from Mongo so we can link things back
+      t.string :mongo_id
+
+      t.timestamps
+    end
+
+    add_index :patients, :primary_phone, unique: true
+    add_index :patients, :other_phone
+    add_index :patients, :other_contact
+    add_index :patients, :name
+    add_index :patients, :line
+    add_index :patients, :urgent_flag
+    add_index :patients, :identifier
+    add_index :patients, :pledge_sent 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_03_213437) do
+ActiveRecord::Schema.define(version: 2021_04_10_151149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -81,6 +81,68 @@ ActiveRecord::Schema.define(version: 2021_04_03_213437) do
     t.index ["line"], name: "index_events_on_line"
   end
 
+  create_table "patients", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "primary_phone", null: false
+    t.string "other_contact"
+    t.string "other_phone"
+    t.string "other_contact_relationship"
+    t.string "identifier"
+    t.string "voicemail_preference", default: "not_specified"
+    t.string "line", null: false
+    t.string "language"
+    t.string "pronouns"
+    t.date "initial_call_date", null: false
+    t.boolean "urgent_flag"
+    t.integer "last_menstrual_period_weeks"
+    t.integer "last_menstrual_period_days"
+    t.integer "age"
+    t.string "city"
+    t.string "state"
+    t.string "county"
+    t.integer "zipcode"
+    t.string "race_ethnicity"
+    t.string "employment_status"
+    t.integer "household_size_children"
+    t.integer "household_size_adults"
+    t.string "insurance"
+    t.string "income"
+    t.string "special_circumstances", default: [], array: true
+    t.string "referred_by"
+    t.boolean "referred_to_clinic"
+    t.boolean "completed_ultrasound"
+    t.date "appointment_date"
+    t.integer "procedure_cost"
+    t.integer "patient_contribution"
+    t.integer "naf_pledge"
+    t.integer "fund_pledge"
+    t.datetime "fund_pledged_at"
+    t.boolean "pledge_sent"
+    t.boolean "resolved_without_fund"
+    t.datetime "pledge_generated_at"
+    t.datetime "pledge_sent_at"
+    t.boolean "textable"
+    t.bigint "clinic_id"
+    t.bigint "pledge_generated_by_id"
+    t.bigint "pledge_sent_by_id"
+    t.bigint "last_edited_by_id"
+    t.string "mongo_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["clinic_id"], name: "index_patients_on_clinic_id"
+    t.index ["identifier"], name: "index_patients_on_identifier"
+    t.index ["last_edited_by_id"], name: "index_patients_on_last_edited_by_id"
+    t.index ["line"], name: "index_patients_on_line"
+    t.index ["name"], name: "index_patients_on_name"
+    t.index ["other_contact"], name: "index_patients_on_other_contact"
+    t.index ["other_phone"], name: "index_patients_on_other_phone"
+    t.index ["pledge_generated_by_id"], name: "index_patients_on_pledge_generated_by_id"
+    t.index ["pledge_sent"], name: "index_patients_on_pledge_sent"
+    t.index ["pledge_sent_by_id"], name: "index_patients_on_pledge_sent_by_id"
+    t.index ["primary_phone"], name: "index_patients_on_primary_phone", unique: true
+    t.index ["urgent_flag"], name: "index_patients_on_urgent_flag"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "line"
@@ -116,4 +178,8 @@ ActiveRecord::Schema.define(version: 2021_04_03_213437) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "patients", "clinics"
+  add_foreign_key "patients", "users", column: "last_edited_by_id"
+  add_foreign_key "patients", "users", column: "pledge_generated_by_id"
+  add_foreign_key "patients", "users", column: "pledge_sent_by_id"
 end

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -51,6 +51,21 @@ namespace :migrate_to_pg do
         attrs
       end
       migrate_model pg, mongo, extra_transform
+
+      # Then patients
+      pt_model_pair = [[Patient, MongoPatient]]
+      pt_model_pair.each do |pair|
+        pg, mongo = pair
+        extra_transform = Proc.new do |attrs, obj|
+          attrs['mongo_id'] = obj['_id'].to_s
+          attrs['clinic_id'] = Clinic.find_by(mongo_id: obj['clinic_id'].to_s)&.id
+          attrs['pledge_generated_by_id'] = User.find_by(mongo_id: obj['pledge_generated_by_id'].to_s)&.id
+          attrs['pledge_sent_by_id'] = User.find_by(mongo_id: obj['pledge_sent_by_id'].to_s)&.id
+          attrs['last_edited_by_id'] = User.find_by(mongo_id: obj['last_edited_by_id'].to_s)&.id
+          attrs
+        end
+        migrate_model(pg, mongo, extra_transform)
+      end
     end
   end
 end

--- a/test/factories/patient.rb
+++ b/test/factories/patient.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     name { 'New Patient' }
     sequence(:primary_phone, 100) { |n| "127-#{n}-1111" }
     line { 'DC' }
-    created_by { FactoryBot.create(:user) }
     initial_call_date { 2.days.ago }
   end
 end

--- a/test/helpers/change_log_helper_test.rb
+++ b/test/helpers/change_log_helper_test.rb
@@ -3,9 +3,11 @@ require 'test_helper'
 class ChangeLogHelperTest < ActionView::TestCase
   describe 'safe_join_fields convenience method' do
     before do
-      pt = create :patient, name: 'Old name'
-      pt.update name: 'New name', city: 'Canada'
-      @changeset = pt.history_tracks.last
+      with_versioning do
+        patient = create :patient, name: 'Old name'
+        patient.update name: 'New name', city: 'Canada'
+        @changeset = patient.versions.first
+      end
     end
 
     it 'should work' do

--- a/test/models/paper_trail_version_test.rb
+++ b/test/models/paper_trail_version_test.rb
@@ -1,67 +1,72 @@
 require 'test_helper'
 
 class PaperTrailVersionTest < ActiveSupport::TestCase
-  # Most of this behavior is related to user/patient behavior, leaving it commented out for now
-  # before do
-  #   @user = create :user # Can't do this until we port over the user model, for example
-  #   with_versioning do
-  #     PaperTrail.request(whodunnit: @user) do
-  #       @patient = create :patient, name: 'Susie Everyteen',
-  #                                   primary_phone: '111-222-3333',
-  #                                   appointment_date: Time.zone.now + 5.days,
-  #                                   initial_call_date: Time.zone.now + 3.days
-  #     end
-  #   end
-  # end
+  before do
+    @user = create :user # Can't do this until we port over the user model, for example
+    with_versioning do
+      PaperTrail.request(whodunnit: @user.id) do
+        @patient = create :patient, name: 'Susie Everyteen',
+                                    primary_phone: '111-222-3333',
+                                    appointment_date: Time.zone.now + 5.days,
+                                    initial_call_date: Time.zone.now + 3.days
+      end
+    end
+  end
 
-  # describe 'natural initializing - everything okay alarm' do
-  #   it 'should be available on a patient creation' do
-  #     assert_not_nil @patient.versions
-  #     assert_kind_of PaperTrailVersion, @patient.versions.first
-  #   end
+  describe 'natural initializing - everything okay alarm' do
+    it 'should be available on a patient creation' do
+      assert_not_nil @patient.versions
+      assert_kind_of PaperTrailVersion, @patient.versions.first
+    end
 
-  #   it 'should record the creating user' do
-  #     assert_equal @patient.created_by, @user
-  #   end
-  # end
+    it 'should record the creating user' do
+      assert_equal @patient.created_by, @user
+    end
+  end
 
-  # describe 'methods' do
-  #   before do
-  #     with_versioning do
-  #       @clinic = create :clinic
-  #       @patient.update name: 'Yolo',
-  #                       primary_phone: '123-456-9999',
-  #                       appointment_date: Date.today + 10.days,
-  #                       city: 'Canada',
-  #                       clinic: @clinic,
-  #                       special_circumstances: ['A', '', 'C', '']
-  #       @track = @patient.versions.first
-  #     end
-  #   end
+  describe 'methods' do
+    before do
+      with_versioning do
+        @clinic = create :clinic
+        @patient.update name: 'Yolo',
+                        primary_phone: '123-456-9999',
+                        appointment_date: Date.today + 10.days,
+                        city: 'Canada',
+                        clinic: @clinic,
+                        special_circumstances: ['A', '', 'C', '']
+        @track = @patient.versions.first
+      end
+    end
 
-  #   it 'should conveniently render the date' do
-  #     assert_equal Time.zone.now.display_date,
-  #                  @track.date_of_change
-  #   end
+    it 'should conveniently render the date' do
+      assert_equal Time.zone.now.display_date,
+                   @track.date_of_change
+    end
 
-  #   it 'should default to System if it cannot find a user' do
-  #     assert_equal @track.changed_by_user, 'System'
-  #   end
+    it 'should default to System if it cannot find a user' do
+      assert_equal @track.changed_by_user, 'System'
+    end
 
-  #   # TODO test has_changed_fields?
-  #   # TODO test date_of_change
+    it 'should know whether the actual changed fields are relevant' do
+      assert @track.has_changed_fields?
+      @track.object_changes = {
+        "updated_at" => [1.day.ago, Time.zone.now],
+        "identifier" => "D1-1111"
+      }
+      refute @track.has_changed_fields?
+    end
 
-  #   it 'should return shaped changes as a single dict' do
-  #     assert_equal @track.shaped_changes,
-  #                  { 'name' => { original: 'Susie Everyteen', modified: 'Yolo' },
-  #                    'primary_phone' => { original: '1112223333', modified: '1234569999' },
-  #                    'appointment_date' => { original: (Date.today + 5.days).display_date, modified: (Date.today + 10.days).display_date },
-  #                    'special_circumstances' => { original: '(empty)', modified: 'A, C' },
-  #                    'city' => { original: '(empty)', modified: 'Canada' },
-  #                    'clinic_id' => { original: '(empty)', modified: @clinic.name },
-  #                  }
-  #   end
-  # end
+    it 'should return shaped changes as a single dict' do
+      assert_equal @track.shaped_changes,
+                   { 'name' => { original: 'Susie Everyteen', modified: 'Yolo' },
+                     'primary_phone' => { original: '1112223333', modified: '1234569999' },
+                     'appointment_date' => { original: (Time.zone.now + 5.days).display_date, modified: (Time.zone.now + 10.days).display_date },
+                     'special_circumstances' => { original: '(empty)', modified: 'A, C' },
+                     'city' => { original: '(empty)', modified: 'Canada' },
+                     'clinic_id' => { original: '(empty)', modified: @clinic.name },
+                   }
+    end
+  end
 
   # ensure that paper trail is versioning properly
   describe 'attachments to objects in general' do

--- a/test/models/paper_trail_version_test.rb
+++ b/test/models/paper_trail_version_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PaperTrailVersionTest < ActiveSupport::TestCase
   before do
-    @user = create :user # Can't do this until we port over the user model, for example
+    @user = create :user
     with_versioning do
       PaperTrail.request(whodunnit: @user.id) do
         @patient = create :patient, name: 'Susie Everyteen',

--- a/test/models/patient/exportable_test.rb
+++ b/test/models/patient/exportable_test.rb
@@ -55,7 +55,7 @@ class PatientTest::Exportable < PatientTest
         end
 
         @patient.update language: 'Spanish'
-          assert_equal @patient.preferred_language, 'Spanish'
+        assert_equal @patient.preferred_language, 'Spanish'
       end
     end
   end

--- a/test/models/patient/last_menstrual_period_measureable_test.rb
+++ b/test/models/patient/last_menstrual_period_measureable_test.rb
@@ -5,8 +5,7 @@ class PatientTest::LastMenstrualPeriodMeasureable < PatientTest
   describe 'last menstrual period calculation concern' do
     before do
       @user = create :user
-      @patient = create :patient, created_by: @user,
-                                  initial_call_date: 2.days.ago,
+      @patient = create :patient, initial_call_date: 2.days.ago,
                                   last_menstrual_period_weeks: 9,
                                   last_menstrual_period_days: 2,
                                   appointment_date: 2.days.from_now

--- a/test/system/change_log_test.rb
+++ b/test/system/change_log_test.rb
@@ -4,10 +4,11 @@ require 'application_system_test_case'
 class ChangeLogTest < ApplicationSystemTestCase
   before do
     @user = create :user, email: 'first_user@email.com'
-    @patient = create :patient, name: 'tester',
-                                primary_phone: '1231231234',
-                                created_by: @user,
-                                city: 'Washington'
+    PaperTrail.request(whodunnit: @user.id) do
+      @patient = create :patient, name: 'tester',
+                                  primary_phone: '1231231234',
+                                  city: 'Washington'
+    end
 
     log_in_as @user
     visit edit_patient_path(@patient)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

I wrote part of this while I was sick, but was mostly copying code from #2123 so it should be cool. This ports over the patient model diffs, not including stuff that involves subobjects.

rails t and `rails db:drop db:create db:migrate` still work!

This pull request makes the following changes:
* port Patient model

no view changes

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
