### PR TITLE
Migrate external pledge to pg

### DIFF
--- a/app/controllers/external_pledges_controller.rb
+++ b/app/controllers/external_pledges_controller.rb
@@ -2,14 +2,13 @@
 class ExternalPledgesController < ApplicationController
   before_action :find_patient, only: [:create]
   before_action :find_pledge, only: [:update, :destroy]
-  rescue_from Mongoid::Errors::DocumentNotFound,
+  rescue_from ActiveRecord::NotFound,
               with: -> { head :not_found }
 
   def create
     @pledge = @patient.external_pledges.new external_pledge_params
-    @pledge.created_by = current_user
     if @pledge.save
-      @pledge = @patient.reload.external_pledges.order_by 'created_at desc'
+      @pledge = @patient.reload.external_pledges.order(created_at: :desc)
       respond_to { |format| format.js }
     else
       head :bad_request

--- a/app/models/external_pledge.rb
+++ b/app/models/external_pledge.rb
@@ -1,31 +1,16 @@
 # Object representing money from organizations that aren't the fund or NAF.
 # For primary fund pledges or NAF pledges, see the patient model.
-class ExternalPledge
-  include Mongoid::Document
-  include Mongoid::Timestamps
-  include Mongoid::History::Trackable
-  include Mongoid::Userstamp
+class ExternalPledge < ApplicationRecord
+  # Concerns
+  include PaperTrailable
 
   # Relationships
-  embedded_in :can_pledge, polymorphic: true
+  belongs_to :can_pledge, polymorphic: true
 
   default_scope -> { where(active: true) }
   scope :active, -> { where(active: true) }
 
-  # Fields
-  field :source, type: String # Name of outside organization or fund
-  field :amount, type: Integer
-  field :active, type: Boolean, default: true
-
   # Validations
-  validates :created_by_id, :source, :amount, presence: true
-  validates :source, uniqueness: { scope: :active }
-
-  # History and auditing
-  track_history on: fields.keys + [:updated_by_id],
-                version_field: :version,
-                track_create: true,
-                track_update: true,
-                track_destroy: true
-  mongoid_userstamp user_model: 'User'
+  validates :source, :amount, presence: true
+  validates :source, uniqueness: { scope: [:active, :can_pledge] }
 end

--- a/app/models/mongo_external_pledge.rb
+++ b/app/models/mongo_external_pledge.rb
@@ -1,0 +1,31 @@
+# Object representing money from organizations that aren't the fund or NAF.
+# For primary fund pledges or NAF pledges, see the patient model.
+class MongoExternalPledge
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::History::Trackable
+  include Mongoid::Userstamp
+
+  # Relationships
+  embedded_in :can_pledge, polymorphic: true
+
+  default_scope -> { where(active: true) }
+  scope :active, -> { where(active: true) }
+
+  # Fields
+  field :source, type: String # Name of outside organization or fund
+  field :amount, type: Integer
+  field :active, type: Boolean, default: true
+
+  # Validations
+  validates :created_by_id, :source, :amount, presence: true
+  validates :source, uniqueness: { scope: :active }
+
+  # History and auditing
+  track_history on: fields.keys + [:updated_by_id],
+                version_field: :version,
+                track_create: true,
+                track_update: true,
+                track_destroy: true
+  mongoid_userstamp user_model: 'User'
+end

--- a/app/views/external_pledges/create.js.erb
+++ b/app/views/external_pledges/create.js.erb
@@ -1,2 +1,2 @@
-$('#existing-external-pledges').empty().append('<%= escape_javascript(render partial: "external_pledges/external_pledges_table", locals: { patient: @patient, external_pledges: @patient.external_pledges.order_by('created_at desc') } ) %>');
+$('#existing-external-pledges').empty().append('<%= escape_javascript(render partial: "external_pledges/external_pledges_table", locals: { patient: @patient, external_pledges: @patient.external_pledges.order(created_at: :desc) } ) %>');
 $('#new-external-pledge').empty().append('<%= escape_javascript(render partial: "external_pledges/new", locals: { patient: @patient, new_external_pledge: @patient.external_pledges.new } ) %>');

--- a/app/views/patients/_abortion_information.html.erb
+++ b/app/views/patients/_abortion_information.html.erb
@@ -94,7 +94,7 @@
       <div class="col">
         <%= render partial: 'external_pledges/external_pledges_table',
                    locals: { patient: patient,
-                             external_pledges: patient.external_pledges.order_by('created_at desc') } %>
+                             external_pledges: patient.external_pledges.order(created_at: :desc) } %>
 
         <div id="new-external-pledge">
           <%= render partial: 'external_pledges/new',

--- a/db/migrate/20210511010317_create_external_pledges.rb
+++ b/db/migrate/20210511010317_create_external_pledges.rb
@@ -1,0 +1,13 @@
+class CreateExternalPledges < ActiveRecord::Migration[6.0]
+  def change
+    create_table :external_pledges do |t|
+      t.string :source, null: false
+      t.integer :amount
+      t.boolean :active
+
+      t.references :can_pledge, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_09_191049) do
+ActiveRecord::Schema.define(version: 2021_05_11_010317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -100,6 +100,17 @@ ActiveRecord::Schema.define(version: 2021_05_09_191049) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["created_at"], name: "index_events_on_created_at"
     t.index ["line"], name: "index_events_on_line"
+  end
+
+  create_table "external_pledges", force: :cascade do |t|
+    t.string "source", null: false
+    t.integer "amount"
+    t.boolean "active"
+    t.string "can_pledge_type", null: false
+    t.bigint "can_pledge_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["can_pledge_type", "can_pledge_id"], name: "index_external_pledges_on_can_pledge_type_and_can_pledge_id"
   end
 
   create_table "fulfillments", force: :cascade do |t|

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -99,6 +99,15 @@ namespace :migrate_to_pg do
           attrs
         end
         migrate_submodel(pt, mongo_pt, pg, mongo, 'practical_supports', 'can_support', extra_transform)
+
+        # Ext pledges
+        pg = ExternalPledge
+        mongo = MongoExternalPledge
+        extra_transform = Proc.new do |attrs, obj, doc|
+          attrs['can_pledge'] = pt.find_by! mongo_id: doc['_id'].to_s
+          attrs
+        end
+        migrate_submodel(pt, mongo_pt, pg, mongo, 'external_pledges', 'can_pledge', extra_transform)
       end
 
       # Then, a couple spares that are Patient only

--- a/test/factories/external_pledge.rb
+++ b/test/factories/external_pledge.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
       "Fund #{n}"
     end
     amount { 100 }
-    created_by { FactoryBot.create(:user) }
   end
 end

--- a/test/helpers/external_pledges_helper_test.rb
+++ b/test/helpers/external_pledges_helper_test.rb
@@ -26,8 +26,7 @@ class ExternalPledgesHelperTest < ActionView::TestCase
       @patient = create :patient
 
       @patient.external_pledges.create source: 'Baltimore Abortion Fund',
-                                       amount: 100,
-                                       created_by: @user
+                                       amount: 100
       #create :external_pledge, source: 'Baltimore Abortion Fund',
       #                         amount: 100,
       #                         patient: @patient

--- a/test/models/external_pledge_test.rb
+++ b/test/models/external_pledge_test.rb
@@ -4,28 +4,16 @@ class ExternalPledgeTest < ActiveSupport::TestCase
   before do
     @user = create :user
     @patient = create :patient
-    @patient.external_pledges.create created_by: @user,
-                                     amount: 100,
+    @patient.external_pledges.create amount: 100,
                                      source: 'BWAH'
     @pledge = @patient.external_pledges.first
   end
 
-  describe 'mongoid attachments' do
-    it 'should have timestamps from Mongoid::Timestamps' do
-      [:created_at, :updated_at].each do |field|
-        assert @pledge.respond_to? field
-        assert @pledge[field]
-      end
-    end
-
+  describe 'concerns' do
     it 'should respond to history methods' do
       assert @pledge.respond_to? :history_tracks
-      assert @pledge.history_tracks.count > 0
-    end
-
-    it 'should have accessible userstamp methods' do
       assert @pledge.respond_to? :created_by
-      assert @pledge.created_by
+      assert @pledge.respond_to? :created_by_id
     end
   end
 
@@ -37,7 +25,7 @@ class ExternalPledgeTest < ActiveSupport::TestCase
       end
     end
 
-    it 'should scope source uniqueness to a particular document' do
+    it 'should scope source uniqueness to patient' do
       pledge = @patient.external_pledges
                        .create attributes_for(:external_pledge,
                                               amount: 200,
@@ -46,19 +34,12 @@ class ExternalPledgeTest < ActiveSupport::TestCase
 
       pledge.source = 'Other Fund'
       assert pledge.valid?
-
-      pt_2 = create :patient
-      pledge2 = pt_2.external_pledges
-                    .create attributes_for(:external_pledge,
-                                           source: 'BWAH')
-      assert pledge2.valid?
     end
   end
 
   describe 'scopes' do
     before do
-      @patient.external_pledges.create! created_by: User.first,
-                                        amount: 100,
+      @patient.external_pledges.create! amount: 100,
                                         source: 'Bar',
                                         active: false
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Migrate the ExternalPledge model to postgres.

The patient edit page isn't _quite_ up to speed with this - looks like there are a few small changes we'll need to make in addition. I'll leave those for a separate PR to keep this one reasonably scoped.

To test:

```
git checkout main && rails db:drop db:create db:migrate db:seed
git checkout pg-extp && rails db:migrate migrate_to_pg:clinic_user_patient
echo "ExternalPledge.count" | rails c # 2
```

This pull request makes the following changes:
* port ExternalPledge to postgres

no view changes

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
