### PR TITLE
Port ArchivedPatient to pg

### DIFF
--- a/app/models/archived_patient.rb
+++ b/app/models/archived_patient.rb
@@ -15,7 +15,8 @@ class ArchivedPatient < ApplicationRecord
   belongs_to :pledge_sent_by, class_name: 'User', inverse_of: nil, optional: true
 
   # Enums
-  enum line: LINES.map { |x| x.to_sym => x.to_s }.inject(&:merge)
+  # turns the LINES env array into the DB friendly structure: { :line1 => "line1", :line2 => "line2", ... }
+  enum line: LINES.map { |x| {x.to_sym => x.to_s} }.inject(&:merge)
   enum age_range: {
     not_specified: :not_specified,
     under_18: :under_18,

--- a/app/models/mongo_archived_patient.rb
+++ b/app/models/mongo_archived_patient.rb
@@ -1,0 +1,149 @@
+class MongoArchivedPatient
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Userstamp
+  extend Enumerize
+
+  store_in collection: 'archived_patients'
+
+  # Concerns
+  include Exportable
+  include LastMenstrualPeriodMeasureable
+
+  # Relationships
+  belongs_to :clinic
+  embeds_one :fulfillment
+  embeds_many :calls
+  embeds_many :external_pledges
+  embeds_many :practical_supports, as: :can_support
+  belongs_to :pledge_generated_by, class_name: 'User', inverse_of: nil
+  belongs_to :pledge_sent_by, class_name: 'User', inverse_of: nil
+
+  # Fields new on archive
+  field :identifier, type: String # UUID, not phone number based!
+
+  # Fields generated from initial patient info
+  field :has_alt_contact, type: Mongoid::Boolean
+  field :age_range
+  enumerize :age_range, in: [:not_specified, :under_18, :age18_24, :age25_34, :age35_44, :age45_54, :age55plus, :bad_value], default: :not_specified
+
+  # Fields pulled from initial Patient
+  field :voicemail_preference
+  enumerize :voicemail_preference, in: [:not_specified, :no, :yes], default: :not_specified
+  field :line
+  enumerize :line, in: LINES, default: LINES[0] # See config/initializers/env_vars.rb
+  field :language, type: String
+  field :initial_call_date, type: Date
+  field :urgent_flag, type: Boolean
+  field :last_menstrual_period_weeks, type: Integer
+  field :last_menstrual_period_days, type: Integer
+  field :city, type: String
+  field :state, type: String
+  field :county, type: String
+  field :race_ethnicity, type: String
+  field :employment_status, type: String
+  field :insurance, type: String
+  field :income, type: String
+  field :notes_count, type: Integer
+  field :has_special_circumstances, type: Boolean
+  field :referred_by, type: String
+  field :referred_to_clinic, type: Boolean
+  field :appointment_date, type: Date
+  field :procedure_cost, type: Integer
+  field :patient_contribution, type: Integer
+  field :naf_pledge, type: Integer
+  field :fund_pledge, type: Integer
+  field :fund_pledged_at, type: Time
+  field :pledge_sent, type: Boolean
+  field :resolved_without_fund, type: Boolean
+  field :pledge_generated_at, type: Time
+  field :pledge_sent_at, type: Time
+  field :textable, type: Boolean
+
+  # Indices
+  index(line: 1)
+  index(identifier: 1)
+
+  # Validations
+  validates :initial_call_date,
+            :created_by_id,
+            :line,
+            presence: true
+  validates :appointment_date, format: /\A\d{4}-\d{1,2}-\d{1,2}\z/,
+                               allow_blank: true
+
+  validates_associated :fulfillment
+
+
+  mongoid_userstamp user_model: 'User'
+
+  # Archive & delete audited patients who called a several months ago, or any
+  # from a year plus ago
+  def self.archive_eligible_patients!
+    Patient.all.each do |patient|
+      if ( patient.archive_date < Date.today )
+        ArchivedPatient.convert_patient(patient)
+        patient.destroy!
+      end
+    end
+  end
+
+  def self.convert_patient(patient)
+    archived_patient = new(
+      line: patient.line,
+      city: patient.city,
+      state: patient.state,
+      county: patient.county,
+      initial_call_date: patient.initial_call_date,
+      appointment_date: patient.appointment_date,
+
+      urgent_flag: patient.urgent_flag,
+      referred_by: patient.referred_by,
+      referred_to_clinic: patient.referred_to_clinic,
+
+      last_menstrual_period_weeks: patient.last_menstrual_period_weeks,
+      last_menstrual_period_days: patient.last_menstrual_period_days,
+
+      race_ethnicity: patient.race_ethnicity,
+      employment_status: patient.employment_status,
+      insurance: patient.insurance,
+      income: patient.income,
+      language: patient.language,
+      voicemail_preference: patient.voicemail_preference,
+
+      procedure_cost: patient.procedure_cost,
+      patient_contribution: patient.patient_contribution,
+      naf_pledge: patient.naf_pledge,
+      fund_pledge: patient.fund_pledge,
+      fund_pledged_at: patient.fund_pledged_at,
+
+      pledge_sent: patient.pledge_sent,
+      resolved_without_fund: patient.resolved_without_fund,
+      pledge_generated_at: patient.pledge_generated_at,
+      pledge_sent_at: patient.pledge_sent_at,
+      textable: patient.textable,
+
+      pledge_generated_by: patient.pledge_generated_by,
+      pledge_sent_by: patient.pledge_sent_by,
+      created_by_id: patient.created_by_id,
+
+      age_range: patient.age_range,
+      has_alt_contact: patient.has_alt_contact,
+      notes_count: patient.notes_count,
+      has_special_circumstances: patient.has_special_circumstances,
+
+    )
+
+    archived_patient.fulfillment = patient.fulfillment.clone
+    archived_patient.clinic_id = patient.clinic_id if patient.clinic_id
+    patient.calls.each do |call|
+      archived_patient.calls.new(call.clone.attributes)
+    end
+    patient.external_pledges.each do |ext_pledge|
+      archived_patient.external_pledges.new(ext_pledge.clone.attributes)
+    end
+
+    archived_patient.save!
+    archived_patient
+  end
+end

--- a/db/migrate/20210524020019_create_archived_patients.rb
+++ b/db/migrate/20210524020019_create_archived_patients.rb
@@ -1,0 +1,54 @@
+class CreateArchivedPatients < ActiveRecord::Migration[6.0]
+  def change
+    create_table :archived_patients do |t|
+      t.string :identifier
+
+      # Generated from initial patient info
+      t.string :age_range, default: 'not_specified'
+      t.boolean :has_alt_contact
+
+      # Pulled directly from initial patient
+      t.string :voicemail_preference, default: 'not_specified'
+      t.string :line, null: false
+      t.string :language
+      t.date :initial_call_date
+      t.boolean :urgent_flag
+      t.integer :last_menstrual_period_weeks
+      t.integer :last_menstrual_period_days
+      t.string :city
+      t.string :state
+      t.string :county
+      t.string :race_ethnicity
+      t.string :employment_status
+      t.string :insurance
+      t.string :income
+      t.integer :notes_count
+      t.boolean :has_special_circumstances
+      t.string :referred_by
+      t.boolean :referred_to_clinic
+      t.date :appointment_date
+      t.integer :procedure_cost
+      t.integer :patient_contribution
+      t.integer :naf_pledge
+      t.integer :fund_pledge
+      t.datetime :fund_pledged_at
+      t.boolean :pledge_sent
+      t.boolean :resolved_without_fund
+      t.datetime :pledge_generated_at
+      t.datetime :pledge_sent_at
+      t.boolean :textable
+
+      t.references :clinic, foreign_key: true
+
+      t.references :pledge_generated_by, foreign_key: { to_table: :users }
+      t.references :pledge_sent_by, foreign_key: { to_table: :users }
+
+      # Scratch field - temp BSON ID from mongo to link things back
+      t.string :mongo_id
+
+      t.timestamps
+    end
+
+    add_index :archived_patients, :line
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,56 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_010317) do
+ActiveRecord::Schema.define(version: 2021_05_24_020019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "archived_patients", force: :cascade do |t|
+    t.string "identifier"
+    t.string "age_range", default: "not_specified"
+    t.boolean "has_alt_contact"
+    t.string "voicemail_preference", default: "not_specified"
+    t.string "line", null: false
+    t.string "language"
+    t.date "initial_call_date"
+    t.boolean "urgent_flag"
+    t.integer "last_menstrual_period_weeks"
+    t.integer "last_menstrual_period_days"
+    t.string "city"
+    t.string "state"
+    t.string "county"
+    t.string "race_ethnicity"
+    t.string "employment_status"
+    t.string "insurance"
+    t.string "income"
+    t.integer "notes_count"
+    t.boolean "has_special_circumstances"
+    t.string "referred_by"
+    t.boolean "referred_to_clinic"
+    t.date "appointment_date"
+    t.integer "procedure_cost"
+    t.integer "patient_contribution"
+    t.integer "naf_pledge"
+    t.integer "fund_pledge"
+    t.datetime "fund_pledged_at"
+    t.boolean "pledge_sent"
+    t.boolean "resolved_without_fund"
+    t.datetime "pledge_generated_at"
+    t.datetime "pledge_sent_at"
+    t.boolean "textable"
+    t.bigint "clinic_id"
+    t.bigint "pledge_generated_by_id"
+    t.bigint "pledge_sent_by_id"
+    t.string "mongo_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["clinic_id"], name: "index_archived_patients_on_clinic_id"
+    t.index ["line"], name: "index_archived_patients_on_line"
+    t.index ["pledge_generated_by_id"], name: "index_archived_patients_on_pledge_generated_by_id"
+    t.index ["pledge_sent_by_id"], name: "index_archived_patients_on_pledge_sent_by_id"
+  end
 
   create_table "call_list_entries", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -246,6 +291,9 @@ ActiveRecord::Schema.define(version: 2021_05_11_010317) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "archived_patients", "clinics"
+  add_foreign_key "archived_patients", "users", column: "pledge_generated_by_id"
+  add_foreign_key "archived_patients", "users", column: "pledge_sent_by_id"
   add_foreign_key "call_list_entries", "patients"
   add_foreign_key "call_list_entries", "users"
   add_foreign_key "patients", "clinics"

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -61,7 +61,9 @@ namespace :migrate_to_pg do
           attrs['clinic_id'] = Clinic.find_by(mongo_id: obj['clinic_id'].to_s)&.id
           attrs['pledge_generated_by_id'] = User.find_by(mongo_id: obj['pledge_generated_by_id'].to_s)&.id
           attrs['pledge_sent_by_id'] = User.find_by(mongo_id: obj['pledge_sent_by_id'].to_s)&.id
-          attrs['last_edited_by_id'] = User.find_by(mongo_id: obj['last_edited_by_id'].to_s)&.id
+          if pg == Patient
+            attrs['last_edited_by_id'] = User.find_by(mongo_id: obj['last_edited_by_id'].to_s)&.id
+          end
           attrs
         end
         migrate_model(pg, mongo, extra_transform)

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -53,7 +53,7 @@ namespace :migrate_to_pg do
       migrate_model pg, mongo, extra_transform
 
       # Then patients
-      pt_model_pair = [[Patient, MongoPatient]]
+      pt_model_pair = [[Patient, MongoPatient], [ArchivedPatient, MongoArchivedPatient]]
       pt_model_pair.each do |pair|
         pg, mongo = pair
         extra_transform = Proc.new do |attrs, obj|

--- a/lib/tasks/migrate_to_pg.rake
+++ b/lib/tasks/migrate_to_pg.rake
@@ -112,6 +112,11 @@ namespace :migrate_to_pg do
         migrate_submodel(pt, mongo_pt, pg, mongo, 'external_pledges', 'can_pledge', extra_transform)
       end
 
+      # Separate verification for the has_one relation
+      if Fulfillment.count != (Patient.count + ArchivedPatient.count)
+        raise 'Every patient not associated with only one fulfillment'
+      end
+
       # Then, a couple spares that are Patient only
       pt = Patient
       mongo_pt = MongoPatient
@@ -172,12 +177,6 @@ def migrate_fulfillment(pt_model, mongo_pt_model, pg_model, mongo_model, relatio
       pg_obj.versions.first.update whodunnit: User.find_by(mongo_id: mongo_obj['created_by_id'].to_s)&.id
     end
   end
-
-  # Check
-  if pg_model.count != Patient.count
-    raise 'Every patient not associated with only one fulfillment'
-  end
-
   puts "#{pg_model.count} Fulfillment migrated to pg"
 end
 

--- a/test/factories/archived_patient.rb
+++ b/test/factories/archived_patient.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :archived_patient do
     line { 'DC' }
-    created_by { FactoryBot.create(:user) }
     initial_call_date { 400.days.ago }
   end
 end

--- a/test/models/archived_patient_test.rb
+++ b/test/models/archived_patient_test.rb
@@ -3,14 +3,19 @@ require 'test_helper'
 class ArchivedPatientTest < ActiveSupport::TestCase
   before do
     @user = create :user
-    @patient = create :patient, other_phone: '111-222-3333',
-                                other_contact: 'Yolo'
+    @user2 = create :user
+    with_versioning do
+      PaperTrail.request(whodunnit: @user) do
+        @patient = create :patient, other_phone: '111-222-3333',
+                                    other_contact: 'Yolo'
 
-    @patient.calls.create attributes_for(:call, created_by: @user, status: :reached_patient)
-    create_language_config
-    @archived_patient = create :archived_patient, line: 'DC',
-                                initial_call_date: 200.days.ago,
-                                created_by_id: @user.id
+        @patient.calls.create attributes_for(:call, status: :reached_patient)
+        create_language_config
+        @archived_patient = create :archived_patient,
+                                   line: 'DC',
+                                   initial_call_date: 200.days.ago
+      end
+    end
   end
 
   describe 'validations' do
@@ -27,39 +32,44 @@ class ArchivedPatientTest < ActiveSupport::TestCase
       @archived_patient.initial_call_date = nil
       refute @archived_patient.valid?
     end
-
-    it 'requires a logged creating user' do
-      @archived_patient.created_by_id = nil
-      refute @archived_patient.valid?
-    end
   end
 
   describe 'The convert_patient method' do
     before do
       @clinic = create :clinic
-      @patient = create :patient, primary_phone: '222-222-3336',
-                                   other_phone: '222-222-4441',
-                                   line: 'DC',
-                                   clinic: @clinic,
-                                   city: 'Washington',
-                                   race_ethnicity: 'Asian',
-                                   initial_call_date: 16.days.ago,
-                                   appointment_date: 6.days.ago
-      @patient.calls.create attributes_for(:call, created_by: @user, status: :couldnt_reach_patient)
-      @patient.calls.create attributes_for(:call, created_by: @user, status: :reached_patient)
-      @patient.update fulfillment: {
-                                  fulfilled: true,
-                                  updated_at: 3.days.ago,
-                                  date_of_check: 3.days.ago,
-                                  procedure_date: 6.days.ago,
-                                  check_number: '123'
-                                }
-      @patient.external_pledges.create source: 'Baltimore Abortion Fund',
-                                     amount: 100,
-                                     created_by: @user
-      @patient.save!
-      @archived_patient = ArchivedPatient.convert_patient(@patient)
-      @archived_patient.save!
+
+      with_versioning do
+        PaperTrail.request(whodunnit: @user) do
+          @patient = create :patient, primary_phone: '222-222-3336',
+                                       other_phone: '222-222-4441',
+                                       line: 'DC',
+                                       clinic: @clinic,
+                                       city: 'Washington',
+                                       race_ethnicity: 'Asian',
+                                       initial_call_date: 16.days.ago,
+                                       appointment_date: 6.days.ago
+          @patient.calls.create attributes_for(:call, status: :couldnt_reach_patient)
+          @patient.external_pledges.create source: 'Friendship Abortion Fund',
+                                           amount: 100
+          @patient.practical_supports.create support_type: 'Metallica tickets'
+          @patient.update fulfillment: { fulfilled: true,
+                                         updated_at: 3.days.ago,
+                                         date_of_check: 3.days.ago,
+                                         procedure_date: 6.days.ago,
+                                         check_number: '123' }
+          @patient.save!
+        end
+
+        PaperTrail.request(whodunnit: @user2) do
+          @patient.calls.create attributes_for(:call, status: :reached_patient)
+          @patient.external_pledges.create source: 'Baltimore Abortion Fund',
+                                           amount: 100
+          @patient.practical_supports.create support_type: 'Louder Metallica tickets'
+        end
+
+        @archived_patient = ArchivedPatient.convert_patient(@patient)
+        @archived_patient.save!
+      end
     end
 
     it 'should have matching data for Patient and Archive Patient' do
@@ -69,23 +79,35 @@ class ArchivedPatientTest < ActiveSupport::TestCase
       assert_equal @archived_patient.appointment_date,
                    @patient.appointment_date
     end
+
     it 'should have a shared clinic for Patient and Archive Patient' do
       assert_equal @archived_patient.clinic_id, @patient.clinic_id
     end
+
     it 'should have matching subobject data Patient and Archive Patient' do
-      assert_equal @archived_patient.calls.count, @patient.calls.count
+      assert_equal 2, @archived_patient.calls.count
+      assert_equal @user, @archived_patient.calls.first.created_by
+      assert_equal @user2, @archived_patient.calls.last.created_by
+
       assert_equal @archived_patient.fulfillment.date_of_check,
                    @patient.fulfillment.date_of_check
-      assert_equal @archived_patient.external_pledges.first.source,
-                   @patient.external_pledges.first.source
+
+      assert_equal 2, @archived_patient.external_pledges.count
+      assert_equal @user, @archived_patient.external_pledges.first.created_by
+      assert_equal @user2, @archived_patient.external_pledges.last.created_by
+
+      assert_equal 2, @archived_patient.practical_supports.count
+      assert_equal @user, @archived_patient.practical_supports.first.created_by
+      assert_equal @user2, @archived_patient.practical_supports.last.created_by
     end
+
     it 'should have distinct subobjects for Patient and Archive Patient' do
-      assert_not_equal @archived_patient.calls.first.id,
-                       @patient.calls.first.id
+      assert_equal 0, Patient.calls.count
+      assert_equal 0, Patient.external_pledges.count
+      assert_equal 0, Patient.practical_supports.count
+
       assert_not_equal @archived_patient.fulfillment.id,
                        @patient.fulfillment.id
-      assert_not_equal @archived_patient.external_pledges.first.id,
-                       @patient.external_pledges.first.id
     end
   end
 
@@ -94,8 +116,7 @@ class ArchivedPatientTest < ActiveSupport::TestCase
       @patient_audited = create :patient, primary_phone: '222-222-3333',
                                       other_phone: '222-222-4444',
                                       initial_call_date: 30.days.ago
-      @patient_audited.update fulfillment: { audited: true }
-      @patient_audited.save!
+      @patient_audited.fulfillment.update audited: true
 
       @patient_unaudited = create :patient, primary_phone: '564-222-3333',
                                       other_phone: '222-222-9074',
@@ -125,7 +146,7 @@ class ArchivedPatientTest < ActiveSupport::TestCase
       @patient_old_unaudited = create :patient, primary_phone: '564-222-3333',
                                       other_phone: '222-222-9074',
                                       initial_call_date: 370.days.ago
-      @patient_old_unaudited.update fulfillment: { audited: false }
+      @patient_old_unaudited.fulfillment.update audited: false
       @patient_old_unaudited.save!
     end
 
@@ -137,5 +158,4 @@ class ArchivedPatientTest < ActiveSupport::TestCase
        end
     end
   end
-
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Port over ArchivedPatient model and the associated goods.

To test, you can just do the migration stuff:

```
git checkout main && rails db:drop db:create db:migrate db:seed
git checkout pg-archived-pt && rails db:migrate migrate_to_pg:clinic_user_patient
```

Should yield the following:

```
4 Clinic migrated to pg
3 User migrated to pg
39 Patient migrated to pg
4 ArchivedPatient migrated to pg
39 Fulfillment migrated to pg
141 calls migrated to pg
0 practical_supports migrated to pg
2 external_pledges migrated to pg
43 Fulfillment migrated to pg
149 calls migrated to pg
0 practical_supports migrated to pg
2 external_pledges migrated to pg
6 CallListEntry migrated to pg
17 notes migrated to pg
```

After this, we're mostly in the domain of getting tests to work I think?

This pull request makes the following changes:
* Port ArchivedPatient to pg

no view changes

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
