### PR TITLE
Migrate Call List Entry model

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   before_action :prevent_caching_via_headers
   before_action :set_locale
   before_action :set_raven_context
-  # before_action :set_paper_trail_whodunnit # Turn on when user model is in pg 
+  before_action :set_paper_trail_whodunnit
 
   # whitelists attributes in devise
   def configure_permitted_parameters

--- a/app/controllers/call_lists_controller.rb
+++ b/app/controllers/call_lists_controller.rb
@@ -3,7 +3,7 @@ class CallListsController < ApplicationController
   include LinesHelper
 
   before_action :retrieve_patients, only: [:add_patient, :remove_patient]
-  rescue_from Mongoid::Errors::DocumentNotFound, with: -> { head :not_found }
+  rescue_from ActiveRecord::RecordNotFound, with: -> { head :not_found }
 
   def add_patient
     current_user.add_patient @patient

--- a/app/models/call_list_entry.rb
+++ b/app/models/call_list_entry.rb
@@ -1,25 +1,10 @@
 # Object representing a patient's call list.
-class CallListEntry
-  include Mongoid::Document
-  include Mongoid::Timestamps
-
+class CallListEntry < ApplicationRecord
   # Relationships
   belongs_to :user
   belongs_to :patient
 
-  # Fields
-  field :order_key, type: Integer
-  field :line, type: String
-
   # Validations
   validates :order_key, :line, presence: true
   validates :patient, uniqueness: { scope: :user }
-
-  # Indices
-  index line: 1
-
-  def self.destroy_orphaned_entries
-    includes(:patient).reject(&:patient)
-                      .each { |x| x.destroy }
-  end
 end

--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -34,9 +34,8 @@ module CallListable
   end
 
   def remove_patient(patient)
-    call_list_entries.find_by(patient_id: patient.id).destroy
+    call_list_entries.find_by!(patient_id: patient.id).destroy
     reload
-  rescue Mongoid::Errors::DocumentNotFound
   end
 
   def reorder_call_list(order, line)
@@ -57,28 +56,28 @@ module CallListable
       clear_call_list(LINES)
     else
       ids_for_destroy = recently_reached_patients(LINES).map { |x| x.id.to_s }
-      call_list_entries.in(patient_id: ids_for_destroy).destroy_all
+      call_list_entries.where(patient_id: ids_for_destroy).destroy_all
     end
     reload
   end
 
   def clear_call_list(line)
-    call_list_entries.in(line: line).destroy_all
+    call_list_entries.where(line: line).destroy_all
   end
 
   private
 
   def ordered_patients(line)
     call_list_entries.includes(:patient)
-                     .in(line: line)
-                     .order_by(order_key: :asc)
+                     .where(line: line)
+                     .order(order_key: :asc)
                      .map(&:patient)
                      .reject(&:nil?)
   end
 
   def recently_reached_by_user?(patient)
     patient.calls.any? do |call|
-      call.created_by_id == id && call.recent? && call.reached?
+      call.created_by_id == id && call.recent? && call.reached_patient?
     end
   end
 

--- a/app/models/mongo_call_list_entry.rb
+++ b/app/models/mongo_call_list_entry.rb
@@ -1,0 +1,25 @@
+# Object representing a patient's call list.
+class MongoCallListEntry
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  # Relationships
+  belongs_to :user
+  belongs_to :patient
+
+  # Fields
+  field :order_key, type: Integer
+  field :line, type: String
+
+  # Validations
+  validates :order_key, :line, presence: true
+  validates :patient, uniqueness: { scope: :user }
+
+  # Indices
+  index line: 1
+
+  def self.destroy_orphaned_entries
+    includes(:patient).reject(&:patient)
+                      .each { |x| x.destroy }
+  end
+end

--- a/app/models/mongo_call_list_entry.rb
+++ b/app/models/mongo_call_list_entry.rb
@@ -3,6 +3,8 @@ class MongoCallListEntry
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  store_in collection: 'call_list_entries'
+
   # Relationships
   belongs_to :user
   belongs_to :patient

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 class User < ApplicationRecord
   # Concerns
   include PaperTrailable
-  # include CallListable # Soon
+  include CallListable
 
   # Devise modules
   devise  :database_authenticatable,
@@ -29,7 +29,7 @@ class User < ApplicationRecord
   after_create :send_account_created_email, if: :persisted?
 
   # Relationships
-  # has_many :call_list_entries # Soon
+  has_many :call_list_entries
 
   # Validations
   # email presence validated through Devise

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,7 +14,7 @@
           <%#= link_to 'Sign up', new_registration_path(resource_name), class: 'right' %>
         <% end -%>
         <%= f.email_field :email,
-                          label: t('mongoid.attributes.user.email'),
+                          label: t('activerecord.attributes.user.email'),
                           autofocus: true,
                           autocorrect: 'off',
                           autocapitalize: 'off',

--- a/db/migrate/20210502050214_create_call_list_entries.rb
+++ b/db/migrate/20210502050214_create_call_list_entries.rb
@@ -1,0 +1,15 @@
+class CreateCallListEntries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :call_list_entries do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :patient, null: false, foreign_key: true
+
+      t.string :line, null: false
+      t.integer :order_key, null: false
+
+      t.timestamps
+    end
+
+    add_index :call_list_entries, :line
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_26_033002) do
+ActiveRecord::Schema.define(version: 2021_05_02_050214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "call_list_entries", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "patient_id", null: false
+    t.string "line", null: false
+    t.integer "order_key", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["line"], name: "index_call_list_entries_on_line"
+    t.index ["patient_id"], name: "index_call_list_entries_on_patient_id"
+    t.index ["user_id"], name: "index_call_list_entries_on_user_id"
+  end
 
   create_table "calls", force: :cascade do |t|
     t.integer "status", null: false
@@ -204,6 +216,8 @@ ActiveRecord::Schema.define(version: 2021_04_26_033002) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "call_list_entries", "patients"
+  add_foreign_key "call_list_entries", "users"
   add_foreign_key "patients", "clinics"
   add_foreign_key "patients", "users", column: "last_edited_by_id"
   add_foreign_key "patients", "users", column: "pledge_generated_by_id"

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -91,6 +91,20 @@ namespace :migrate_to_pg do
         end
         migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'can_call', extra_transform)
       end
+
+      # Then, a couple spares that are Patient only
+      pt = Patient
+      mongo_pt = MongoPatient
+
+      # Call List Entries
+      pg = CallListEntry
+      mongo = MongoCallListEntry
+      extra_transform = Proc.new do |attrs, obj|
+        attrs['patient_id'] = Patient.find_by!(mongo_id: obj['patient_id'].to_s).id
+        attrs['user_id'] = User.find_by!(mongo_id: obj['user_id'].to_s).id
+        attrs
+      end
+      migrate_model(pg, mongo, extra_transform)
     end
   end
 end

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -19,9 +19,6 @@ task nightly_cleanup: :environment do
   MongoidStore::Session.where(:updated_at.lte => 30.days.ago).delete_all  
   puts "#{Time.now} - removed old sessions"
 
-  CallListEntry.destroy_orphaned_entries
-  puts "#{Time.now} - removed orphaned call list entries"
-
   if Time.zone.now.monday?
     # Run these events weekly
     Clinic.update_all_coordinates

--- a/test/controllers/call_lists_controller_test.rb
+++ b/test/controllers/call_lists_controller_test.rb
@@ -65,7 +65,7 @@ class CallListsControllerTest < ActionDispatch::IntegrationTest
       assert_no_difference '@user.call_list_entries.count' do
         patch remove_patient_path(@patient_1), xhr: true
       end
-      assert_response :success
+      assert_response :not_found
     end
 
     it 'should should return bad request on sketch ids' do

--- a/test/models/call_list_entry_test.rb
+++ b/test/models/call_list_entry_test.rb
@@ -22,31 +22,13 @@ class CallListEntryTest < ActiveSupport::TestCase
       call_list_user = @call_list_entry.user_id
 
       entry = build :call_list_entry, patient_id: call_list_pt,
-                                          user_id: call_list_user
+                                      user_id: call_list_user
       refute entry.valid?
-      assert_equal 'Patient is already taken',
+      assert_equal 'Patient has already been taken',
                    entry.errors.full_messages.first
 
       entry.user = create :user
       assert entry.valid?
-    end
-  end
-
-  describe 'mongoid attachments' do
-    it 'should have timestamps from Mongoid::Timestamps' do
-      [:created_at, :updated_at].each do |field|
-        assert @call_list_entry.respond_to? field
-        assert @call_list_entry[field]
-      end
-    end
-  end
-
-  describe 'methods' do
-    it 'should nuke call list entries that do not have a patient associated' do
-      @call_list_entry.update patient: nil
-      assert_difference 'CallListEntry.count', -1 do
-        CallListEntry.destroy_orphaned_entries
-      end
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Merge over Call List stuff.

We are almost back to being able to load the call list - still need notes, but getting ever closer!

To test:

```
git checkout main && rails db:drop db:create db:migrate db:seed
git checkout pg-calllist && rails db:migrate migrate_to_pg:clinic_user_patient
rails c
CallListEntry.count # => 6
```

This pull request makes the following changes:
* migrate call list entry model

no view changes

It relates to the following issue #s: 
* Bumps #2072

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
