### PR TITLE
Improve new instance setup instructions around user generation

### DIFF
--- a/docs/administering/SETTING_UP_A_NEW_INSTANCE.md
+++ b/docs/administering/SETTING_UP_A_NEW_INSTANCE.md
@@ -75,7 +75,15 @@ With the instance set up, we want to make sure it's properly configured and work
 
 You should be able to access the rails console via this snippet: `heroku run rails c -a daria-FUND`
 
-* Create yourself an admin account from the rails console. Confirm that this sends an email to you notifying you of account creation. You can use this snippet: `User.create email: 'your@email.org', name: 'Your Name', role: :admin, password: 'random string', password_confirmation: 'same random string as in password'`. Throw out the password after generating it as you won't need it again. This confirms we can save new users to the database and that the mailer is properly configured. If an email doesn't send, check that the Sendgrid Heroku addon is working right and that the sendgrid env vars are properly set.
+* Create yourself an admin account from the rails console. Confirm that this sends an email to you notifying you of account creation. This confirms we can save new users to the database and that the mailer is properly configured. If an email doesn't send, check that the Sendgrid Heroku addon is working right and that the sendgrid env vars are properly set. You can use this snippet:
+```
+scratch_pass = SecureRandom.alphanumeric
+User.create email: 'your@email.org',
+            name: 'Your Name',
+            role: :admin,
+            password: scratch_pass,
+            password_confirmation: scratch_pass
+```
 * Go to the url at `http://daria-FUND.herokuapp.com`. Confirm that this loads, and redirects you to `https://...`
 * Confirm the oauth signin flow works by clicking the `Sign in with Google` button. This confirms that oauth is properly set up. If something is weird here, check that `DARIA_GOOGLE_KEY` and `DARIA_GOOGLE_SECRET` are properly set and configured.
 * Confirm that the lines are properly set and show up right. For most funds, this means after logging in you will go straight to the call list. For funds with more than one line, you'll go to a line selection screen instead. If this is does not behave as expected, check that the `DARIA_LINES` environment variable is properly set.


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

@xmunoz ID'd a problem in docs when doing some testing - not clear what a scratch password on instance setup should be. This bumps docs to make that a bit more straightforward, and makes it a plug-and-chug snippet. Thanks much to @xmunoz for calling this out!

This pull request makes the following changes:
* improves the snippet to generate an alphanumeric

no view changes

It relates to the following issue #s: 
* Fixes #2175 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
