### PR TITLE
Allow system tests to run in local docker

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -45,6 +45,9 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - && \
 # remove unnecessary build dependencies
 RUN apt-get purge -y ${BUILD_DEPENDENCIES} && apt-get autoremove -y 
 
+# Install firefox for system tests
+RUN apt-get install -y firefox-esr
+
 # Check docker base image for vulnerable packages, ignore non zero exit code (just informative)
 RUN mkdir /tmp/ahab && \
     cd /tmp/ahab && \

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,5 +19,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   # if in CI, run system tests headlessly.
   browser = ENV['GITHUB_WORKFLOW'] ? :headless_chrome : :chrome
+
+  # if in docker, run headless firefox
+  browser = ENV['DOCKER'] ? :headless_firefox : browser
+
   driven_by :selenium, using: browser
 end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This PR installs firefox inside the docker container, allowing system tests to be run locally.

I attempted to install Chrome, to match CircleCI, but ran into a bunch of issues with running it headlessly. FIrefox works out of the box.

⚠️ **Warning!** I was able to run individual system tests with no issues, but running the entire suite hung my computer terribly (adjusted load averages ~4). This was on a 3.3GHz 8-core machine with 8GB RAM that I was only using for DARIA work. YMMV.

This pull request makes the following changes:
* installs firefox
* uses firefox for system tests if running in docker.
  * this should not break existing functionality, specifically, running system tests on bare metal

(If there are changes to the views, please include a screenshot so we know what to look for!)

It relates to the following issue #s: 
* Fixes #1874 


For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
