### PR TITLE
remove mongo_id from tables

### DIFF
--- a/app/lib/paper_trail_version.rb
+++ b/app/lib/paper_trail_version.rb
@@ -11,7 +11,6 @@ class PaperTrailVersion < PaperTrail::Version
     last_edited_by_id
     identifier
     updated_at
-    mongo_id
     created_at
   ].freeze
   DATE_FIELDS = %w[

--- a/db/migrate/20210618205056_remove_mongo_id_columns.rb
+++ b/db/migrate/20210618205056_remove_mongo_id_columns.rb
@@ -1,0 +1,7 @@
+class RemoveMongoIdColumns < ActiveRecord::Migration[6.0]
+  def change
+    %w(archived_patients clinics patients users).each do |model|
+      remove_column model, :mongo_id, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_13_035820) do
+ActiveRecord::Schema.define(version: 2021_06_18_205056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -52,7 +52,6 @@ ActiveRecord::Schema.define(version: 2021_06_13_035820) do
     t.bigint "clinic_id"
     t.bigint "pledge_generated_by_id"
     t.bigint "pledge_sent_by_id"
-    t.string "mongo_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["clinic_id"], name: "index_archived_patients_on_clinic_id"
@@ -121,7 +120,6 @@ ActiveRecord::Schema.define(version: 2021_06_13_035820) do
     t.integer "costs_28wks"
     t.integer "costs_29wks"
     t.integer "costs_30wks"
-    t.string "mongo_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -228,7 +226,6 @@ ActiveRecord::Schema.define(version: 2021_06_13_035820) do
     t.bigint "pledge_generated_by_id"
     t.bigint "pledge_sent_by_id"
     t.bigint "last_edited_by_id"
-    t.string "mongo_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["clinic_id"], name: "index_patients_on_clinic_id"
@@ -270,7 +267,6 @@ ActiveRecord::Schema.define(version: 2021_06_13_035820) do
     t.string "line"
     t.integer "role", default: 0, null: false
     t.boolean "disabled_by_fund", default: false
-    t.string "mongo_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "email", default: "", null: false


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Don't merge until EOM, but this drops the mongo id tables, thereby nuking our last vestige of mongo.

This pull request makes the following changes:
* remove mongo_id columns

no view changes

It relates to the following issue #s: 
* Bumps #2072 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
