### PR TITLE
Allow rubocop to run locally

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 Style/ClassAndModuleChildren:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :development do
   gem 'shog' # makes rails s output color!
   gem 'listen', '>= 3.0.5', '< 3.2' # used by systemtests, hardset rails 6 compat
   gem 'rubocop', require: false # our code style / linting system
+  gem 'rubocop-rails', require: false
 
   # Security scanners that also run in CI. They run with bundle exec.
   gem 'ruby_audit', require: false #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.3.0)
       parser (>= 2.7.1.4)
+    rubocop-rails (2.8.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.4)
@@ -498,6 +502,7 @@ DEPENDENCIES
   rails-i18n (~> 6.0)
   render_async (~> 2.1)
   rubocop
+  rubocop-rails
   ruby_audit
   sass-rails (>= 6)
   sdoc (~> 1.0.0)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Minor changes to configs to allow `rubocop` to run locally.

After `bundle install`ing, run `rubocop [files...]` (or `docker-compose run --rm web rubocop [files...]`). With no arguments, checks everything, and there are a lot of suggestions! I think this will mostly be useful to look at *new* changes: you could use `git diff --name-only main` to get a list of ruby files changed on this branch, so

```
docker-compose run --rm web rubocop `git diff --name-only main *.rb`
```

I know we're not planning on doing a full re-lint of the codebase, but this might help, moving forward, to be able to keep things up to spec!

Open to comments/config changes/doc suggestions.

This pull request makes the following changes:
* Installs `rubocop-rails`.

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
