### PR TITLE
port over form related scss, delete some old bootstrap3 artifacts

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -55,6 +55,7 @@ a:hover, a:active, a:visited, a:focus {
 }
 // End duplicated styles
 
+// accessible color contrast
 .btn-danger {
   background-color: #A42823 !important;
   border-color: #A42823 !important;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -55,19 +55,9 @@ a:hover, a:active, a:visited, a:focus {
 }
 // End duplicated styles
 
-//override the bootstrap form-text and btn-danger defaults for accessible color contrast
-.form-text {
-  color: #595959 !important;
-}
 .btn-danger {
   background-color: #A42823 !important;
   border-color: #A42823 !important;
-}
-
-
-.form-error {
-  color: red;
-  font-size: 14px;
 }
 
 .btn-primary {
@@ -89,43 +79,13 @@ a:hover, a:active, a:visited, a:focus {
   text-decoration: none;
 }
 
-.border-bottom {
-  border-bottom: 1px solid black;
-  padding-bottom: 10px;
-}
 
 
-// increase size of text in form fields
-.form-control {
-  font-size: $font-size;
-}
 
 .btn-lg {
   margin: 15px 0;
   padding: 15px 30px;
 }
-
-
-.column {
-  @extend .col-md-6;
-  @extend .text-center;
-  }
-.form {
-  @extend .col-md-6;
-  }
-.form-centered {
-  @extend .col-md-6;
-  @extend .text-center;
-  }
-.submit {
-  @extend .btn;
-  @extend .btn-primary;
-  @extend .btn-lg;
-  }
-
-// apply styles to HTML elements
-// to make views framework-neutral
-
 
 
 .button-xs {
@@ -135,19 +95,6 @@ a:hover, a:active, a:visited, a:focus {
   @extend .btn-sm;
 }
 
-.info-form .checkbox label {
-  font-weight: bold;
-}
-
-// Search result
-// shell styling
-.form-group input {
-  &[type="date"]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    display: none;
-  }
-
-}
 
 $daria-color-lt : #825fb9;
 
@@ -219,14 +166,8 @@ $daria-color-lt : #825fb9;
 .btn[data-orientation='cancel'] {
   color: red;
 }
-
-.form-check label {
-  min-height: 20px;
-  font-weight: 400;
-  cursor: pointer;
-  line-height: 1.5;
-}
-
-.form-check-label{
-  display: inline;
-}
+.submit {
+  @extend .btn;
+  @extend .btn-primary;
+  @extend .btn-lg;
+  }

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -24,3 +24,4 @@
 @import '../styles/tooltips';
 @import '../styles/lines';
 @import '../styles/flash';
+@import '../styles/forms';

--- a/app/javascript/styles/_variables.scss
+++ b/app/javascript/styles/_variables.scss
@@ -14,6 +14,7 @@ $white: #ffffff;
 $black: #000000;
 $phone-icon-blue: #337ab7;
 $lavendar: #ECE0FF;
+$red: #ff0000;
 
 // Sizing
 $font-size-small: .8rem;

--- a/app/javascript/styles/forms.scss
+++ b/app/javascript/styles/forms.scss
@@ -1,0 +1,26 @@
+// Styling around forms.
+
+// Override rails_bootstrap_forms checkbox styling
+.form-check label {
+  min-height: 20px;
+  font-weight: 400;
+  cursor: pointer;
+  line-height: 1.5;
+}
+.form-check-label {
+  display: inline;
+}
+
+// Override rails bootstrap form-text for accessible color contrast
+.form-text {
+  color: $grey-color !important;
+}
+
+// On date inputs, don't do the annoying
+// 'click to increment up/down' thing.
+.form-group input {
+  &[type="date"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    display: none;
+  }
+}

--- a/app/javascript/styles/globals.scss
+++ b/app/javascript/styles/globals.scss
@@ -72,3 +72,8 @@ a:hover, a:active, a:visited, a:focus {
   color: $dark-blue;
   text-decoration: underline;
 }
+
+.border-bottom {
+  border-bottom: 1px solid $black;
+  padding-bottom: 10px;
+}

--- a/app/javascript/styles/patient_edit.scss
+++ b/app/javascript/styles/patient_edit.scss
@@ -12,6 +12,11 @@
   padding-left: 9.5%;
 }
 
+.pledge-error {
+  color: $red;
+  font-size: $font-size;
+}
+
 // Overrides/styling related to multistep modal
 .js-title-step {
   .label {

--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -3,7 +3,7 @@
     <div class="hide" data-step="1" data-title="<%= t('patient.pledge.step_one.title')%>">
       <% if patient.pledge_info_present? %>
         <% patient.pledge_info_errors.each do |error| %>
-          <div class="form-error row"><%= t('patient.pledge.errors.data_required') %> <%= error %></div>
+          <div class="pledge-error row"><%= t('patient.pledge.errors.data_required') %> <%= error %></div>
         <% end %>
       <% end %>
       <div class="row"><%= t('patient.pledge.step_one.patient_name') %> <%= patient.name %></div>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Ports over the still relevant form scss from webpack; also removes a couple things from the bootstrap 3 era that aren't relevant anymore. (see inline notes)

This pull request makes the following changes:
* ports form-related scss to its own module, or the appropriate patient module
* deletes some old webpack 3 styling

no view changes

It relates to the following issue #s: 
* Bumps #1854 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
