### PR TITLE
remove kaminari-mongoid gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem 'sentry-raven'
 gem 'rack-attack', '~> 5.4.1'
 
 # For pagination
-gem 'kaminari-mongoid', '~> 1.0'
 gem 'kaminari', '~> 1.2'
 
 # Specific useful stuff

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,9 +185,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    kaminari-mongoid (1.0.1)
-      kaminari-core (~> 1.0)
-      mongoid
     knapsack (1.18.0)
       rake
     launchy (2.5.0)
@@ -468,7 +465,6 @@ DEPENDENCIES
   jquery-ui-rails
   js-routes
   kaminari (~> 1.2)
-  kaminari-mongoid (~> 1.0)
   knapsack
   launchy
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Since we don't do any mongoid queries anymore, we can strip the mongoid-kaminari gem and just leave regular kaminari.

This pull request makes the following changes:
* remove `mongoid-kaminari` gem

It relates to the following issue #s: 
* Fixes #2237 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
