### PR TITLE
Move modal styling into webpack

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -203,9 +203,7 @@ a:hover, a:active, a:visited, a:focus {
 
 $daria-color-lt : #825fb9;
 
-// Modal partial styling
 .btn-success {
-
   background-color: $daria-color;
   border-color: $daria-color;
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -277,17 +277,6 @@ $daria-color-lt : #825fb9;
   color: red;
 }
 
-.modal-header, .modal-body, .modal-footer {
-  padding: 30px
-}
-
-.modal-header > h4 {
-  padding-left: 1em;
-  .label {
-    margin-left: -2em;
-  }
-}
-
 #flash {
   position: fixed;
 }
@@ -315,9 +304,4 @@ $daria-color-lt : #825fb9;
 // This is necessary because of a vendored multimodal plugin that we should aim to deprecate
 .hide {
   @extend .d-none;
-}
-
-// widen default modal from bootstrap default
-.modal-dialog {
-  max-width: 60%;
 }

--- a/app/assets/stylesheets/patients.scss
+++ b/app/assets/stylesheets/patients.scss
@@ -10,14 +10,6 @@
     cursor: pointer;
 }
 
-.partial_fulfillment_modal {
-  padding: 5%;
-}
-
-.pledge_modal_category {
-  margin-left: 1em;
-}
-
 // This is necessary because of a vendored multimodal plugin that we should aim to deprecate
 .js-title-step {
   .label {

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -17,3 +17,4 @@
 @import '../styles/patient_edit';
 @import '../styles/tables';
 @import '../styles/footer';
+@import '../styles/modals';

--- a/app/javascript/styles/modals.scss
+++ b/app/javascript/styles/modals.scss
@@ -1,11 +1,18 @@
 // Styling for modals, used in a variety of spots.
-// Generally we inherit everything from bootstrap where possible!
 
 .modal-header > h4 {
   padding-left: 1em;
   .label {
     margin-left: -2em;
   }
+}
+
+.modal-dialog {
+  max-width: 60%;
+}
+
+.modal-header, .modal-body, .modal-footer {
+  padding: 1.75rem;
 }
 
 // Extra padding for accounting modals

--- a/app/javascript/styles/modals.scss
+++ b/app/javascript/styles/modals.scss
@@ -1,0 +1,26 @@
+// Styling for modals, used in a variety of spots.
+
+// widen default modal from bootstrap default
+.modal-dialog {
+  max-width: 60%;
+}
+
+.modal-header, .modal-body, .modal-footer {
+  padding: 30px
+}
+
+.modal-header > h4 {
+  padding-left: 1em;
+  .label {
+    margin-left: -2em;
+  }
+}
+
+// Styling for particular modals
+.partial_fulfillment_modal {
+  padding: 5%;
+}
+
+.pledge_modal_category {
+  margin-left: 1em;
+}

--- a/app/javascript/styles/modals.scss
+++ b/app/javascript/styles/modals.scss
@@ -7,12 +7,15 @@
   }
 }
 
+// These are marked important because of conflicts between
+// sprockets and webpacker. When bootstrap is fully webpackered,
+// we can remove the important declarations.
 .modal-dialog {
-  max-width: 60%;
+  max-width: 60% !important;
 }
 
 .modal-header, .modal-body, .modal-footer {
-  padding: 1.75rem;
+  padding: 1.75rem !important;
 }
 
 // Extra padding for accounting modals

--- a/app/javascript/styles/modals.scss
+++ b/app/javascript/styles/modals.scss
@@ -1,13 +1,5 @@
 // Styling for modals, used in a variety of spots.
-
-// widen default modal from bootstrap default
-.modal-dialog {
-  max-width: 60%;
-}
-
-.modal-header, .modal-body, .modal-footer {
-  padding: 30px
-}
+// Generally we inherit everything from bootstrap where possible!
 
 .modal-header > h4 {
   padding-left: 1em;
@@ -16,11 +8,7 @@
   }
 }
 
-// Styling for particular modals
+// Extra padding for accounting modals
 .partial_fulfillment_modal {
   padding: 5%;
-}
-
-.pledge_modal_category {
-  margin-left: 1em;
 }

--- a/app/views/calls/_new_call.html.erb
+++ b/app/views/calls/_new_call.html.erb
@@ -15,5 +15,5 @@
       <%= display_couldnt_reach_patient_link patient %>
 
       <%= display_note_text_for patient.most_recent_note %>
-  </div><!-- calls-layout -->
-</div><!-- /.modal-body -->
+  </div>
+</div>

--- a/app/views/dashboards/_modal.html.erb
+++ b/app/views/dashboards/_modal.html.erb
@@ -2,6 +2,6 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <!-- dynamically load modal-content -->
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Ports over styling around modals out of sprockets and into webpack.

This pull request makes the following changes:
* port over modal styling overrides into their own webpack module
* delete some unused or ineffective styling that doesn't actually take effect anymore (see comments) 

no view changes

It relates to the following issue #s: 
* Bumps #1854 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
