### PR TITLE
Port footer SCSS to webpack

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -117,23 +117,6 @@ a:hover, a:active, a:visited, a:focus {
   padding-bottom: 10px;
 }
 
-// Styling for #app_footer
-#app_footer .glyphicon-earphone {
-  color: inherit;
-  background-color: inherit;
-  vertical-align: top;
-}
-.hr_gradient {
-  border: 0;
-  height: 1px;
-  background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
-}
-.logo {
-  display: inline-block;
-  padding: 0 10px;
-  height: 45px;
-}
-
 // empty add - char
 .blush:empty:before {
   content: '\2013';

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -16,3 +16,4 @@
 @import '../styles/patient_menu';
 @import '../styles/patient_edit';
 @import '../styles/tables';
+@import '../styles/footer';

--- a/app/javascript/styles/footer.scss
+++ b/app/javascript/styles/footer.scss
@@ -1,0 +1,19 @@
+// Styling for application footer.
+
+#app_footer .glyphicon-earphone {
+  color: inherit;
+  background-color: inherit;
+  vertical-align: top;
+}
+
+.hr_gradient {
+  border: 0;
+  height: 1px;
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
+}
+
+.logo {
+  display: inline-block;
+  padding: 0 10px;
+  height: 45px;
+}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Picking up this piece again! This moves footer styling out of sprockets and into webpack. Not too intensive.

This pull request makes the following changes:
* moves footer styling out of sprockets and into a webpack module

no view changes, but you can try it out by increasing `.logo`'s height to 900 or something and then seeing it make the footer images huge.

It relates to the following issue #s: 
* Bumps #1854 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
