### PR TITLE
CI fix - get build green by running an apt-get update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
+      - run: sudo apt-get update
       - run: sudo apt-get install libfontconfig postgresql-client
       - run: gem install bundler # Update bundler
       - run: sudo gem update --system # Update rubygems


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

CI started failing because of some work on the debian repository side that's way out of our purview; apt-get update brings things up to speed.

This pull request makes the following changes:
* add an `apt-get update` to our circle.yml config

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
