### PR TITLE
Adds a clinic's city & state to the clinic dropdown

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -61,7 +61,7 @@ module PatientsHelper
       [ t('patient.helper.referred_by.sexual_assault_crisis_org'),    'Sexual assault crisis org' ],
       [ t('patient.helper.referred_by.youth'),                        'Youth outreach' ], ]
     full_set = standard_options + Config.find_or_create_by(config_key: 'referred_by').options
-    
+
     options_plus_current(full_set, current_value)
   end
 
@@ -112,7 +112,7 @@ module PatientsHelper
     clinics = Clinic.all.sort_by(&:name)
     active_clinics = clinics.select(&:active)
                             .map { |clinic| [
-                              clinic.name,
+                              t('patient.abortion_information.clinic_section.clinic_display', clinic_name: clinic.name, city: clinic.city, state: clinic.state),
                               clinic.id,
                               { data: { naf: !!clinic.accepts_naf, medicaid: !!clinic.accepts_medicaid } }
                             ]}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,7 @@ en:
     abortion_information:
       clinic_section:
         clinic: Clinic
+        clinic_display: "%{clinic_name} (%{city}, ${state})"
         inactive_clinics: Inactive clinics
         medicaid_only_toggle: Enable only Medicaid clinics
         naf_only_toggle: Enable only NAF clinics

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,7 +286,7 @@ en:
     abortion_information:
       clinic_section:
         clinic: Clinic
-        clinic_display: "%{clinic_name} (%{city}, ${state})"
+        clinic_display: "%{clinic_name} (%{city}, %{state})"
         inactive_clinics: Inactive clinics
         medicaid_only_toggle: Enable only Medicaid clinics
         naf_only_toggle: Enable only NAF clinics

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -286,7 +286,7 @@ es:
     abortion_information:
       clinic_section:
         clinic: Clínica
-        clinic_display: "%{clinic_name} (%{city}, ${state})"
+        clinic_display: "%{clinic_name} (%{city}, %{state})"
         inactive_clinics: Clinícas inactivas
         medicaid_only_toggle: Enseñar solo las clínicas de Medicaid
         naf_only_toggle: Enseñar solo clínicas de la NAF

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -286,6 +286,7 @@ es:
     abortion_information:
       clinic_section:
         clinic: Clínica
+        clinic_display: "%{clinic_name} (%{city}, ${state})"
         inactive_clinics: Clinícas inactivas
         medicaid_only_toggle: Enseñar solo las clínicas de Medicaid
         naf_only_toggle: Enseñar solo clínicas de la NAF

--- a/test/helpers/patients_helper_test.rb
+++ b/test/helpers/patients_helper_test.rb
@@ -74,7 +74,7 @@ class PatientsHelperTest < ActionView::TestCase
       @inactive = create :clinic, name: 'closed clinic', active: false
       expected_clinic_array = [
         nil,
-        [@active.name, @active.id, { data: { naf: false, medicaid: false }}],
+        ["#{@active.name} (#{@active.city}, #{@active.state})", @active.id, { data: { naf: false, medicaid: false }}],
         ['--- INACTIVE CLINICS ---', nil, { disabled: true }],
         ["(Not currently working with DCAF) - #{@inactive.name}", @inactive.id, { data: { naf: false, medicaid: false }}]
       ]
@@ -85,7 +85,7 @@ class PatientsHelperTest < ActionView::TestCase
     it 'should skip inactive clinics section if there are not any' do
       expected_clinic_array = [
         nil,
-        [@active.name, @active.id, { data: { naf: false, medicaid: false }}]
+        ["#{@active.name} (#{@active.city}, #{@active.state})", @active.id, { data: { naf: false, medicaid: false }}]
       ]
 
       assert_same_elements clinic_options, expected_clinic_array

--- a/test/system/filter_medicaid_clinics_test.rb
+++ b/test/system/filter_medicaid_clinics_test.rb
@@ -23,8 +23,8 @@ class FilterMedicaidClinicsTest < ApplicationSystemTestCase
       options_with_filter = find('#patient_clinic_id').all('option')
                                                       .map { |opt| { name: opt.text, disabled: opt['disabled'] } }
 
-      assert_equal 'true', options_with_filter.find { |x| x[:name] == @non_medicaid_clinic.name }[:disabled]
-      assert_equal 'false', options_with_filter.find { |x| x[:name] == @medicaid_clinic.name }[:disabled]
+      assert_equal 'true', options_with_filter.find { |x| x[:name] == "#{@non_medicaid_clinic.name} (#{@non_medicaid_clinic.city}, #{@non_medicaid_clinic.state})" }[:disabled]
+      assert_equal 'false', options_with_filter.find { |x| x[:name] == "#{@medicaid_clinic.name} (#{@medicaid_clinic.city}, #{@medicaid_clinic.state})" }[:disabled]
 
       # try to select and watch it not work
       select @non_medicaid_clinic.name, from: 'patient_clinic_id'

--- a/test/system/filter_medicaid_clinics_test.rb
+++ b/test/system/filter_medicaid_clinics_test.rb
@@ -15,8 +15,8 @@ class FilterMedicaidClinicsTest < ApplicationSystemTestCase
 
   describe 'filtering to just Medicaid clinics' do
     it 'should filter to only Medicaid clinics when box is checked' do
-      assert has_select? 'patient_clinic_id', with_options: [@medicaid_clinic.name,
-                                                             @non_medicaid_clinic.name]
+      assert has_select? 'patient_clinic_id', with_options: ["#{@medicaid_clinic.name} (#{@medicaid_clinic.city}, #{@medicaid_clinic.state})",
+                                                             "#{@non_medicaid_clinic.name} (#{@non_medicaid_clinic.city}, #{@non_medicaid_clinic.state})"]
 
       check 'Enable only Medicaid clinics'
       wait_for_ajax

--- a/test/system/filter_naf_clinics_test.rb
+++ b/test/system/filter_naf_clinics_test.rb
@@ -15,8 +15,8 @@ class FilterNafClinicsTest < ApplicationSystemTestCase
 
   describe 'filtering to just NAF clinics' do
     it 'should filter to only NAF clinics when box is checked' do
-      assert has_select? 'patient_clinic_id', with_options: [@naf_clinic.name,
-                                                             @nonnaf_clinic.name]
+      assert has_select? 'patient_clinic_id', with_options: ["#{@naf_clinic.name} (#{@naf_clinic.city}, #{@naf_clinic.state})" ,
+                                                             "#{@nonnaf_clinic.name} (#{@naf_clinic.city}, #{@naf_clinic.state})" ]
 
       check 'Enable only NAF clinics'
       wait_for_ajax

--- a/test/system/filter_naf_clinics_test.rb
+++ b/test/system/filter_naf_clinics_test.rb
@@ -23,8 +23,8 @@ class FilterNafClinicsTest < ApplicationSystemTestCase
       options_with_filter = find('#patient_clinic_id').all('option')
                                                       .map { |opt| { name: opt.text, disabled: opt['disabled'] } }
 
-      assert_equal 'true', options_with_filter.find { |x| x[:name] == @nonnaf_clinic.name }[:disabled]
-      assert_equal 'false', options_with_filter.find { |x| x[:name] == @naf_clinic.name }[:disabled]
+      assert_equal 'true', options_with_filter.find { |x| x[:name] == "#{@nonnaf_clinic.name} (#{@naf_clinic.city}, #{@naf_clinic.state})" }[:disabled]
+      assert_equal 'false', options_with_filter.find { |x| x[:name] == "#{@naf_clinic.name} (#{@naf_clinic.city}, #{@naf_clinic.state})" }[:disabled]
 
       # try to select and watch it not work
       select @nonnaf_clinic.name, from: 'patient_clinic_id'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Adds clinic city, state to the drop-down in "Patient/edit" > "Abortion Information"

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Resolves #2188 