### PR TITLE
Migrate Note to PG

### DIFF
--- a/app/models/mongo_note.rb
+++ b/app/models/mongo_note.rb
@@ -1,0 +1,25 @@
+# A case manager's log of their interactions with a patient.
+# A patient embeds many notes.
+class MongoNote
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::History::Trackable
+  include Mongoid::Userstamp
+
+  # Relationships
+  embedded_in :patient
+
+  # Fields
+  field :full_text, type: String
+
+  # Validations
+  validates :created_by_id, :full_text, presence: true
+
+  # History and auditing
+  track_history on: fields.keys + [:updated_by_id],
+                version_field: :version,
+                track_create: true,
+                track_update: true,
+                track_destroy: true
+  mongoid_userstamp user_model: 'User'
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,8 @@
 # A case manager's log of their interactions with a patient.
 class Note < ApplicationRecord
+  # Concerns
+  include PaperTrailable
+
   # Relationships
   belongs_to :patient
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,25 +1,8 @@
 # A case manager's log of their interactions with a patient.
-# A patient embeds many notes.
-class Note
-  include Mongoid::Document
-  include Mongoid::Timestamps
-  include Mongoid::History::Trackable
-  include Mongoid::Userstamp
-
+class Note < ApplicationRecord
   # Relationships
-  embedded_in :patient
-
-  # Fields
-  field :full_text, type: String
+  belongs_to :patient
 
   # Validations
-  validates :created_by_id, :full_text, presence: true
-
-  # History and auditing
-  track_history on: fields.keys + [:updated_by_id],
-                version_field: :version,
-                track_create: true,
-                track_update: true,
-                track_destroy: true
-  mongoid_userstamp user_model: 'User'
+  validates :full_text, presence: true
 end

--- a/app/views/notes/_notes_table.html.erb
+++ b/app/views/notes/_notes_table.html.erb
@@ -4,7 +4,7 @@
       <% unless note.new_record? %>
         <tr class="note-header">
           <th>
-            <%= note.created_by.name %> <%= note.created_at.display_date %> <%= note.created_at.display_time %>    
+            <%= note.created_by&.name || 'System' %> <%= note.created_at.display_date %> <%= note.created_at.display_time %>    
           </th>
         </tr>
         <tr class="note-body">

--- a/app/views/patients/_notes.html.erb
+++ b/app/views/patients/_notes.html.erb
@@ -28,5 +28,5 @@
     </div>
 
   <%= render partial: 'notes/notes_table',
-             locals: { notes: patient.notes.includes(:created_by).order_by('created_at desc') } %>
+             locals: { notes: patient.notes.order(created_at: :desc) } %>
 </div>

--- a/db/migrate/20210503043154_create_notes.rb
+++ b/db/migrate/20210503043154_create_notes.rb
@@ -1,0 +1,11 @@
+class CreateNotes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notes do |t|
+      t.string :full_text, null: false
+
+      t.references :patient
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_02_050214) do
+ActiveRecord::Schema.define(version: 2021_05_03_043154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -117,6 +117,14 @@ ActiveRecord::Schema.define(version: 2021_05_02_050214) do
     t.index ["audited"], name: "index_fulfillments_on_audited"
     t.index ["can_fulfill_type", "can_fulfill_id"], name: "index_fulfillments_on_can_fulfill_type_and_can_fulfill_id"
     t.index ["fulfilled"], name: "index_fulfillments_on_fulfilled"
+  end
+
+  create_table "notes", force: :cascade do |t|
+    t.string "full_text", null: false
+    t.bigint "patient_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["patient_id"], name: "index_notes_on_patient_id"
   end
 
   create_table "patients", force: :cascade do |t|

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -178,7 +178,11 @@ def migrate_submodel(pt_model, mongo_pt_model, pg_model, mongo_model, relation, 
     end
 
     # Check
-    obj_count = pg_model.where(parent_relation.to_sym => pt_model.find_by!(mongo_id: doc['_id'].to_s)).count
+    begin
+      obj_count = pg_model.where(parent_relation.to_sym => pt_model.find_by!(mongo_id: doc['_id'].to_s)).count
+    rescue ActiveRecord::StatementInvalid
+      binding.pry
+    end
     if obj_count != mongo_objs.count
       raise "PG and mongo counts for #{relation} are in disagreement (#{obj_count} and #{mongo_objs.count}); aborting"
     end

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -110,11 +110,10 @@ namespace :migrate_to_pg do
       pg = Note
       mongo = MongoNote
       extra_transform = Proc.new do |attrs, obj, doc|
-        attrs['patient_id'] = Patient.find_by!(mongo_id: doc['_id'].to_s).id
-        puts attrs
+        attrs['patient'] = pt.find_by! mongo_id: doc['_id'].to_s
         attrs
       end
-      migrate_submodel(pt, mongo_pt, pg, mongo, 'notes', 'notes', extra_transform)
+      migrate_submodel(pt, mongo_pt, pg, mongo, 'notes', 'patient', extra_transform)
     end
   end
 end
@@ -178,11 +177,7 @@ def migrate_submodel(pt_model, mongo_pt_model, pg_model, mongo_model, relation, 
     end
 
     # Check
-    begin
-      obj_count = pg_model.where(parent_relation.to_sym => pt_model.find_by!(mongo_id: doc['_id'].to_s)).count
-    rescue ActiveRecord::StatementInvalid
-      binding.pry
-    end
+    obj_count = pg_model.where(parent_relation.to_sym => pt_model.find_by!(mongo_id: doc['_id'].to_s)).count
     if obj_count != mongo_objs.count
       raise "PG and mongo counts for #{relation} are in disagreement (#{obj_count} and #{mongo_objs.count}); aborting"
     end

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -98,6 +98,7 @@ namespace :migrate_to_pg do
           attrs['patient_id'] = Patient.find_by!(mongo_id: doc['_id'].to_s).id
           attrs
         end
+        migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'notes', extra_transform)
       end
 
       # Then, a couple spares that are Patient only

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -114,7 +114,7 @@ namespace :migrate_to_pg do
         puts attrs
         attrs
       end
-      migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'notes', extra_transform)
+      migrate_submodel(pt, mongo_pt, pg, mongo, 'notes', 'notes', extra_transform)
     end
   end
 end

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -90,6 +90,14 @@ namespace :migrate_to_pg do
           attrs
         end
         migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'can_call', extra_transform)
+
+        # Then, notes
+        pg = Note
+        mongo = MongoNote
+        extra_transform = Proc.new do |attrs, obj, doc|
+          attrs['patient_id'] = Patient.find_by!(mongo_id: doc['_id'].to_s).id
+          attrs
+        end
       end
 
       # Then, a couple spares that are Patient only

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -90,15 +90,6 @@ namespace :migrate_to_pg do
           attrs
         end
         migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'can_call', extra_transform)
-
-        # Then, notes
-        pg = Note
-        mongo = MongoNote
-        extra_transform = Proc.new do |attrs, obj, doc|
-          attrs['patient_id'] = Patient.find_by!(mongo_id: doc['_id'].to_s).id
-          attrs
-        end
-        migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'notes', extra_transform)
       end
 
       # Then, a couple spares that are Patient only
@@ -114,6 +105,16 @@ namespace :migrate_to_pg do
         attrs
       end
       migrate_model(pg, mongo, extra_transform)
+
+      # Notes
+      pg = Note
+      mongo = MongoNote
+      extra_transform = Proc.new do |attrs, obj, doc|
+        attrs['patient_id'] = Patient.find_by!(mongo_id: doc['_id'].to_s).id
+        puts attrs
+        attrs
+      end
+      migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'notes', extra_transform)
     end
   end
 end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -9,12 +9,16 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
 
   describe 'create method' do
     before do
-      @note = attributes_for :note, full_text: 'This is a note'
-      post patient_notes_path(@patient), params: { note: @note }, xhr: true
+      with_versioning do
+        PaperTrail.request(whodunnit: @user) do
+          @note = attributes_for :note, full_text: 'This is a note'
+          post patient_notes_path(@patient), params: { note: @note }, xhr: true
+        end
+      end
     end
 
     it 'should create and save a new note' do
-      assert_difference 'Patient.find(@patient).notes.count', 1 do
+      assert_difference 'Patient.find(@patient.id).notes.count', 1 do
         post patient_notes_path(@patient), params: { note: @note }, xhr: true
       end
     end
@@ -24,12 +28,12 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should log the creating user' do
-      assert_equal Patient.find(@patient).notes.first.created_by, @user
+      assert_equal Patient.find(@patient.id).notes.first.created_by, @user
     end
 
     it 'should alert failure if there is not text or an associated patient' do
       @note[:full_text] = nil
-      assert_no_difference 'Patient.find(@patient).notes.count' do
+      assert_no_difference 'Patient.find(@patient.id).notes.count' do
         post patient_notes_path(@patient), params: { note: @note }, xhr: true
       end
       assert_response :bad_request

--- a/test/factories/note.rb
+++ b/test/factories/note.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :note do
     patient
     full_text { 'behold, a note' }
-    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/helpers/notes_helper_test.rb
+++ b/test/helpers/notes_helper_test.rb
@@ -23,12 +23,16 @@ class NotesHelperTest < ActionView::TestCase
     end
 
     it 'should return note name, timestamp, and full text if it has text' do
-      note = create :note
-      displayed_note_text = display_note_text_for note
+      with_versioning do
+        PaperTrail.request(whodunnit: create(:user)) do
+          note = create :note
+          displayed_note_text = display_note_text_for note
 
-      assert_match note.created_at.display_timestamp, displayed_note_text
-      assert_match note.full_text, displayed_note_text
-      assert_match note.created_by.name, displayed_note_text
+          assert_match note.created_at.display_timestamp, displayed_note_text
+          assert_match note.full_text, displayed_note_text
+          assert_match note.created_by.name, displayed_note_text
+        end
+      end
     end
   end
 end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -2,9 +2,14 @@ require 'test_helper'
 
 class NoteTest < ActiveSupport::TestCase
   before do
-    @user = create :user
-    @patient = create :patient
-    @note = create :note, patient: @patient, created_by: @user
+    with_versioning do
+      @user = create :user
+      PaperTrail.request(whodunnit: @user) do
+        @patient = create :patient
+        @patient.notes.create attributes_for(:note)
+        @note = @patient.notes.first
+      end
+    end
   end
 
   describe 'validation' do
@@ -18,11 +23,6 @@ class NoteTest < ActiveSupport::TestCase
       @note.full_text = nil
       refute @note.valid?
     end
-
-    it 'requires a creator' do
-      @note.created_by = nil
-      refute @note.valid?
-    end
   end
 
   describe 'relationships' do
@@ -32,22 +32,11 @@ class NoteTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'mongoid attachments' do
-    it 'should have timestamps from Mongoid::Timestamps' do
-      [:created_at, :updated_at].each do |field|
-        assert @note.respond_to? field
-        assert @note[field]
-      end
-    end
-
+  describe 'concerns' do
     it 'should respond to history methods' do
-      assert @note.respond_to? :history_tracks
-      assert @note.history_tracks.count > 0
-    end
-
-    it 'should have accessible userstamp methods' do
+      assert @note.respond_to? :versions
       assert @note.respond_to? :created_by
-      assert @note.created_by
+      assert @note.respond_to? :created_by_id
     end
   end
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This is it! This is the one that lets us log in cleanly again. You can run `rails s` and log in, and do some basic call stuff like logging them, moving patients around in the call list, etc.

test the migration via:

```
git checkout main && rails db:drop db:create db:migrate db:seed
git checkout pg-note && rails db:migrate migrate_to_pg:clinic_user_patient
rails c
Note.count # 17
```

or, you could load up the main page I guess, and see the notes section in the call list.

This pull request makes the following changes:
* Port Note model to pg

no view changes

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
