### PR TITLE
Adjust seedfile to postgres

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ User.create! name: 'testuser3', email: 'dcaf.testing@gmail.com',
              role: :cm
 
 # Default to user2 as the actor
-PaperTrail.request.whodunnit = user2
+PaperTrail.request.whodunnit = user2.id
 
 # Create a few clinics
 Clinic.create! name: 'Sample Clinic 1 - DC', street_address: '1600 Pennsylvania Ave',
@@ -84,7 +84,7 @@ Config.create config_key: :start_of_week,
                             created_at: 3.days.ago
     end
   when 1
-    PaperTrail.request(whodunnit: user) do
+    PaperTrail.request(whodunnit: user.id) do
       patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
                       other_phone: '234-456-6789', other_contact_relationship: 'Sister'
       patient.calls.create! status: :reached_patient,
@@ -110,7 +110,7 @@ Config.create config_key: :start_of_week,
                     pronouns: 'ze/zir',
                     name: 'Pledge submitted - 3'
   when 4
-    PaperTrail.request(whodunnit: user) do
+    PaperTrail.request(whodunnit: user.id) do
       # With special circumstances
       patient.update! name: 'Special Circumstances - 4',
                       special_circumstances: ['Prison', 'Fetal anomaly']
@@ -146,7 +146,7 @@ Config.create config_key: :start_of_week,
 end
 
 # Add patients for reporting purposes - CSV exports, fulfillments, etc.
-PaperTrail.request.whodunnit = user
+PaperTrail.request.whodunnit = user.id
 10.times do |i|
   patient = Patient.create!(
     name: "Reporting Patient #{i}",
@@ -314,7 +314,7 @@ end
   )
 
   # notes tab
-  PaperTrail.request(whodunnit: user2) do
+  PaperTrail.request(whodunnit: user2.id) do
     patient.notes.create!(
       full_text: 'Two note, maybe with iffy PII! From the second call.',
       created_at: 133.days.ago

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,12 @@ raise 'No running seeds in prod' unless [nil, 'Sandbox'].include? ENV['DARIA_FUN
 Config.destroy_all
 Event.destroy_all
 Call.destroy_all
-# CallListEntry.destroy_all
-# ExternalPledge.destroy_all
-# Fulfillment.destroy_all
-# Note.destroy_all
+CallListEntry.destroy_all
+ExternalPledge.destroy_all
+Fulfillment.destroy_all
+Note.destroy_all
 Patient.destroy_all
+ArchivedPatient.destroy_all
 User.destroy_all
 Clinic.destroy_all
 
@@ -72,7 +73,8 @@ Config.create config_key: :start_of_week,
                             initial_call_date: 3.days.ago,
                             urgent_flag: i.even?,
                             last_menstrual_period_weeks: (i + 1 * 2),
-                            last_menstrual_period_days: 3
+                            last_menstrual_period_days: 3,
+                            line: 'DC'
 
   # Create associated objects
   case i
@@ -82,10 +84,12 @@ Config.create config_key: :start_of_week,
                             created_at: 3.days.ago
     end
   when 1
-    patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
-                    other_phone: '234-456-6789', other_contact_relationship: 'Sister'
-    patient.calls.create! status: :reached_patient,
-                          created_at: 14.hours.ago
+    PaperTrail.request(whodunnit: user) do
+      patient.update! name: 'Other Contact info - 1', other_contact: 'Jane Doe',
+                      other_phone: '234-456-6789', other_contact_relationship: 'Sister'
+      patient.calls.create! status: :reached_patient,
+                            created_at: 14.hours.ago
+    end
   when 2
     # appointment one week from today && clinic selected
     patient.update! name: 'Clinic and Appt - 2',
@@ -106,11 +110,13 @@ Config.create config_key: :start_of_week,
                     pronouns: 'ze/zir',
                     name: 'Pledge submitted - 3'
   when 4
-    # With special circumstances
-    patient.update! name: 'Special Circumstances - 4',
-                    special_circumstances: ['Prison', 'Fetal anomaly']
-    # And a recent call on file
-    patient.calls.create! status: :left_voicemail
+    PaperTrail.request(whodunnit: user) do
+      # With special circumstances
+      patient.update! name: 'Special Circumstances - 4',
+                      special_circumstances: ['Prison', 'Fetal anomaly']
+      # And a recent call on file
+      patient.calls.create! status: :left_voicemail
+    end
   when 5
     # Resolved without DCAF
     patient.update! name: 'Resolved without DCAF - 5',
@@ -140,6 +146,7 @@ Config.create config_key: :start_of_week,
 end
 
 # Add patients for reporting purposes - CSV exports, fulfillments, etc.
+PaperTrail.request.whodunnit = user
 10.times do |i|
   patient = Patient.create!(
     name: "Reporting Patient #{i}",
@@ -147,7 +154,6 @@ end
     initial_call_date: 3.days.ago,
     urgent_flag: i.even?,
     line: i.even? ? 'DC' : 'MD',
-    created_by: user,
     clinic: Clinic.all.sample,
     appointment_date: 10.days.from_now,
     last_menstrual_period_weeks: 7,
@@ -161,12 +167,9 @@ end
 
   next unless i.even?
 
-  patient.build_fulfillment(
-    created_by_id: user.id,
-    fulfilled: true,
-    fund_payout: 4000,
-    procedure_date: 10.days.from_now
-  ).save
+  patient.fulfillment.update fulfilled: true,
+                             fund_payout: 4000,
+                             procedure_date: 10.days.from_now
 end
 
 (1..5).each do |patient_number|
@@ -176,7 +179,6 @@ end
     initial_call_date: 3.days.ago,
     urgent_flag: patient_number.even?,
     line: lines[patient_number % 3],
-    created_by: user,
     clinic: Clinic.all.sample,
     appointment_date: 10.days.from_now
   )
@@ -184,10 +186,8 @@ end
   # reached within the past 30 days
   5.times do
     patient.calls.create! status: :reached_patient,
-                          created_by: user,
                           created_at: (Time.now - rand(10).days)
     patient.calls.create! status: :reached_patient,
-                          created_by: user,
                           created_at: (Time.now - rand(10).days - 10.days)
   end
 end
@@ -199,14 +199,12 @@ end
     initial_call_date: 3.days.ago,
     urgent_flag: patient_number.even?,
     line: lines[patient_number % 3],
-    created_by: user,
     clinic: Clinic.all.sample,
     appointment_date: 10.days.from_now
   )
 
   5.times do
     patient.calls.create! status: :reached_patient,
-                          created_by: user,
                           created_at: (Time.now - rand(10).days - 6.months)
   end
 end
@@ -218,7 +216,6 @@ end
     initial_call_date: 3.days.ago,
     urgent_flag: patient_number.even?,
     line: lines[patient_number % 3],
-    created_by: user,
     clinic: Clinic.all.sample,
     appointment_date: 10.days.from_now,
     pledge_sent: true,
@@ -238,15 +235,14 @@ end
     initial_call_date: 140.days.ago,
     last_menstrual_period_weeks: 6,
     last_menstrual_period_days: 5,
-    created_by: user,
     created_at: 140.days.ago
   )
 
   # Call, but no answer. leave a VM.
-  patient.calls.create status: :left_voicemail, created_by: user, created_at: 139.days.ago
+  patient.calls.create status: :left_voicemail, created_at: 139.days.ago
 
   # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: :reached_patient, created_by: user, created_at: 138.days.ago
+  patient.calls.create status: :reached_patient, created_at: 138.days.ago
 
   patient.update!(
     # header info - hand filled in
@@ -286,7 +282,6 @@ end
   # generate notes
   patient.notes.create!(
     full_text: 'One note, with iffy PII! This one was from the first call!',
-    created_by: user,
     created_at: 137.days.ago
   )
 
@@ -294,7 +289,7 @@ end
   next if patient.resolved_without_fund?
 
   # another call. get abortion information, create pledges, a note.
-  patient.calls.create! status: :reached_patient, created_by: user, created_at: 136.days.ago
+  patient.calls.create! status: :reached_patient, created_at: 136.days.ago
 
   # abortion info - pledges - hand filled in
   patient.update!(
@@ -304,29 +299,27 @@ end
     fund_pledge: 115,
     pledge_sent: true,
     pledge_generated_at: 133.days.ago,
-    pledge_generated_by: user,
     updated_at: 133.days.ago
   )
   # generate external pledges
   patient.external_pledges.create!(
     source: 'Metallica Abortion Fund',
     amount: 100,
-    created_by: user,
     created_at: 133.days.ago
   )
   patient.external_pledges.create!(
     source: 'Baltimore Abortion Fund',
     amount: 100,
-    created_by: user,
     created_at: 133.days.ago
   )
 
   # notes tab
-  patient.notes.create!(
-    full_text: 'Two note, maybe with iffy PII! From the second call.',
-    created_by: user2,
-    created_at: 133.days.ago
-  )
+  PaperTrail.request(whodunnit: user2) do
+    patient.notes.create!(
+      full_text: 'Two note, maybe with iffy PII! From the second call.',
+      created_at: 133.days.ago
+    )
+  end
 
   # fulfillment
   patient.fulfillment.update!(
@@ -351,15 +344,14 @@ end
     initial_call_date: 640.days.ago,
     last_menstrual_period_weeks: 6,
     last_menstrual_period_days: 5,
-    created_by: user,
     created_at: 640.days.ago
   )
 
   # Call, but no answer. leave a VM.
-  patient.calls.create status: :left_voicemail, created_by: user, created_at: 639.days.ago
+  patient.calls.create status: :left_voicemail, created_at: 639.days.ago
 
   # Call, which updates patient info, maybe flags urgent, make a note.
-  patient.calls.create status: :reached_patient, created_by: user, created_at: 138.days.ago
+  patient.calls.create status: :reached_patient, created_at: 138.days.ago
 
   # Patient 1 drops off immediately
   next if patient_number.odd?
@@ -404,16 +396,22 @@ end
   # generate notes
   patient.notes.create!(
     full_text: 'One note, with iffy PII! This one was from the first call!',
-    created_by: user,
     created_at: 637.days.ago
   )
 end
 
 # Log results
-puts "Seed completed! Inserted #{Patient.count} patient objects. \n" \
-     "Inserted #{Clinic.count} clinic objects. \n" \
-     "Inserted #{User.count} user objects. \n" \
-     "Inserted #{Config.count} config objects. \n" \
-     "Inserted #{Event.count} event objects. \n" \
+puts "Seed completed! \n" \
+     "Inserted #{Config.count} Config objects. \n" \
+     "Inserted #{Event.count} Event objects. \n" \
+     "Inserted #{Call.count} Call objects. \n" \
+     "Inserted #{CallListEntry.count} CallListEntry objects. \n" \
+     "Inserted #{ExternalPledge.count} ExternalPledge objects. \n" \
+     "Inserted #{Fulfillment.count} Fulfillment objects. \n" \
+     "Inserted #{Note.count} Note objects. \n" \
+     "Inserted #{Patient.count} Patient objects. \n" \
+     "Inserted #{ArchivedPatient.count} ArchivedPatient objects. \n" \
+     "Inserted #{User.count} User objects. \n" \
+     "Inserted #{Clinic.count} Clinic objects. \n" \
      'User credentials are as follows: ' \
      "EMAIL: #{user.email} PASSWORD: AbortionsAreAHumanRight1"


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Fix up seedfile to be pg-friendly.

This pull request makes the following changes:
* fix seeds to run in postgres

Test by:
```
git checkout pg-seed
rails db:drop db:create db:migrate db:seed # should complete
rails c

Patient.find_by(name: 'Patient 0').created_by.name #  testuser2
Patient.find_by(name: 'Other Contact info - 1').created_by.name # testuser
```


It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
