### PR TITLE
Fix user search bug causing errors if no results are found

### DIFF
--- a/app/views/users/search.js.erb
+++ b/app/views/users/search.js.erb
@@ -1,4 +1,4 @@
-<% if @results.any? %>
+<% if @results&.any? %>
   $('#user-list').html("<%= escape_javascript(render partial: 'users/users_table', locals: { users: @results, autosortable: true }) %>");
   <%= render partial: 'shared/activate_stupidtable' %>
 <% else %>


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)
Made the user search nil response friendly. Based on Sentry alert:

```

Exception

NoMethodError: undefined method `any?' for nil:NilClass
  app/views/users/search.js.erb:1:in `_app_views_users_search_js_erb__235396535284795989_968060'
    <% if @results.any? %>
...
(133 additional frame(s) were not displayed)

ActionView::Template::Error: undefined method `any?' for nil:NilClass

```

This pull request makes the following changes:
* Cleaner `nil` handling for if you search for users with only whitespace

You can recreate the error:

  - checkout main
  - navigate to user management
  - search for a space, boom, error

Checkout this branch and do it again - no error!


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
