### PR TITLE
Migrate events as part of pg; log places where n+1 queries will crop up for future work

### DIFF
--- a/app/controllers/accountants_controller.rb
+++ b/app/controllers/accountants_controller.rb
@@ -12,6 +12,8 @@ class AccountantsController < ApplicationController
   def search
     @results = if params[:search].present?
                  Patient.where(pledge_sent: true)
+                        .includes(:clinic)
+                        .includes(:fulfillment)
                         .order(pledge_sent_at: :desc)
                         .search(params[:search])
                else
@@ -38,6 +40,8 @@ class AccountantsController < ApplicationController
   def pledged_patients
     Patient.where(pledge_sent: true,
                   initial_call_date: 6.months.ago..)
+           .includes(:clinic)
+           .includes(:fulfillment)
            .order(pledge_sent_at: :desc)
   end
 

--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -2,6 +2,7 @@ class ConfigsController < ApplicationController
   before_action :confirm_admin_user
 
   def index
+    # n+1 join here
     Config.autosetup
     @configs = Config.all.sort_by(&:config_key)
   end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -6,10 +6,12 @@ class DashboardsController < ApplicationController
   before_action :pick_line_if_not_set, only: [:index, :search]
 
   def index
+    # n+1 join here
     @urgent_patients = Patient.urgent_patients(current_line)
   end
 
   def search
+    # n+1 join here
     @results = Patient.search params[:search],
                               [current_line.try(:to_sym) || lines]
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -7,6 +7,7 @@ class PatientsController < ApplicationController
               with: -> { redirect_to root_path }
 
   def index
+    # n+1 join here
     respond_to do |format|
       format.csv do
         render_csv
@@ -102,6 +103,7 @@ class PatientsController < ApplicationController
   private
 
   def find_patient
+    # n+1 join here
     @patient = Patient.find params[:id]
   end
 

--- a/app/models/concerns/call_listable.rb
+++ b/app/models/concerns/call_listable.rb
@@ -68,6 +68,7 @@ module CallListable
   private
 
   def ordered_patients(line)
+    # n+1 join here
     call_list_entries.includes(:patient)
                      .where(line: line)
                      .order(order_key: :asc)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Mark a few places where n+1 joins are taking place - we used to get this for free from the mongodb document model and now we extremely don't. This is fine for now since we don't do that much traffic, but we should try and resolve after we get this into production. as noted this will be a good @elimbaum shaped ticket
* fix a few n+1 joins on the accountants page as a proof of concept
* fix patient ids on events - since they get numeric ids now, we need to bump them from the BSON IDs

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
