### PR TITLE
remove mongo refs from tests, release commands, and docker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: rails db:migrate && rails db:mongoid:create_indexes
+release: rails db:migrate
 web: bundle exec puma -p $PORT -C ./config/puma.rb

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": "A Rails-based case management system for abortion funds",
   "repository": "https://github.com/DCAFEngineering/dcaf_case_management",
   "scripts": {
-    "postdeploy": "bundle exec rake db:mongoid:create_indexes"
+    "postdeploy": "bundle exec rails db:migrate"
   },
   "env": {
     "CSP_VIOLATION_URI": {
@@ -52,10 +52,6 @@
     "DARIA_PLEDGE_GENERATOR_DISABLED": {
       "description": "The PDF Pledge generator only works for DCAF for now",
       "value": "true"
-    },
-    "MONGODB_URI": {
-      "description": "Connection string for the MongoDB cluster",
-      "value": ""
     },
     "RAILS_LOG_TO_STDOUT": {
       "description": "set to true",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,18 +19,12 @@ services:
       - "3000:3000"
     links:
       - db
-      - pg
       - webpacker
     environment:
-      mongohost: db
-      pg_url: postgres://postgres:postgres@pg
+      pg_url: postgres://postgres:postgres@db
     env_file:
       - .docker/web-variables.env
   db:
-    image: mongo
-    ports:
-      - "27017:27017"
-  pg:
     image: postgres
     ports:
       - "5432:5432"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,7 +29,6 @@ if ENV['CIRCLECI']
 end
 
 DatabaseCleaner.clean_with :truncation
- DatabaseCleaner[:mongoid].clean_with :truncation
 
 # Convenience methods around config creation, and database cleaning
 class ActiveSupport::TestCase


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Remove a couple of mongo refs from tests, release commands, and docker. (In part because I want to see if this builds independently.)

This pull request makes the following changes:
* Remove mongo refs from tests, release commands, and Docker

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
