### PR TITLE
Port button styling into webpack

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -55,19 +55,9 @@ a:hover, a:active, a:visited, a:focus {
 }
 // End duplicated styles
 
-// accessible color contrast
-.btn-danger {
-  background-color: #A42823 !important;
-  border-color: #A42823 !important;
-}
-
-
-
-
-
 .btn-lg {
-  margin: 15px 0;
-  padding: 15px 30px;
+  margin: .75em 0;
+  padding: .75em 1.5em;
 }
 
 
@@ -112,7 +102,3 @@ $daria-color-lt : #825fb9;
 }
 
 
-
-.btn[data-orientation='cancel'] {
-  color: red;
-}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -54,30 +54,3 @@ a:hover, a:active, a:visited, a:focus {
   text-decoration: underline;
 }
 // End duplicated styles
-
-
-
-
-$daria-color-lt : #825fb9;
-
-.btn-success {
-  background-color: $daria-color;
-  border-color: $daria-color;
-
-  &:hover {
-    background-color: $daria-color-lt;
-    border-color: $daria-color;
-  }
-  &:active {
-    background-color: #286090 !important;
-  }
-  &:focus {
-    background-color: $daria-color;
-    &:hover {
-    background-color: $daria-color-lt;
-    }
-  }
-}
-
-
-

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -24,7 +24,7 @@ $spacers: map-merge(
   $spacers
 );
 
-@import "bootstrap";
+// @import "bootstrap";
 
 
 $daria-color: #5D3E8D;
@@ -61,24 +61,6 @@ a:hover, a:active, a:visited, a:focus {
   border-color: #A42823 !important;
 }
 
-.btn-primary {
-  @extend .btn-primary;
-  background-color: $daria-color;
-  border: none;
-  color: white;
-  margin-bottom: 2px;
-  font-size: $font-size;
-}
-
-.btn-primary:hover {
-  background-color: lighten($daria-color,15%);
-}
-
-.btn-primary:focus {
-  background-color: lighten($daria-color,15%);
-  color: white;
-  text-decoration: none;
-}
 
 
 
@@ -86,14 +68,6 @@ a:hover, a:active, a:visited, a:focus {
 .btn-lg {
   margin: 15px 0;
   padding: 15px 30px;
-}
-
-
-.button-xs {
-// maybe deleteable?
-  @extend .btn;
-  @extend .btn-primary;
-  @extend .btn-sm;
 }
 
 
@@ -137,38 +111,8 @@ $daria-color-lt : #825fb9;
   }
 }
 
-@mixin disabled-button {
-  color: white;
-  background-color: gray;
-  border-color: $daria-color;
-  &:hover {
-    background-color: gray;
-    border-color: $daria-color;
-  }
-  &:focus {
-    background-color: gray;
-    border-color: $daria-color;
-    &:hover {
-      background-color: gray;
-      border-color: $daria-color;
-    }
-  }
-}
-
-.btn-success[disabled] {
-  @include disabled-button;
-}
-
-.btn-warning[disabled] {
-  @include disabled-button;
-}
 
 
 .btn[data-orientation='cancel'] {
   color: red;
 }
-.submit {
-  @extend .btn;
-  @extend .btn-primary;
-  @extend .btn-lg;
-  }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -55,10 +55,7 @@ a:hover, a:active, a:visited, a:focus {
 }
 // End duplicated styles
 
-.btn-lg {
-  margin: .75em 0;
-  padding: .75em 1.5em;
-}
+
 
 
 $daria-color-lt : #825fb9;
@@ -82,23 +79,5 @@ $daria-color-lt : #825fb9;
   }
 }
 
-.btn-warning {
-  color: black;
-  border-color: $daria-color;
-  background-color: white;
-  &:hover {
-    background-color: $daria-color-lt;
-    border-color: $daria-color;
-  }
-  &:active {
-    background-color: #286090 !important;
-  }
-  &:focus {
-    background-color: $daria-color;
-    &:hover {
-    background-color: $daria-color-lt;
-    }
-  }
-}
 
 

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -25,3 +25,4 @@
 @import '../styles/lines';
 @import '../styles/flash';
 @import '../styles/forms';
+@import '../styles/buttons';

--- a/app/javascript/styles/_variables.scss
+++ b/app/javascript/styles/_variables.scss
@@ -15,6 +15,7 @@ $black: #000000;
 $phone-icon-blue: #337ab7;
 $lavendar: #ECE0FF;
 $red: #ff0000;
+$dark-red: #A42823; // Slightly darker red for accessibility
 
 // Sizing
 $font-size-small: .8rem;

--- a/app/javascript/styles/buttons.scss
+++ b/app/javascript/styles/buttons.scss
@@ -23,6 +23,18 @@
   text-decoration: none;
 }
 
+// btn-danger
+.btn-danger {
+  background-color: $dark-red !important;
+  border-color: $dark-red !important;
+}
+
+// btn sizes
+.btn-lg {
+  margin: .75em 0;
+  padding: .75em 1.5em;
+}
+
 // Disabled button styling
 @mixin disabled-button {
   color: $white;
@@ -48,4 +60,9 @@
 
 .btn-warning[disabled] {
   @include disabled-button;
+}
+
+// Styling for the cancel button on pledge modal
+.btn[data-orientation='cancel'] {
+  color: $red;
 }

--- a/app/javascript/styles/buttons.scss
+++ b/app/javascript/styles/buttons.scss
@@ -29,6 +29,26 @@
   border-color: $dark-red !important;
 }
 
+// btn-warning
+.btn-warning {
+  color: $black;
+  border-color: $daria-color;
+  background-color: $white;
+  &:hover {
+    background-color: $daria-color-lt;
+    border-color: $daria-color;
+  }
+  &:active {
+    background-color: $soft-blue !important;
+  }
+  &:focus {
+    background-color: $daria-color;
+    &:hover {
+    background-color: $daria-color-lt;
+    }
+  }
+}
+
 // btn sizes
 .btn-lg {
   margin: .75em 0;

--- a/app/javascript/styles/buttons.scss
+++ b/app/javascript/styles/buttons.scss
@@ -1,0 +1,51 @@
+// Button styling.
+
+@import './bootstrap';
+@import './_variables';
+
+// btn-primary
+.btn-primary {
+  @extend .btn-primary;
+  background-color: $daria-color;
+  border: none;
+  color: $white;
+  margin-bottom: 2px;
+  font-size: $font-size;
+}
+
+.btn-primary:hover {
+  background-color: lighten($daria-color,15%);
+}
+
+.btn-primary:focus {
+  background-color: lighten($daria-color,15%);
+  color: $white;
+  text-decoration: none;
+}
+
+// Disabled button styling
+@mixin disabled-button {
+  color: $white;
+  background-color: gray;
+  border-color: $daria-color;
+  &:hover {
+    background-color: gray;
+    border-color: $daria-color;
+  }
+  &:focus {
+    background-color: gray;
+    border-color: $daria-color;
+    &:hover {
+      background-color: gray;
+      border-color: $daria-color;
+    }
+  }
+}
+
+.btn-success[disabled] {
+  @include disabled-button;
+}
+
+.btn-warning[disabled] {
+  @include disabled-button;
+}

--- a/app/javascript/styles/buttons.scss
+++ b/app/javascript/styles/buttons.scss
@@ -34,6 +34,7 @@
   color: $black;
   border-color: $daria-color;
   background-color: $white;
+
   &:hover {
     background-color: $daria-color-lt;
     border-color: $daria-color;
@@ -44,7 +45,27 @@
   &:focus {
     background-color: $daria-color;
     &:hover {
+      background-color: $daria-color-lt;
+    }
+  }
+}
+
+// btn-success
+.btn-success {
+  background-color: $daria-color;
+  border-color: $daria-color;
+
+  &:hover {
     background-color: $daria-color-lt;
+    border-color: $daria-color;
+  }
+  &:active {
+    background-color: $soft-blue !important;
+  }
+  &:focus {
+    background-color: $daria-color;
+    &:hover {
+      background-color: $daria-color-lt;
     }
   }
 }


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Port button styling into webpack. Still gotta do a little additional tidying, but this means almost all our custom code is ported.

This pull request makes the following changes:
* Port button styling into webpack

screencaps posted inline

It relates to the following issue #s: 
* Bumps #1859 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
