### PR TITLE
Fix - Updating update_pledge_sent_by_sent_at  save for consistency

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -20,7 +20,7 @@ class Patient < ApplicationRecord
   # Callbacks
   before_validation :clean_fields
   before_save :save_identifier
-  before_update :update_pledge_sent_by_sent_at
+  before_save :update_pledge_sent_by_sent_at
   before_save :update_fund_pledged_at
   after_create :initialize_fulfillment
   after_update :confirm_still_urgent, if: :urgent_flag?

--- a/test/system/data_entry_test.rb
+++ b/test/system/data_entry_test.rb
@@ -160,13 +160,13 @@ class DataEntryTest < ApplicationSystemTestCase
       has_text? 'Patient information' # wait for redirect
     end
 
-    it 'should not show backdated new patient in the budget bar' do
+    it 'should show backdated new patient in the budget bar' do
       visit root_path
 
       within :css, '#budget_bar' do
-        assert has_text? "$0 sent (0 patients)"
+        assert has_text? "$99 sent (1 patients)"
         assert has_text? "$0 pledged (0 patients)"
-        refute has_text? "$99 sent"
+        refute has_text? "$0 sent"
       end
     end
   end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Make behavior consistent with `update_fund_pledge_at`

It relates to the following issue #s: 
* Fixes #2019 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
