### PR TITLE
PG: Port fulfillment model

### DIFF
--- a/app/assets/javascripts/patients.coffee
+++ b/app/assets/javascripts/patients.coffee
@@ -4,16 +4,16 @@
 
 markFulfilledWhenFieldsChecked = ->
   pledge_fields = [
-    '#patient_fulfillment_fund_payout'
-    '#patient_fulfillment_check_number'
-    '#patient_fulfillment_gestation_at_procedure'
-    '#patient_fulfillment_date_of_check'
-    '#patient_fulfillment_procedure_date'
+    '#patient_fulfillment_attributes_fund_payout'
+    '#patient_fulfillment_attributes_check_number'
+    '#patient_fulfillment_attributes_gestation_at_procedure'
+    '#patient_fulfillment_attributes_date_of_check'
+    '#patient_fulfillment_attributes_procedure_date'
   ]
 
   i = 0
   empty = true
-  el = $('#patient_fulfillment_fulfilled')
+  el = $('#patient_fulfillment_attributes_fulfilled')
 
   while i < pledge_fields.length
     if $(pledge_fields[i]).val().length > 0

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -3,7 +3,7 @@ class PatientsController < ApplicationController
   before_action :confirm_admin_user, only: [:destroy]
   before_action :confirm_data_access, only: [:index]
   before_action :find_patient, only: [:edit, :update, :download, :destroy]
-  rescue_from ActiveRecord::DocumentNotFound,
+  rescue_from ActiveRecord::RecordNotFound,
               with: -> { redirect_to root_path }
 
   def index
@@ -17,7 +17,6 @@ class PatientsController < ApplicationController
   def create
     patient = Patient.new patient_params
 
-    patient.created_by = current_user
     if patient.save
       flash[:notice] = t('flash.new_patient_save')
       current_user.add_patient patient
@@ -126,8 +125,8 @@ class PatientsController < ApplicationController
   ].freeze
 
   FULFILLMENT_PARAMS = [
-    fulfillment: [:fulfilled, :procedure_date, :gestation_at_procedure,
-                  :fund_payout, :check_number, :date_of_check, :audited]
+    fulfillment_attributes: [:id, :fulfilled, :procedure_date, :gestation_at_procedure,
+                             :fund_payout, :check_number, :date_of_check, :audited]
   ].freeze
 
   OTHER_PARAMS = [:urgent_flag, :initial_call_date, :pledge_sent].freeze

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -1,33 +1,11 @@
 # Indicator that a pledge by the primary fund was cashed in,
 # which in turn indicates that the patient used our pledged money.
-class Fulfillment
-  include Mongoid::Document
-  include Mongoid::Timestamps
-  include Mongoid::History::Trackable
-  include Mongoid::Userstamp
+class Fulfillment < ApplicationRecord
+  # Concerns
+  include PaperTrailable
 
   # Relationships
-  embedded_in :can_fulfill, polymorphic: true
-
-  field :fulfilled, type: Boolean
-  field :procedure_date, type: Date
-  field :gestation_at_procedure, type: String
-  field :fund_payout, type: Integer
-  field :check_number, type: String
-  field :date_of_check, type: Date
-  field :audited, type: Boolean
-
-  # Validations
-  validates :created_by_id,
-            presence: true
-
-  # History and auditing
-  track_history on: fields.keys + [:updated_by_id],
-                version_field: :version,
-                track_create: true,
-                track_update: true,
-                track_destroy: true
-  mongoid_userstamp user_model: 'User'
+  belongs_to :can_fulfill, polymorphic: true
 
   # Methods
   def gestation_at_procedure_display

--- a/app/models/mongo_fulfillment.rb
+++ b/app/models/mongo_fulfillment.rb
@@ -1,6 +1,6 @@
 # Indicator that a pledge by the primary fund was cashed in,
 # which in turn indicates that the patient used our pledged money.
-class Fulfillment
+class MongoFulfillment
   include Mongoid::Document
   include Mongoid::Timestamps
   include Mongoid::History::Trackable

--- a/app/models/mongo_fulfillment.rb
+++ b/app/models/mongo_fulfillment.rb
@@ -1,0 +1,36 @@
+# Indicator that a pledge by the primary fund was cashed in,
+# which in turn indicates that the patient used our pledged money.
+class Fulfillment
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::History::Trackable
+  include Mongoid::Userstamp
+
+  # Relationships
+  embedded_in :can_fulfill, polymorphic: true
+
+  field :fulfilled, type: Boolean
+  field :procedure_date, type: Date
+  field :gestation_at_procedure, type: String
+  field :fund_payout, type: Integer
+  field :check_number, type: String
+  field :date_of_check, type: Date
+  field :audited, type: Boolean
+
+  # Validations
+  validates :created_by_id,
+            presence: true
+
+  # History and auditing
+  track_history on: fields.keys + [:updated_by_id],
+                version_field: :version,
+                track_create: true,
+                track_update: true,
+                track_destroy: true
+  mongoid_userstamp user_model: 'User'
+
+  # Methods
+  def gestation_at_procedure_display
+    I18n.t('accountants.table_content.weeks_at_procedure_display', gestation: gestation_at_procedure) if gestation_at_procedure.present?
+  end
+end

--- a/app/views/patients/_fulfillment.html.erb
+++ b/app/views/patients/_fulfillment.html.erb
@@ -16,7 +16,7 @@
                           remote: true do |f| %>
     <div class="row">
       <div class="col">
-        <%= f.fields_for patient.fulfillment do |pt| %>
+        <%= f.fields_for :fulfillment do |pt| %>
           <%= pt.form_group :fulfilled do %>
             <%= pt.check_box :fulfilled, label: t('patient.pledge_fulfillment.form.pledge_fulfilled_box'), autocomplete: 'off' %>
           <% end %>
@@ -26,7 +26,7 @@
 
     <div class="row">
       <div class="info-form-left col-6">
-        <%= f.fields_for patient.fulfillment do |pt| %>
+        <%= f.fields_for :fulfillment do |pt| %>
           <%= pt.number_field :fund_payout,
                               label: t('patient.pledge_fulfillment.form.fund_payout', fund: "#{FUND}"),
                               autocomplete: 'off',
@@ -42,7 +42,7 @@
       </div>
 
       <div class="info-form-right col-6">
-        <%= f.fields_for patient.fulfillment do |pt| %>
+        <%= f.fields_for :fulfillment do |pt| %>
           <%= pt.text_field :check_number, label: t('patient.pledge_fulfillment.form.check_num'), autocomplete: 'off'%>
           <%= pt.date_field :date_of_check, label: t('patient.pledge_fulfillment.form.date_of_check'), autocomplete: 'off' %>
         <% end %>
@@ -53,7 +53,7 @@
 
     <div class="row">
       <div class="col">
-        <%= f.fields_for patient.fulfillment do |pt| %>
+        <%= f.fields_for :fulfillment do |pt| %>
           <%= pt.form_group :audited do %>
             <%= pt.check_box :audited, label: t('patient.pledge_fulfillment.audit.audited_box'), autocomplete: 'off' %>
           <% end %>

--- a/db/migrate/20210410151149_create_patients.rb
+++ b/db/migrate/20210410151149_create_patients.rb
@@ -22,7 +22,7 @@ class CreatePatients < ActiveRecord::Migration[6.0]
       t.string :city
       t.string :state
       t.string :county
-      t.integer :zipcode
+      t.string :zipcode
       t.string :race_ethnicity
       t.string :employment_status
       t.integer :household_size_children

--- a/db/migrate/20210415015227_create_fulfillment.rb
+++ b/db/migrate/20210415015227_create_fulfillment.rb
@@ -1,0 +1,20 @@
+class CreateFulfillment < ActiveRecord::Migration[6.0]
+  def change
+    create_table :fulfillments do |t|
+      t.boolean :fulfilled, null: false, default: false
+      t.date :procedure_date
+      t.integer :gestation_at_procedure
+      t.integer :fund_payout
+      t.string :check_number
+      t.string :date_of_check
+      t.boolean :audited
+
+      t.references :can_fulfill, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :fulfillments, :fulfilled
+    add_index :fulfillments, :audited
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_10_151149) do
+ActiveRecord::Schema.define(version: 2021_04_15_015227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -79,6 +79,23 @@ ActiveRecord::Schema.define(version: 2021_04_10_151149) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["created_at"], name: "index_events_on_created_at"
     t.index ["line"], name: "index_events_on_line"
+  end
+
+  create_table "fulfillments", force: :cascade do |t|
+    t.boolean "fulfilled", default: false, null: false
+    t.date "procedure_date"
+    t.integer "gestation_at_procedure"
+    t.integer "fund_payout"
+    t.string "check_number"
+    t.string "date_of_check"
+    t.boolean "audited"
+    t.string "can_fulfill_type", null: false
+    t.bigint "can_fulfill_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["audited"], name: "index_fulfillments_on_audited"
+    t.index ["can_fulfill_type", "can_fulfill_id"], name: "index_fulfillments_on_can_fulfill_type_and_can_fulfill_id"
+    t.index ["fulfilled"], name: "index_fulfillments_on_fulfilled"
   end
 
   create_table "patients", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,7 +117,7 @@ ActiveRecord::Schema.define(version: 2021_04_15_015227) do
     t.string "city"
     t.string "state"
     t.string "county"
-    t.integer "zipcode"
+    t.string "zipcode"
     t.string "race_ethnicity"
     t.string "employment_status"
     t.integer "household_size_children"

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -124,7 +124,7 @@ def migrate_fulfillment(pt_model, mongo_pt_model, pg_model, mongo_model, relatio
       raise 'PG and mongo counts are in disagreement, aborting'
     end
     if pg_model.count != Patient.count
-      'Every patient not associated with only one fulfillment'
+      raise 'Every patient not associated with only one fulfillment'
     end
   end
 end

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -121,7 +121,7 @@ def migrate_fulfillment(pt_model, mongo_pt_model, pg_model, mongo_model, relatio
 
     # Check
     if pg_model.count != mongo_model.count
-      'PG and mongo counts are in disagreement, aborting'
+      raise 'PG and mongo counts are in disagreement, aborting'
     end
     if pg_model.count != Patient.count
       'Every patient not associated with only one fulfillment'

--- a/test/factories/fulfillment.rb
+++ b/test/factories/fulfillment.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :fulfillment do
     patient
-    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/models/fulfillment_test.rb
+++ b/test/models/fulfillment_test.rb
@@ -5,39 +5,13 @@ class FulfillmentTest < ActiveSupport::TestCase
     @user = create :user
     @pt_1 = create :patient, name: 'Susan Smith'
     @fulfillment = @pt_1.fulfillment
-    @fulfillment.created_by = @user
-    @fulfillment.reload
   end
 
-  describe 'validations' do
-    it 'should be able to build an object' do
-      assert @fulfillment.valid?
-    end
-
-    %w(created_by).each do |field|
-      it "should enforce presence of #{field}" do
-        @fulfillment[field.to_sym] = nil
-        refute @fulfillment.valid?
-      end
-    end
-  end
-
-  describe 'mongoid attachments' do
-    it 'should have timestamps from Mongoid::Timestamps' do
-      [:created_at, :updated_at].each do |field|
-        assert @fulfillment.respond_to? field
-        assert @fulfillment[field]
-      end
-    end
-
+  describe 'concerns' do
     it 'should respond to history methods' do
-      assert @fulfillment.respond_to? :history_tracks
-      assert @fulfillment.history_tracks.count > 0
-    end
-
-    it 'should have accessible userstamp methods' do
+      assert @fulfillment.respond_to? :versions
       assert @fulfillment.respond_to? :created_by
-      assert @fulfillment.created_by
+      assert @fulfillment.respond_to? :created_by_id
     end
   end
 

--- a/test/system/update_patient_info_test.rb
+++ b/test/system/update_patient_info_test.rb
@@ -7,8 +7,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
     @clinic = create :clinic
     @patient = create :patient, line: :DC
     @patient.external_pledges.create source: 'Baltimore Abortion Fund',
-                                     amount: 100,
-                                     created_by: @user
+                                     amount: 100
     @ext_pledge = @patient.external_pledges.first
     create_external_pledge_source_config
     create_insurance_config
@@ -327,7 +326,7 @@ class UpdatePatientInfoTest < ApplicationSystemTestCase
         assert has_field? 'Procedure date',
                           with: 2.days.from_now.strftime('%Y-%m-%d')
         assert_equal '12',
-                     find('#patient_fulfillment_gestation_at_procedure').value
+                     find('#patient_fulfillment_attributes_gestation_at_procedure').value
         assert has_field? 'DCAF payout', with: 100
         assert has_field? 'Check #', with: '444-22'
         assert has_checked_field? 'Fulfillment audited?'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Port Fulfillment to pg. This should let us cleanly init patient objects again.

Try out the migration script:
```
git checkout main && rails db:drop db:create db:migrate db:seed
git checkout pg-fulfillment && rails db:migrate
rails migrate_to_pg:clinic_user_patient
rails c
Fulfillment.where(fulfilled: true).count
```

This pull request makes the following changes:
* `Patient` model to pg

no view change

It relates to the following issue #s: 
* Bumps #2072

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
