### PR TITLE
bump papertrail gem to v12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'jquery-ui-rails'
 
 # Our database is postgres
 gem 'pg', '~> 1.2'
-gem 'paper_trail', '~> 10.3'
+gem 'paper_trail', '~> 12.0'
 gem 'activerecord-session_store'
 
 # Our authentication library is devise, with oauth2 for google signin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crass (1.0.6)
     database_cleaner (1.8.5)
     devise (4.8.0)
@@ -238,8 +238,8 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    paper_trail (10.3.1)
-      activerecord (>= 4.2)
+    paper_trail (12.0.0)
+      activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.19.2)
     parser (2.7.1.4)
@@ -453,7 +453,7 @@ DEPENDENCIES
   nokogiri (>= 1.11.1)
   omniauth-google-oauth2 (~> 0.8.1)
   omniauth-rails_csrf_protection (~> 1.0)
-  paper_trail (~> 10.3)
+  paper_trail (~> 12.0)
   pdf-inspector
   pg (~> 1.2)
   prawn


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Got a warning that this was not compat with papertrail at version 10, so upgrading to see if that squelches the issue. Also, might as well keep our libs fresh!

This pull request makes the following changes:
* bundle update paper_trail

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* bumps #2251 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
