### PR TITLE
Portl Call model to pg

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -4,7 +4,6 @@ class CallsController < ApplicationController
 
   def create
     @call = @patient.calls.new call_params
-    @call.created_by = current_user
     if call_saved_and_patient_reached @call, params
       redirect_to edit_patient_path @patient
     elsif @call.save
@@ -12,6 +11,8 @@ class CallsController < ApplicationController
     else
       head :bad_request
     end
+  rescue ArgumentError
+    head :bad_request
   end
 
   def new
@@ -43,6 +44,6 @@ class CallsController < ApplicationController
   end
 
   def call_saved_and_patient_reached(call, params)
-    call.save && params[:call][:status] == 'Reached patient'
+    call.save && params[:call][:status] == 'reached_patient'
   end
 end

--- a/app/helpers/calls_helper.rb
+++ b/app/helpers/calls_helper.rb
@@ -27,7 +27,7 @@ module CallsHelper
     content_tag :p do
       link_to t('call.new.result.reached_patient'),
               patient_calls_path(patient,
-                                 call: { status: 'Reached patient' }),
+                                 call: { status: :reached_patient }),
               method: :post,
               class: 'btn btn-primary calls-btn'
     end
@@ -37,20 +37,9 @@ module CallsHelper
     content_tag :p do
       link_to t('call.new.result.did_not_reach_patient'),
               patient_calls_path(patient,
-                                 call: { status: "Couldn't reach patient" }),
+                                 call: { status: :couldnt_reach_patient }),
               method: :post, remote: true,
               class: 'calls-response'
-    end
-  end
-
-  def display_call_status(call)
-    case call.status
-    when 'Reached patient'
-      t('call.status.reached_patient')
-    when "Couldn't reach patient"
-      t('call.status.could_not_reach_patient')
-    when 'Left voicemail'
-      t('call.status.left_voicemail')
     end
   end
 
@@ -65,7 +54,7 @@ module CallsHelper
   def leave_a_voicemail_link(patient)
     link_to t('call.new.result.left_voicemail'),
             patient_calls_path(patient,
-                               call: { status: 'Left voicemail' }),
+                               call: { status: :left_voicemail }),
             method: :post,
             remote: true,
             class: 'calls-response'

--- a/app/lib/reporting/patient.rb
+++ b/app/lib/reporting/patient.rb
@@ -6,7 +6,7 @@ module Reporting
           eligible_calls = patient
             .calls
             .where(created_at: (start_date..end_date))
-            .where(status: 'Reached patient')
+            .where(status: :reached_patient)
             .count
 
           if eligible_calls > 0
@@ -19,7 +19,7 @@ module Reporting
 
       def new_contacted_for_line(line, start_date, end_date)
         ::Patient.where(line: line).inject(0) do |count, patient|
-          first_reached_call = patient.calls.where(status: 'Reached patient').order(created_at: 'asc').first
+          first_reached_call = patient.calls.where(status: :reached_patient).order(created_at: 'asc').first
 
           if first_reached_call && first_reached_call.created_at >= start_date && first_reached_call.created_at <= end_date
             count += 1

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -1,47 +1,32 @@
 # Object representing a case manager dialing a patient.
-class Call
-  include Mongoid::Document
-  include Mongoid::Timestamps
-  include Mongoid::History::Trackable
-  include Mongoid::Userstamp
+class Call < ApplicationRecord
+  # Concerns
   include EventLoggable
+  include PaperTrailable
+
+  # Enums
+  enum status: {
+    reached_patient: 0,
+    left_voicemail: 1,
+    couldnt_reach_patient: 2
+  }
 
   # Relationships
-  embedded_in :can_call, polymorphic: true
-
-  # Fields
-  field :status, type: String
+  belongs_to :can_call, polymorphic: true
 
   # Validations
-  ALLOWED_STATUSES = {
-    'Reached patient' => :reached_patient,
-    'Left voicemail' => :left_voicemail,
-    "Couldn't reach patient" => :couldnt_reach_patient
-  }
-  validates :status,  presence: true,
-                      inclusion: { in: ALLOWED_STATUSES.keys }
-  validates :created_by_id, presence: true
+  validates :status,  presence: true
 
-  # History and auditing
-  track_history on: fields.keys + [:updated_by_id],
-                version_field: :version,
-                track_create: true,
-                track_update: true,
-                track_destroy: true
-  mongoid_userstamp user_model: 'User'
-
+  # Methods
   def recent?
     updated_at > 8.hours.ago ? true : false
   end
 
-  def reached?
-    status == 'Reached patient'
-  end
-
   def event_params
+    user = User.find_by(id: PaperTrail&.request&.whodunnit)
     {
-      event_type:   ALLOWED_STATUSES[status],
-      cm_name:      created_by&.name || 'System',
+      event_type:   status.to_s,
+      cm_name:      user&.name || 'System',
       patient_name: can_call.name,
       patient_id:   can_call.id,
       line:         can_call.line

--- a/app/models/concerns/callable.rb
+++ b/app/models/concerns/callable.rb
@@ -3,11 +3,11 @@ module Callable
   extend ActiveSupport::Concern
 
   def recent_calls
-    calls.includes(:created_by).order('created_at DESC').limit(10)
+    calls.includes(:versions).order('created_at DESC').limit(10)
   end
 
   def old_calls
-    calls.includes(:created_by).order('created_at DESC').offset(10)
+    calls.includes(:versions).order('created_at DESC').offset(10)
   end
 
   def last_call

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -131,8 +131,7 @@ module Exportable
   end
 
   def reached_patient_call_count
-    reached_calls = calls.select {|call| call.status == "Reached patient"}
-    reached_calls.count
+    calls.select { |call| call.reached_patient? }.count
   end
 
   def export_clinic_name

--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -38,7 +38,7 @@ module Statusable
 
   def contact_made?
     calls.each do |call|
-      return true if call.status == 'Reached patient'
+      return true if call.reached_patient?
     end
     false
   end

--- a/app/models/mongo_call.rb
+++ b/app/models/mongo_call.rb
@@ -1,0 +1,50 @@
+# Object representing a case manager dialing a patient.
+class MongoCall
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::History::Trackable
+  include Mongoid::Userstamp
+  include EventLoggable
+
+  # Relationships
+  embedded_in :can_call, polymorphic: true
+
+  # Fields
+  field :status, type: String
+
+  # Validations
+  ALLOWED_STATUSES = {
+    'Reached patient' => :reached_patient,
+    'Left voicemail' => :left_voicemail,
+    "Couldn't reach patient" => :couldnt_reach_patient
+  }
+  validates :status,  presence: true,
+                      inclusion: { in: ALLOWED_STATUSES.keys }
+  validates :created_by_id, presence: true
+
+  # History and auditing
+  track_history on: fields.keys + [:updated_by_id],
+                version_field: :version,
+                track_create: true,
+                track_update: true,
+                track_destroy: true
+  mongoid_userstamp user_model: 'User'
+
+  def recent?
+    updated_at > 8.hours.ago ? true : false
+  end
+
+  def reached?
+    status == 'Reached patient'
+  end
+
+  def event_params
+    {
+      event_type:   ALLOWED_STATUSES[status],
+      cm_name:      created_by&.name || 'System',
+      patient_name: can_call.name,
+      patient_id:   can_call.id,
+      line:         can_call.line
+    }
+  end
+end

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -17,13 +17,14 @@
       <th><%= t('patient.call_log.table.case_manager') %></th>
       <th><%= t('patient.call_log.table.actions') %></th>
     </tr>
+
     <tbody>
       <% @patient.recent_calls.each do |call| %>
         <tr class="call-log-row">
           <td><%= call.created_at.display_date %></td>
           <td><%= call.created_at.display_time %></td>
-          <td><%= display_call_status call %></td>
-          <td><%= call.created_by.name %></td>
+          <td><%= t("call.status.#{call.status}") call %></td>
+          <td><%= call.created_by&.name || 'System' %></td>
           <td>
             <% if call.created_by == current_user && call.recent? %>
               <%= button_to t('patient.call_log.table.remove_button'),
@@ -41,8 +42,8 @@
         <tr class="old-calls d-none">
           <td><%= call.created_at.display_date %></td>
           <td><%= call.created_at.display_time %></td>
-          <td><%= call.status %></td>
-          <td><%= call.created_by.name %></td>
+          <td><%= t("call.status.#{call.status}") call %></td>
+          <td><%= call.created_by&.name || 'System' %></td>
           <td></td>
         </tr>
       <% end %>

--- a/app/views/patients/_call_log.html.erb
+++ b/app/views/patients/_call_log.html.erb
@@ -23,7 +23,7 @@
         <tr class="call-log-row">
           <td><%= call.created_at.display_date %></td>
           <td><%= call.created_at.display_time %></td>
-          <td><%= t("call.status.#{call.status}") call %></td>
+          <td><%= t("call.status.#{call.status}") %></td>
           <td><%= call.created_by&.name || 'System' %></td>
           <td>
             <% if call.created_by == current_user && call.recent? %>
@@ -42,7 +42,7 @@
         <tr class="old-calls d-none">
           <td><%= call.created_at.display_date %></td>
           <td><%= call.created_at.display_time %></td>
-          <td><%= t("call.status.#{call.status}") call %></td>
+          <td><%= t("call.status.#{call.status}") %></td>
           <td><%= call.created_by&.name || 'System' %></td>
           <td></td>
         </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,7 +93,7 @@ en:
       other_contact: "%{name} %{rel} is the primary contact for this patient%{punc}"
       primary: 'Primary contact:'
     status:
-      could_not_reach_patient: Couldn't reach patient
+      couldnt_reach_patient: Couldn't reach patient
       left_voicemail: Left voicemail
       reached_patient: Reached patient
   clinic_locator:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -93,7 +93,7 @@ es:
       other_contact: "%{name} %{rel} es el contacto principal para este paciente%{punc}"
       primary: 'Contacto primario:'
     status:
-      could_not_reach_patient: No hablé con el paciente
+      couldnt_reach_patient: No hablé con el paciente
       left_voicemail: Dejé un mensaje de voz
       reached_patient: Paciente alcanzado
   clinic_locator:

--- a/db/migrate/20210426033002_create_calls.rb
+++ b/db/migrate/20210426033002_create_calls.rb
@@ -1,0 +1,11 @@
+class CreateCalls < ActiveRecord::Migration[6.0]
+  def change
+    create_table :calls do |t|
+      t.integer :status, null: false
+
+      t.references :can_call, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_15_015227) do
+ActiveRecord::Schema.define(version: 2021_04_26_033002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "calls", force: :cascade do |t|
+    t.integer "status", null: false
+    t.string "can_call_type", null: false
+    t.bigint "can_call_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["can_call_type", "can_call_id"], name: "index_calls_on_can_call_type_and_can_call_id"
+  end
 
   create_table "clinics", force: :cascade do |t|
     t.string "name", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,11 +2,19 @@
 raise 'No running seeds in prod' unless [nil, 'Sandbox'].include? ENV['DARIA_FUND']
 
 # Clear out existing DB
+Config.destroy_all
+Event.destroy_all
+Call.destroy_all
+# CallListEntry.destroy_all
+# ExternalPledge.destroy_all
+# Fulfillment.destroy_all
+# Note.destroy_all
 Patient.destroy_all
 User.destroy_all
 Clinic.destroy_all
-Event.destroy_all
-Config.destroy_all
+
+# Do versioning
+PaperTrail.enabled = true
 
 # Set a few config constants
 lines = %w[DC VA MD]
@@ -23,6 +31,9 @@ user2 = User.create! name: 'testuser2', email: 'test2@example.com',
 User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
              password: 'P4ssword', password_confirmation: 'P4ssword',
              role: :cm
+
+# Default to user2 as the actor
+PaperTrail.request.whodunnit = user2
 
 # Create a few clinics
 Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '1600 Pennsylvania Ave',
@@ -67,13 +78,13 @@ Config.create config_key: :start_of_week,
   case i
   when 0
     10.times do
-      patient.calls.create! status: 'Reached patient',
+      patient.calls.create! status: :reached_patient,
                             created_at: 3.days.ago
     end
   when 1
     patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
                     other_phone: '234-456-6789', other_contact_relationship: 'Sister'
-    patient.calls.create! status: 'Reached patient',
+    patient.calls.create! status: :reached_patient,
                           created_at: 14.hours.ago
   when 2
     # appointment one week from today && clinic selected
@@ -99,7 +110,7 @@ Config.create config_key: :start_of_week,
     patient.update! name: 'Special Circumstances - 4',
                     special_circumstances: ['Prison', 'Fetal anomaly']
     # And a recent call on file
-    patient.calls.create! status: 'Left voicemail'
+    patient.calls.create! status: :left_voicemail
   when 5
     # Resolved without DCAF
     patient.update! name: 'Resolved without DCAF - 5',
@@ -108,7 +119,7 @@ Config.create config_key: :start_of_week,
 
   if i != 9
     5.times do
-      patient.calls.create! status: 'Left voicemail',
+      patient.calls.create! status: :left_voicemail,
                             created_at: 3.days.ago
     end
   end
@@ -172,10 +183,10 @@ end
 
   # reached within the past 30 days
   5.times do
-    patient.calls.create! status: 'Reached patient',
+    patient.calls.create! status: :reached_patient,
                           created_by: user,
                           created_at: (Time.now - rand(10).days)
-    patient.calls.create! status: 'Reached patient',
+    patient.calls.create! status: :reached_patient,
                           created_by: user,
                           created_at: (Time.now - rand(10).days - 10.days)
   end
@@ -194,7 +205,7 @@ end
   )
 
   5.times do
-    patient.calls.create! status: 'Reached patient',
+    patient.calls.create! status: :reached_patient,
                           created_by: user,
                           created_at: (Time.now - rand(10).days - 6.months)
   end
@@ -232,10 +243,10 @@ end
   )
 
   # Call, but no answer. leave a VM.
-  patient.calls.create status: 'Left voicemail', created_by: user, created_at: 139.days.ago
+  patient.calls.create status: :left_voicemail, created_by: user, created_at: 139.days.ago
 
   # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: 'Reached patient', created_by: user, created_at: 138.days.ago
+  patient.calls.create status: :reached_patient, created_by: user, created_at: 138.days.ago
 
   patient.update!(
     # header info - hand filled in
@@ -283,7 +294,7 @@ end
   next if patient.resolved_without_fund?
 
   # another call. get abortion information, create pledges, a note.
-  patient.calls.create! status: 'Reached patient', created_by: user, created_at: 136.days.ago
+  patient.calls.create! status: :reached_patient, created_by: user, created_at: 136.days.ago
 
   # abortion info - pledges - hand filled in
   patient.update!(
@@ -345,10 +356,10 @@ end
   )
 
   # Call, but no answer. leave a VM.
-  patient.calls.create status: 'Left voicemail', created_by: user, created_at: 639.days.ago
+  patient.calls.create status: :left_voicemail, created_by: user, created_at: 639.days.ago
 
   # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: 'Reached patient', created_by: user, created_at: 138.days.ago
+  patient.calls.create status: :reached_patient, created_by: user, created_at: 138.days.ago
 
   # Patient 1 drops off immediately
   next if patient_number.odd?

--- a/lib/tasks/create_fake_data.rake
+++ b/lib/tasks/create_fake_data.rake
@@ -49,7 +49,7 @@ namespace :db do
           end
 
           # create calls, where every patient will have at least one call made
-          call_status = ["Left voicemail", "Reached patient", "Couldn't reach patient"]
+          call_status = [:left_voicemail, :reached_patient, :couldnt_reach_patient]
 
           gen.rand(1..7).times do
             patient.calls.create status: call_status[gen.rand(3)], created_by: users.sample

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -87,8 +87,9 @@ namespace :migrate_to_pg do
         extra_transform = Proc.new do |attrs, obj, doc|
           attrs['can_call'] = pt.find_by! mongo_id: doc['_id'].to_s
           attrs['status'] = MongoCall::ALLOWED_STATUSES[obj['status']]
+          attrs
         end
-        migrate_fulfillment(pt, mongo_pt, pg, mongo, 'calls', 'can_call', extra_transform)
+        migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'can_call', extra_transform)
       end
     end
   end
@@ -139,7 +140,7 @@ end
 
 def migrate_submodel(pt_model, mongo_pt_model, pg_model, mongo_model, relation, parent_relation, transform)
   attributes = pg_model.attribute_names
-  mongo_pt_model.colleciton.find.batch_size(100).each do |doc|
+  mongo_pt_model.collection.find.batch_size(100).each do |doc|
     mongo_objs = doc[relation] || []
     mongo_objs.each do |obj|
       pg_attrs = obj.slice(*attributes)

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -138,6 +138,7 @@ def migrate_fulfillment(pt_model, mongo_pt_model, pg_model, mongo_model, relatio
   puts "#{pg_model.count} Fulfillment migrated to pg"
 end
 
+# handles patient has_many submodels
 def migrate_submodel(pt_model, mongo_pt_model, pg_model, mongo_model, relation, parent_relation, transform)
   attributes = pg_model.attribute_names
   mongo_pt_model.collection.find.batch_size(100).each do |doc|
@@ -155,7 +156,7 @@ def migrate_submodel(pt_model, mongo_pt_model, pg_model, mongo_model, relation, 
     # Check
     obj_count = pg_model.where(parent_relation.to_sym => pt_model.find_by!(mongo_id: doc['_id'].to_s)).count
     if obj_count != mongo_objs.count
-      raise "PG and mongo counts for #{relation} are in disagreement; aborting"
+      raise "PG and mongo counts for #{relation} are in disagreement (#{obj_count} and #{mongo_objs.count}); aborting"
     end
   end
 

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -16,18 +16,20 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
 
   describe 'create method' do
     before do
-      @call = attributes_for :call, status: 'Reached patient'
-      post patient_calls_path(@patient), params: { call: @call }, xhr: true
+      with_versioning do
+        @call = attributes_for :call, status: 'Reached patient'
+        post patient_calls_path(@patient), params: { call: @call }, xhr: true
+      end
     end
 
     it 'should create and save a new call' do
-      assert_difference 'Patient.find(@patient).calls.count', 1 do
+      assert_difference 'Patient.find(@patient.id).calls.count', 1 do
         post patient_calls_path(@patient), params: { call: @call }, xhr: true
       end
     end
 
     it 'should respond success if patient is not reached' do
-      ['Left voicemail', "Couldn't reach patient"].each do |status|
+      [:left_voicemail, :couldnt_reach_patient].each do |status|
         call = attributes_for :call, status: status
         post patient_calls_path(@patient), params: { call: call }, xhr: true
         assert_response :success
@@ -41,7 +43,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     it 'should not save and flash an error if status is blank or bad' do
       [nil, 'not a real status'].each do |bad_status|
         call = attributes_for :call, status: bad_status
-        assert_no_difference 'Patient.find(@patient).calls.count' do
+        assert_no_difference 'Call.count' do
           post patient_calls_path(@patient), params: { call: call }, xhr: true
         end
         assert_response :bad_request
@@ -49,24 +51,35 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should log the creating user' do
-      assert_equal Patient.find(@patient).calls.last.created_by, @user
+      assert_equal Patient.find(@patient.id).calls.last.created_by,
+                   @user
     end
   end
 
   describe 'destroy method' do
     it 'should destroy a call' do
-      @patient.calls.create attributes_for(:call, created_by: @user)
+      with_versioning do
+        PaperTrail.request(whodunnit: @user.id) do
+          @patient.calls.create attributes_for(:call)
+        end
+      end
+
       call = @patient.calls.first
-      assert_difference 'Patient.find(@patient).calls.count', -1 do
+      assert_difference 'Patient.find(@patient.id).calls.count', -1 do
         delete patient_call_path(@patient, call), params: { id: call.id },
                                                   xhr: true
       end
     end
 
     it 'should not allow user to destroy calls created by others' do
-      @patient.calls.create attributes_for(:call, created_by: create(:user))
+      with_versioning do
+        PaperTrail.request(whodunnit: create(:user)) do
+          @patient.calls.create attributes_for(:call)
+        end
+      end
+
       call = @patient.calls.first
-      assert_no_difference 'Patient.find(@patient).calls.count' do
+      assert_no_difference 'Patient.find(@patient.id).calls.count' do
         delete patient_call_path(@patient, call), params: { id: call.id },
                                                   xhr: true
       end
@@ -74,10 +87,16 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should not allow user to destroy old calls' do
-      @patient.calls.create attributes_for(:call, created_by: @user,updated_at: Time.zone.now - 1.day)
+      with_versioning do
+        PaperTrail.request(whodunnit: @user.id) do
+          @patient.calls.create attributes_for(:call, updated_at: Time.zone.now - 1.day)
+        end
+      end
+
+      @patient.calls.create attributes_for(:call, updated_at: Time.zone.now - 1.day)
       call = @patient.calls.first
 
-      assert_no_difference 'Patient.find(@patient).calls.count' do
+      assert_no_difference 'Patient.find(@patient.id).calls.count' do
         delete patient_call_path(@patient, call), params: { id: call.id },
                                                   xhr: true
       end

--- a/test/controllers/calls_controller_test.rb
+++ b/test/controllers/calls_controller_test.rb
@@ -17,7 +17,7 @@ class CallsControllerTest < ActionDispatch::IntegrationTest
   describe 'create method' do
     before do
       with_versioning do
-        @call = attributes_for :call, status: 'Reached patient'
+        @call = attributes_for :call, status: :reached_patient
         post patient_calls_path(@patient), params: { call: @call }, xhr: true
       end
     end

--- a/test/factories/call.rb
+++ b/test/factories/call.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :call do
     association :patient
-    status { 'Reached patient' }
+    status { :reached_patient }
   end
 end

--- a/test/factories/call.rb
+++ b/test/factories/call.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :call do
     association :patient
     status { 'Reached patient' }
-    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/lib/reporting/patient_test.rb
+++ b/test/lib/reporting/patient_test.rb
@@ -16,14 +16,14 @@ class ReportingPatientTest < ActiveSupport::TestCase
       # reached calls this month
       (1..5).each do |call_number|
         Timecop.freeze(Time.zone.now - call_number.days) do
-          patient.calls.create attributes_for(:call, status: 'Reached patient')
+          patient.calls.create attributes_for(:call, status: :reached_patient)
         end
       end
 
       # not reached calls this month
       (1..5).each do |call_number|
         Timecop.freeze(Time.zone.now - call_number.days) do
-          patient.calls.create attributes_for(:call, status: 'Left voicemail')
+          patient.calls.create attributes_for(:call, status: :left_voicemail)
         end
       end
     end
@@ -40,7 +40,7 @@ class ReportingPatientTest < ActiveSupport::TestCase
       # calls this year
       (1..5).each do |call_number|
         Timecop.freeze(Time.zone.now - call_number.months - call_number.days) do
-          patient.calls.create attributes_for(:call, status: 'Reached patient')
+          patient.calls.create attributes_for(:call, status: :reached_patient)
         end
       end
     end
@@ -69,11 +69,11 @@ class ReportingPatientTest < ActiveSupport::TestCase
 
       # call from 2 months ago
       Timecop.freeze(Time.zone.now - 2.months) do
-        patient.calls.create attributes_for(:call, status: 'Reached patient')
+        patient.calls.create attributes_for(:call, status: :reached_patient)
       end
 
       # call from now
-      patient.calls.create attributes_for(:call, status: 'Reached patient')
+      patient.calls.create attributes_for(:call, status: :reached_patient)
     end
     it 'should return the correct amount of contacted patients for the first time in the timeframe' do
       month_num_contacted = Reporting::Patient.new_contacted_for_line('VA', Time.zone.now - 1.month, Time.zone.now)

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -6,7 +6,7 @@ class ArchivedPatientTest < ActiveSupport::TestCase
     @patient = create :patient, other_phone: '111-222-3333',
                                 other_contact: 'Yolo'
 
-    @patient.calls.create attributes_for(:call, created_by: @user, status: 'Reached patient')
+    @patient.calls.create attributes_for(:call, created_by: @user, status: :reached_patient)
     create_language_config
     @archived_patient = create :archived_patient, line: 'DC',
                                 initial_call_date: 200.days.ago,
@@ -45,8 +45,8 @@ class ArchivedPatientTest < ActiveSupport::TestCase
                                    race_ethnicity: 'Asian',
                                    initial_call_date: 16.days.ago,
                                    appointment_date: 6.days.ago
-      @patient.calls.create attributes_for(:call, created_by: @user, status: "Couldn't reach patient")
-      @patient.calls.create attributes_for(:call, created_by: @user, status: 'Reached patient')
+      @patient.calls.create attributes_for(:call, created_by: @user, status: :couldnt_reach_patient)
+      @patient.calls.create attributes_for(:call, created_by: @user, status: :reached_patient)
       @patient.update fulfillment: {
                                   fulfilled: true,
                                   updated_at: 3.days.ago,

--- a/test/models/call_test.rb
+++ b/test/models/call_test.rb
@@ -2,10 +2,14 @@ require 'test_helper'
 
 class CallTest < ActiveSupport::TestCase
   before do
-    @user = create :user
-    @patient = create :patient
-    @patient.calls.create attributes_for(:call, created_by: @user)
-    @call = @patient.calls.first
+    with_versioning do
+      @user = create :user
+      PaperTrail.request(whodunnit: @user.id) do
+        @patient = create :patient
+        @patient.calls.create attributes_for(:call, created_by: @user)
+        @call = @patient.calls.first
+      end
+    end
   end
 
   describe 'basic validations' do
@@ -14,21 +18,14 @@ class CallTest < ActiveSupport::TestCase
     end
 
     it 'should only allow certain statuses' do
-      [nil, 'not a status'].each do |bad_status|
-        @call.status = bad_status
-        refute @call.valid?
-      end
-      valid_call_statuses =
-        ['Left voicemail', "Couldn't reach patient", 'Reached patient']
+      @call.status = nil
+      refute @call.valid?
+
+      valid_call_statuses = [:left_voicemail, :couldnt_reach_patient, :reached_patient]
       valid_call_statuses.each do |status|
         @call.status = status
         assert @call.valid?
       end
-    end
-
-    it 'should require a user id' do
-      @call.created_by = nil
-      refute @call.valid?
     end
   end
 
@@ -42,22 +39,11 @@ class CallTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'mongoid attachments' do
-    it 'should have timestamps from Mongoid::Timestamps' do
-      [:created_at, :updated_at].each do |field|
-        assert @call.respond_to? field
-        assert @call[field]
-      end
-    end
-
+  describe 'concerns' do
     it 'should respond to history methods' do
-      assert @call.respond_to? :history_tracks
-      assert @call.history_tracks.count > 0
-    end
-
-    it 'should have accessible userstamp methods' do
+      assert @call.respond_to? :versions
       assert @call.respond_to? :created_by
-      assert @call.created_by
+      assert @call.respond_to? :created_by_id
     end
   end
 end

--- a/test/models/patient/statusable_test.rb
+++ b/test/models/patient/statusable_test.rb
@@ -15,7 +15,7 @@ class PatientTest::Statusable < PatientTest
       end
 
       it 'should default to "No Contact Made" on a patient left voicemail' do
-        @patient.calls.create attributes_for(:call, status: 'Left voicemail')
+        @patient.calls.create attributes_for(:call, status: :left_voicemail)
         assert_equal Patient::STATUSES[:no_contact][:key], @patient.status
       end
 
@@ -27,12 +27,12 @@ class PatientTest::Statusable < PatientTest
 
     describe 'status method branch 2' do
       it 'should update to "Needs Appointment" once patient has been reached' do
-        @patient.calls.create attributes_for(:call, status: 'Reached patient')
+        @patient.calls.create attributes_for(:call, status: :reached_patient)
         assert_equal Patient::STATUSES[:needs_appt][:key], @patient.status
       end
 
       it 'should update to "Fundraising" once appointment made and patient reached' do
-        @patient.calls.create attributes_for(:call, status: 'Reached patient')
+        @patient.calls.create attributes_for(:call, status: :reached_patient)
         @patient.appointment_date = '01/01/2017'
         assert_equal Patient::STATUSES[:fundraising][:key], @patient.status
       end
@@ -56,10 +56,10 @@ class PatientTest::Statusable < PatientTest
       # it 'should update to "Pledge Paid" after a pledge has been paid' do
       # end
       it 'should update to "No contact in 120 days" after 120ish days of no calls' do
-        @patient.calls.create attributes_for(:call, status: 'Reached patient', created_at: 121.days.ago)
+        @patient.calls.create attributes_for(:call, status: :reached_patient, created_at: 121.days.ago)
         assert_equal Patient::STATUSES[:dropoff][:key], @patient.status
 
-        @patient.calls.create attributes_for(:call, status: 'Reached patient', created_at: 120.days.ago)
+        @patient.calls.create attributes_for(:call, status: :reached_patient, created_at: 120.days.ago)
         assert_equal Patient::STATUSES[:needs_appt][:key], @patient.status
       end
 
@@ -75,12 +75,12 @@ class PatientTest::Statusable < PatientTest
       end
 
       it 'should return false if an unsuccessful call has been made' do
-        @patient.calls.create attributes_for(:call, status: 'Left voicemail')
+        @patient.calls.create attributes_for(:call, status: :left_voicemail)
         refute @patient.send :contact_made?
       end
 
       it 'should return true if a successful call has been made' do
-        @patient.calls.create attributes_for(:call, status: 'Reached patient')
+        @patient.calls.create attributes_for(:call, status: :reached_patient)
         assert @patient.send :contact_made?
       end
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -69,7 +69,7 @@ class UserTest < ActiveSupport::TestCase
 
     it 'should clean calls when patient has been reached' do
       assert_equal 0, @user.recently_called_patients('DC').count
-      @patient.calls.create attributes_for(:call, created_by: @user, status: 'Reached patient')
+      @patient.calls.create attributes_for(:call, created_by: @user, status: :reached_patient)
       @call = @patient.calls.first
       assert_equal 1, @user.recently_called_patients('DC').count
       @user.clean_call_list_between_shifts
@@ -78,7 +78,7 @@ class UserTest < ActiveSupport::TestCase
 
     it 'should not clear calls when patient has not been reached' do
       assert_equal 0, @user.recently_called_patients('DC').count
-      @patient.calls.create attributes_for(:call, created_by: @user, status: 'Left voicemail' )
+      @patient.calls.create attributes_for(:call, created_by: @user, status: :left_voicemail)
       @call = @patient.calls.first
       assert_equal 1, @user.recently_called_patients('DC').count
       @user.clean_call_list_between_shifts

--- a/test/system/table_content_test.rb
+++ b/test/system/table_content_test.rb
@@ -8,14 +8,12 @@ class TableContentTest < ApplicationSystemTestCase
     @patient = create :patient, initial_call_date: 3.days.ago,
                                 appointment_date: 3.days.from_now.utc,
                                 urgent_flag: true,
-                                created_by: @user,
                                 last_menstrual_period_weeks: 6,
                                 last_menstrual_period_days: 3
 
-    @patient.calls.create status: 'Left voicemail',
+    @patient.calls.create status: :left_voicemail,
                           created_at: 3.days.ago,
-                          updated_at: 3.days.ago,
-                          created_by: @user
+                          updated_at: 3.days.ago
 
     @user.add_patient @patient
     log_in_as @user


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Port Call to pg. Should let us log calls again and contains a proof of concept for porting over an embeds many submodel. After this, we'll do CallList and be able to look at pages again finally.

Try it out:

```
git checkout main && rails db:drop db:create db:migrate db:seed
git checkout pg-call && rails db:migrate
rails migrate_to_pg:clinic_user_patient
rails c
Call.count # 141
```

I think I might be mishandling 'couldnt_reach_patient' statuses but we can kick this up for rev regardless.

This pull request makes the following changes:
* port Call to pg

no view

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
