### PR TITLE
Port practical support model to pg

### DIFF
--- a/app/controllers/practical_supports_controller.rb
+++ b/app/controllers/practical_supports_controller.rb
@@ -2,15 +2,14 @@
 class PracticalSupportsController < ApplicationController
   before_action :find_patient, only: [:create]
   before_action :find_support, only: [:update, :destroy]
-  rescue_from Mongoid::Errors::DocumentNotFound,
+  rescue_from ActiveRecord::RecordNotFound,
               with: -> { head :not_found }
 
   def create
     @support = @patient.practical_supports.new practical_support_params
-    @support.created_by = current_user
     if @support.save
       flash.now[:notice] = t('flash.patient_info_saved', timestamp: Time.zone.now.display_timestamp)
-      @support = @patient.reload.practical_supports.order_by 'created_at desc'
+      @support = @patient.reload.practical_supports.order(created_at: :desc)
       respond_to { |format| format.js }
     else
       flash.now[:alert] = "Practical support failed to save: #{@support.errors.full_messages.to_sentence}"

--- a/app/models/mongo_practical_support.rb
+++ b/app/models/mongo_practical_support.rb
@@ -1,0 +1,27 @@
+# Representation of non-monetary assistance coordinated for a patient.
+class MongoPracticalSupport
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::History::Trackable
+  include Mongoid::Userstamp
+
+  # Relationships
+  embedded_in :can_support, polymorphic: true
+
+  # Fields
+  field :support_type, type: String
+  field :confirmed, type: Mongoid::Boolean
+  field :source, type: String # Name of outside organization or fund
+
+  # Validations
+  validates :created_by_id, :source, :support_type, presence: true
+  validates :support_type, uniqueness: true
+
+  # History and auditing
+  track_history on: fields.keys + [:updated_by_id],
+                version_field: :version,
+                track_create: true,
+                track_update: true,
+                track_destroy: true
+  mongoid_userstamp user_model: 'User'
+end

--- a/app/models/practical_support.rb
+++ b/app/models/practical_support.rb
@@ -1,27 +1,12 @@
 # Representation of non-monetary assistance coordinated for a patient.
-class PracticalSupport
-  include Mongoid::Document
-  include Mongoid::Timestamps
-  include Mongoid::History::Trackable
-  include Mongoid::Userstamp
+class PracticalSupport < ApplicationRecord
+  # Concerns
+  include PaperTrailable
 
   # Relationships
-  embedded_in :can_support, polymorphic: true
-
-  # Fields
-  field :support_type, type: String
-  field :confirmed, type: Mongoid::Boolean
-  field :source, type: String # Name of outside organization or fund
+  belongs_to :can_support, polymorphic: true
 
   # Validations
-  validates :created_by_id, :source, :support_type, presence: true
-  validates :support_type, uniqueness: true
-
-  # History and auditing
-  track_history on: fields.keys + [:updated_by_id],
-                version_field: :version,
-                track_create: true,
-                track_update: true,
-                track_destroy: true
-  mongoid_userstamp user_model: 'User'
+  validates :source, :support_type, presence: true
+  validates :support_type, uniqueness: { scope: :can_support }
 end

--- a/db/migrate/20210509191049_create_practical_supports.rb
+++ b/db/migrate/20210509191049_create_practical_supports.rb
@@ -1,0 +1,13 @@
+class CreatePracticalSupports < ActiveRecord::Migration[6.0]
+  def change
+    create_table :practical_supports do |t|
+      t.string :support_type, null: false
+      t.boolean :confirmed
+      t.string :source, null: false
+
+      t.references :can_support, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_03_043154) do
+ActiveRecord::Schema.define(version: 2021_05_09_191049) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -187,6 +187,17 @@ ActiveRecord::Schema.define(version: 2021_05_03_043154) do
     t.index ["pledge_sent_by_id"], name: "index_patients_on_pledge_sent_by_id"
     t.index ["primary_phone"], name: "index_patients_on_primary_phone", unique: true
     t.index ["urgent_flag"], name: "index_patients_on_urgent_flag"
+  end
+
+  create_table "practical_supports", force: :cascade do |t|
+    t.string "support_type", null: false
+    t.boolean "confirmed"
+    t.string "source", null: false
+    t.string "can_support_type"
+    t.bigint "can_support_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["can_support_type", "can_support_id"], name: "index_practical_supports_on_can_support_type_and_can_support_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -90,6 +90,15 @@ namespace :migrate_to_pg do
           attrs
         end
         migrate_submodel(pt, mongo_pt, pg, mongo, 'calls', 'can_call', extra_transform)
+
+        # Practical supports
+        pg = PracticalSupport
+        mongo = MongoPracticalSupport
+        extra_transform = Proc.new do |attrs, obj, doc|
+          attrs['can_support'] = pt.find_by! mongo_id: doc['_id'].to_s
+          attrs
+        end
+        migrate_submodel(pt, mongo_pt, pg, mongo, 'practical_supports', 'can_support', extra_transform)
       end
 
       # Then, a couple spares that are Patient only

--- a/test/controllers/practical_supports_controller_test.rb
+++ b/test/controllers/practical_supports_controller_test.rb
@@ -9,15 +9,19 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
 
   describe 'create' do
     before do
-      @support = attributes_for :practical_support
-      post patient_practical_supports_path(@patient),
-           params: { practical_support: @support },
-           xhr: true
+      with_versioning do
+        PaperTrail.request(whodunnit: @user) do
+          @support = attributes_for :practical_support
+          post patient_practical_supports_path(@patient),
+               params: { practical_support: @support },
+               xhr: true
+        end
+      end
     end
 
     it 'should create and save a new support record' do
       @support[:support_type] = 'different'
-      assert_difference 'Patient.find(@patient).practical_supports.count', 1 do
+      assert_difference 'Patient.find(@patient.id).practical_supports.count', 1 do
         post patient_practical_supports_path(@patient), params: { practical_support: @support }, xhr: true
       end
     end
@@ -33,7 +37,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it 'should log the creating user' do
-      assert_equal Patient.find(@patient).practical_supports.last.created_by,
+      assert_equal Patient.find(@patient.id).practical_supports.last.created_by,
                    @user
     end
   end
@@ -42,8 +46,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
     before do
       @patient.practical_supports.create support_type: 'Transit',
                                          confirmed: false,
-                                         source: 'Transit',
-                                         created_by: @user
+                                         source: 'Transit'
       @support = @patient.practical_supports.first
       @support_edits = { support_type: 'Lodging' }
       patch patient_practical_support_path(@patient, @support),
@@ -63,9 +66,7 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
     [:source, :support_type].each do |field|
       it "should refuse to save #{field} to blank" do
         [nil, ''].each do |bad_text|
-          assert_no_difference 'Patient.find(@patient)
-                                       .practical_supports.find(@support)
-                                       .history_tracks.count' do
+          assert_no_difference '@support.versions.count' do
             @support_edits[:source] = bad_text
             patch patient_practical_support_path(@patient, @support),
                   params: { practical_support: @support_edits },
@@ -81,13 +82,12 @@ class PracticalSupportsControllerTest < ActionDispatch::IntegrationTest
     before do
       @patient.practical_supports.create support_type: 'Transit',
                                          confirmed: false,
-                                         source: 'Transit',
-                                         created_by: @user
+                                         source: 'Transit'
       @support = @patient.practical_supports.first
     end
 
     it 'should destroy a support record' do
-      assert_difference 'Patient.find(@patient).practical_supports.count', -1 do
+      assert_difference 'Patient.find(@patient.id).practical_supports.count', -1 do
         delete patient_practical_support_path(@patient, @support), xhr: true
       end
     end

--- a/test/factories/practical_support.rb
+++ b/test/factories/practical_support.rb
@@ -8,6 +8,5 @@ FactoryBot.define do
       "Support #{n}"
     end
     confirmed { false }
-    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/models/practical_support_test.rb
+++ b/test/models/practical_support_test.rb
@@ -4,38 +4,25 @@ class PracticalSupportTest < ActiveSupport::TestCase
   before do
     @user = create :user
     @patient = create :patient
-    @patient.practical_supports.create created_by: @user,
-                                support_type: 'Concert Tickets',
-                                source: 'Metallica Abortion Fund'
-    @patient.practical_supports.create created_by: @user,
-                                support_type: 'Swag',
-                                source: 'YOLO AF',
-                                confirmed: true
+    @patient.practical_supports.create support_type: 'Concert Tickets',
+                                       source: 'Metallica Abortion Fund'
+    @patient.practical_supports.create support_type: 'Swag',
+                                       source: 'YOLO AF',
+                                       confirmed: true
     @psupport1 = @patient.practical_supports.first
     @psupport2 = @patient.practical_supports.last
   end
 
-  describe 'mongoid attachments' do
-    it 'should have timestamps from Mongoid::Timestamps' do
-      [:created_at, :updated_at].each do |field|
-        assert @psupport1.respond_to? field
-        assert @psupport1[field]
-      end
-    end
-
+  describe 'concerns' do
     it 'should respond to history methods' do
       assert @psupport1.respond_to? :history_tracks
-      assert @psupport1.history_tracks.count > 0
-    end
-
-    it 'should have accessible userstamp methods' do
       assert @psupport1.respond_to? :created_by
-      assert @psupport1.created_by
+      assert @psupport1.respond_to? :created_by_id
     end
   end
 
   describe 'validations' do
-    [:created_by, :source, :support_type].each do |field|
+    [:source, :support_type].each do |field|
       it "should enforce presence of #{field}" do
         @psupport1[field.to_sym] = nil
         refute @psupport1.valid?
@@ -49,7 +36,7 @@ class PracticalSupportTest < ActiveSupport::TestCase
 
       support2 = @patient.practical_supports.new fields
       refute support2.valid?
-      assert_equal ['is already taken'],
+      assert_equal ['has already been taken'],
                    support2.errors.messages[:support_type]
     end
   end

--- a/test/system/practical_support_behaviors_test.rb
+++ b/test/system/practical_support_behaviors_test.rb
@@ -87,8 +87,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
   describe 'destroying a practical support entry' do
     before do
       @patient.practical_supports.create support_type: 'lodging',
-                                         source: 'Other (see notes)',
-                                         created_by: @user
+                                         source: 'Other (see notes)'
       go_to_practical_support_tab
     end
 
@@ -107,8 +106,7 @@ class PracticalSupportBehaviorsTest < ApplicationSystemTestCase
   describe 'hiding practical support' do
     before do
       @patient.practical_supports.create support_type: 'lodging',
-                                         source: 'Other (see notes)',
-                                         created_by: @user
+                                         source: 'Other (see notes)'
     end
 
     it 'can hide the practical support tab' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Ports practical support and associated logic to postgres.

There's no practical supports in the seedfile, so you'll need to create some manually, unfortunately:
```
git checkout main && rails db:drop db:create db:migrate db:seed
echo "Patient.first.practical_supports.create source: 'Metallica Abortion Fund', support_type: 'Transportation', created_by: User.first" | rails c
echo "Patient.last.practical_supports.create source: 'Metallica Abortion Fund', support_type: 'Transportation', created_by: User.first" | rails c

git checkout pg-psup && rails db:migrate migrate_to_pg:clinic_user_patient
echo "PracticalSupport.count" # 2
```

This pull request makes the following changes:
* Port PracticalSupport model to pg

no view changes

It relates to the following issue #s: 
* Bumps #2072

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
