### PR TITLE
Add archive configs

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -14,7 +14,7 @@ class Config < ApplicationRecord
     start_of_week: "How to render your budget bar. Default is weekly starting on Monday. Enter \"Sunday\" for weekly budget starting on Sunday, or \"Monthly\" for a calendar month based budget.",
     budget_bar_max: "The maximum for the budget bar. Defaults to 1000 if not set. Enter as a number with no dollar sign or commas.",
     hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.',
-    days_to_keep_fulfilled_patients: "Number of days (after initial entry) to keep identifying information for a patient whose pledge has been fulfilled. Defaults to 90 days (3 months).",
+    days_to_keep_fulfilled_patients: "Number of days (after initial entry) to keep identifying information for a patient whose pledge has been fulfilled and marked audited. Defaults to 90 days (3 months).",
     days_to_keep_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year)."
   }.freeze
 

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -14,8 +14,8 @@ class Config < ApplicationRecord
     start_of_week: "How to render your budget bar. Default is weekly starting on Monday. Enter \"Sunday\" for weekly budget starting on Sunday, or \"Monthly\" for a calendar month based budget.",
     budget_bar_max: "The maximum for the budget bar. Defaults to 1000 if not set. Enter as a number with no dollar sign or commas.",
     hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.',
-    archive_fulfilled_patients: "Number of days (after initial entry) to keep identifying information for a patient whose pledge has been fulfilled. Defaults to 90 days (3 months).",
-    archive_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year)."
+    days_to_keep_fulfilled_patients: "Number of days (after initial entry) to keep identifying information for a patient whose pledge has been fulfilled. Defaults to 90 days (3 months).",
+    days_to_keep_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year)."
   }.freeze
 
   enum config_key: {
@@ -32,8 +32,8 @@ class Config < ApplicationRecord
     start_of_week: 10,
     budget_bar_max: 11,
     voicemail: 12,
-    archive_fulfilled_patients: 13,
-    archive_all_patients: 14
+    days_to_keep_fulfilled_patients: 13,
+    days_to_keep_all_patients: 14
   }
 
   # which fields are URLs (run special validation only on those)
@@ -55,8 +55,8 @@ class Config < ApplicationRecord
     fax_service: :validate_url,
     practical_support_guidance_url: :validate_url,
 
-    archive_fulfilled_patients: :validate_patient_archive,
-    archive_all_patients: :validate_patient_archive,
+    days_to_keep_fulfilled_patients: :validate_patient_archive,
+    days_to_keep_all_patients: :validate_patient_archive,
   }.freeze
 
   before_validation :clean_config_value
@@ -101,14 +101,14 @@ class Config < ApplicationRecord
   end
 
   def self.archive_fulfilled_patients
-    archive_days = Config.find_or_create_by(config_key: 'archive_fulfilled_patients').options.try :last
+    archive_days = Config.find_or_create_by(config_key: 'days_to_keep_fulfilled_patients').options.try :last
     # default 3 months
     archive_days ||= 90
     archive_days.to_i
   end
 
   def self.archive_all_patients
-    archive_days = Config.find_or_create_by(config_key: 'archive_all_patients').options.try :last
+    archive_days = Config.find_or_create_by(config_key: 'days_to_keep_all_patients').options.try :last
     # default 1 year
     archive_days ||= 365
     archive_days.to_i

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -13,7 +13,9 @@ class Config < ApplicationRecord
     fax_service: 'A link to your fax service. ex: https://www.efax.com',
     start_of_week: "How to render your budget bar. Default is weekly starting on Monday. Enter \"Sunday\" for weekly budget starting on Sunday, or \"Monthly\" for a calendar month based budget.",
     budget_bar_max: "The maximum for the budget bar. Defaults to 1000 if not set. Enter as a number with no dollar sign or commas.",
-    hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.'
+    hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.',
+    archive_fulfilled_patients: "Number of days (after initial entry) to keep identifying information for a patient whose pledge has been fulfilled. Defaults to 90 days (3 months).",
+    archive_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year)."
   }.freeze
 
   enum config_key: {
@@ -30,6 +32,8 @@ class Config < ApplicationRecord
     start_of_week: 10,
     budget_bar_max: 11,
     voicemail: 12,
+    archive_fulfilled_patients: 13,
+    archive_all_patients: 14
   }
 
   # which fields are URLs (run special validation only on those)
@@ -49,7 +53,10 @@ class Config < ApplicationRecord
     
     resources_url: :validate_url,
     fax_service: :validate_url,
-    practical_support_guidance_url: :validate_url
+    practical_support_guidance_url: :validate_url,
+
+    archive_fulfilled_patients: :validate_patient_archive,
+    archive_all_patients: :validate_patient_archive,
   }.freeze
 
   before_validation :clean_config_value
@@ -91,6 +98,20 @@ class Config < ApplicationRecord
     start = Config.find_or_create_by(config_key: 'start_of_week').options.try :last
     start ||= "monday"
     start.downcase.to_sym
+  end
+
+  def self.archive_fulfilled_patients
+    archive_days = Config.find_or_create_by(config_key: 'archive_fulfilled_patients').options.try :last
+    # default 3 months
+    archive_days ||= 90
+    archive_days.to_i
+  end
+
+  def self.archive_all_patients
+    archive_days = Config.find_or_create_by(config_key: 'archive_all_patients').options.try :last
+    # default 1 year
+    archive_days ||= 365
+    archive_days.to_i
   end
 
   private
@@ -136,7 +157,7 @@ class Config < ApplicationRecord
 
     # generic validator for numerics
     def validate_number
-      return options.last =~ /\A\d+\z/
+      options.last =~ /\A\d+\z/
     end
 
 
@@ -169,13 +190,21 @@ class Config < ApplicationRecord
     ].freeze
 
     def validate_start_of_week
-      return START_OF_WEEK.include?(options.last.capitalize)
+      START_OF_WEEK.include?(options.last.capitalize)
     end
 
     ### Practical support
 
     def validate_hide_practical_support
       # allow yes or no, to be nice (technically only yes is considered)
-      return options.last =~ /\A(yes|no)\z/i
+      options.last =~ /\A(yes|no)\z/i
+    end
+
+    ### Patient archive
+    ARCHIVE_MIN_DAYS = 60   # 2 months
+    ARCHIVE_MAX_DAYS = 550  # 1.5 years
+
+    def validate_patient_archive
+      validate_number && options.last.to_i.between?(ARCHIVE_MIN_DAYS, ARCHIVE_MAX_DAYS)
     end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -268,7 +268,6 @@ class Patient
       # If a patient fulfillment is ticked off as audited, archive 3 months
       # after initial call date. If we're already past 3 months later when
       # the audit happens, it will archive that night
-      # initial_call_date + 3.months
       initial_call_date + Config.archive_fulfilled_patients.days
     else
       # If a patient is waiting for audit they archive a year after their

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -268,11 +268,12 @@ class Patient
       # If a patient fulfillment is ticked off as audited, archive 3 months
       # after initial call date. If we're already past 3 months later when
       # the audit happens, it will archive that night
-      initial_call_date + 3.months
+      # initial_call_date + 3.months
+      initial_call_date + Config.archive_fulfilled_patients.days
     else
       # If a patient is waiting for audit they archive a year after their
       # initial call date
-      initial_call_date + 1.year
+      initial_call_date + Config.archive_all_patients.days
     end
   end
 

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -121,6 +121,36 @@ class ConfigTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'archive_patients' do
+      it 'should return proper defaults' do
+        assert_equal 90, Config.archive_fulfilled_patients
+        assert_equal 365, Config.archive_all_patients
+      end
+
+      it 'should validate bounds' do
+        c = Config.find_or_create_by(config_key: 'archive_all_patients')
+        
+        # low out of bounds
+        c.config_value = { options: ["10"] }
+        refute c.valid?
+        
+        # low edge
+        c.config_value = { options: ["60"] }
+        assert c.valid?
+        
+        # in bounds
+        c.config_value = { options: ["120"] }
+        assert c.valid?
+        
+        # high edge
+        c.config_value = { options: ["550"] }
+        assert c.valid?
+        
+        c.config_value = { options: ["1000"] }
+        refute c.valid?
+      end
+    end
+
     describe '#hide_practical_support?' do
       it 'can return true' do
         c = Config.find_or_create_by(config_key: 'hide_practical_support')

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -128,7 +128,7 @@ class ConfigTest < ActiveSupport::TestCase
       end
 
       it 'should validate bounds' do
-        c = Config.find_or_create_by(config_key: 'archive_all_patients')
+        c = Config.find_or_create_by(config_key: 'days_to_keep_all_patients')
         
         # low out of bounds
         c.config_value = { options: ["10"] }

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -131,7 +131,7 @@ class ConfigTest < ActiveSupport::TestCase
         c = Config.find_or_create_by(config_key: 'days_to_keep_all_patients')
         
         # low out of bounds
-        c.config_value = { options: ["10"] }
+        c.config_value = { options: ["59"] }
         refute c.valid?
         
         # low edge
@@ -146,7 +146,7 @@ class ConfigTest < ActiveSupport::TestCase
         c.config_value = { options: ["550"] }
         assert c.valid?
         
-        c.config_value = { options: ["1000"] }
+        c.config_value = { options: ["551"] }
         refute c.valid?
       end
     end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -438,11 +438,11 @@ class PatientTest < ActiveSupport::TestCase
     describe 'archive_date method' do
       it 'should return a year if unaudited' do
         @patient.fulfillment.update audited: false
-        assert_equal @patient.initial_call_date + 1.year, @patient.archive_date
+        assert_equal @patient.initial_call_date + 365.days, @patient.archive_date
       end
       it 'should return three months if audited' do
         @patient.fulfillment.update audited: true
-        assert_equal @patient.initial_call_date + 3.months, @patient.archive_date
+        assert_equal @patient.initial_call_date + 90.days, @patient.archive_date
       end
     end
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -444,6 +444,22 @@ class PatientTest < ActiveSupport::TestCase
         @patient.fulfillment.update audited: true
         assert_equal @patient.initial_call_date + 90.days, @patient.archive_date
       end
+
+      it 'should return custom audit config' do
+        c = Config.find_or_create_by(config_key: 'archive_all_patients')
+        c.config_value = { options: ["100"] }
+        c.save
+
+        c = Config.find_or_create_by(config_key: 'archive_fulfilled_patients')
+        c.config_value = { options: ["300"] }
+        c.save
+
+        @patient.fulfillment.update audited: false
+        assert_equal @patient.initial_call_date + 100.days, @patient.archive_date
+
+        @patient.fulfillment.update audited: true
+        assert_equal @patient.initial_call_date + 300.days, @patient.archive_date
+      end
     end
 
     describe 'has_special_circumstances' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -446,11 +446,11 @@ class PatientTest < ActiveSupport::TestCase
       end
 
       it 'should return custom audit config' do
-        c = Config.find_or_create_by(config_key: 'archive_all_patients')
+        c = Config.find_or_create_by(config_key: 'days_to_keep_all_patients')
         c.config_value = { options: ["100"] }
         c.save
 
-        c = Config.find_or_create_by(config_key: 'archive_fulfilled_patients')
+        c = Config.find_or_create_by(config_key: 'days_to_keep_fulfilled_patients')
         c.config_value = { options: ["300"] }
         c.save
 


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Adds config for custom patient-archive timelines.

This pull request makes the following changes:
* Adds new configs with bounds-checking
* Replaces constants in patient model with those custom values

<img width="577" alt="Screen Shot 2021-05-09 at 17 50 51" src="https://user-images.githubusercontent.com/7085805/117588057-19b69300-b0ef-11eb-85fa-84479a065446.png">

*new configs*

It relates to the following issue #s: 
* Fixes #2150 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
