### PR TITLE
Allow patients with sent pledges to be marked urgent again

### DIFF
--- a/app/models/concerns/urgency.rb
+++ b/app/models/concerns/urgency.rb
@@ -4,7 +4,7 @@ module Urgency
 
   def still_urgent?
     # Verify that a pregnancy has not been marked urgent in the past six days
-    return false if pledge_sent || resolved_without_fund
+    return false if resolved_without_fund
     recent = versions.where('created_at > ?', 6.days.ago)
     return true if recent.any?(&:marked_urgent?)
     false

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -253,13 +253,9 @@ class PatientTest < ActiveSupport::TestCase
                                     fund_pledge: 300
       end
 
-      %w[pledge_sent resolved_without_fund].each do |attrib|
-        it "should unmark urgent after update if #{attrib}" do
-          @patient[attrib.to_sym] = true
-          @patient.save
-
-          refute @patient.urgent_flag
-        end
+      it "should unmark urgent after update if #{attrib}" do
+        @patient.update resolved_without_fund: true
+        refute @patient.urgent_flag
       end
     end
 
@@ -372,12 +368,6 @@ class PatientTest < ActiveSupport::TestCase
           @patient.reload
         end
         assert @patient.still_urgent?
-      end
-
-      it 'should return false if pledge sent' do
-        @patient.update urgent_flag: true
-        @patient.update pledge_sent: true
-        assert_not @patient.still_urgent?
       end
 
       it 'should return false if resolved without fund' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -253,7 +253,7 @@ class PatientTest < ActiveSupport::TestCase
                                     fund_pledge: 300
       end
 
-      it "should unmark urgent after update if #{attrib}" do
+      it "should unmark urgent after update if resolved_without_fund" do
         @patient.update resolved_without_fund: true
         refute @patient.urgent_flag
       end

--- a/test/system/submit_pledge_test.rb
+++ b/test/system/submit_pledge_test.rb
@@ -50,9 +50,6 @@ class SubmitPledgeTest < ApplicationSystemTestCase
       assert has_text? Patient::STATUSES[:pledge_sent][:key]
       assert has_link? 'Fulfillment'
       assert has_link? 'Cancel pledge'
-
-      click_link 'Notes'
-      refute has_checked_field? 'Flag this patient as urgent'
     end
 
     it 'should render after opening call modal' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

A few funds have reported that postgres caused a slight change in how urgency works, and that they can no longer mark patients with sent pledges urgent. That was original intent, but funds are used to the not-quite-right version, so this PR implements the not-quite-right version. (I think the source of this is callbacks working slightly differently in activerecord than in mongoid, but exact details aren't that important, I don't think.)

This pull request makes the following changes:
* remove pledge_sent from unmark-urgency criteria

no view changes

It relates to the following issue #s: 
* Fixes #2262

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
