### PR TITLE
Port navbar scss to webpack

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -64,29 +64,6 @@ a:hover, a:active, a:visited, a:focus {
   border-color: #A42823 !important;
 }
 
-/* NAVBAR */
-.navbar-inverse{
-  background-color: #f5f5f5;
-  border: none;
-  .navbar-header > a, .navbar-nav > li > a {
-    color: $daria-color;
-    &:hover{
-      color: lighten($daria-color, 20%);
-      text-decoration: underline;
-    }
-    &:visited{
-      color: #000080;
-    }
-  }
-
-  .navbar-text {
-    color: $daria-color;
-  }
-
-  .navbar-text-alt {
-    color: $grey-color;
-  }
-}
 
 .form-error {
   color: red;

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -18,3 +18,4 @@
 @import '../styles/tables';
 @import '../styles/footer';
 @import '../styles/modals';
+@import '../styles/navbar';

--- a/app/javascript/styles/navbar.scss
+++ b/app/javascript/styles/navbar.scss
@@ -1,0 +1,29 @@
+// Styling for the navbar.
+
+@import './_variables';
+
+.navbar-inverse{
+  background-color: $light-gray;
+  border: none;
+
+  .navbar-header > a, .navbar-nav > li > a {
+    color: $daria-color;
+
+    &:hover{
+      color: lighten($daria-color, 20%);
+      text-decoration: underline;
+    }
+
+    &:visited{
+      color: $dark-blue;
+    }
+  }
+
+  .navbar-text {
+    color: $daria-color;
+  }
+
+  .navbar-text-alt {
+    color: $grey-color;
+  }
+}


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Moves navbar styling out of sprockets and into a webpack module.

No view changes, but you can try it out by checking that the navbar background is #F1F1F1 rather than what it used to be, #F5F5F5.

This pull request makes the following changes:
* port navbar scss into its own webpack module


It relates to the following issue #s: 
* Bumps #1854 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
