### PR TITLE
Add dependabot config to autoassign reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  reviewers:
+    - "xmunoz"
+    - "colinxfleming"
+    - "lomky"
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  reviewers:
+    - "xmunoz"
+    - "colinxfleming"
+    - "lomky"

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'sass-rails', '>= 6'
 gem 'bootstrap', '~> 4.5.0'
 gem 'bootstrap_form', '~> 4.5.0'
 gem 'coffee-rails', '~> 5.0.0'
-gem 'jquery-rails', '~> 4.3.4'
+gem 'jquery-rails', '~> 4.4.0'
 gem 'jquery-ui-rails'
 
 # Our database is postgres

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    jquery-rails (4.3.5)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -187,7 +187,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.9.1)
+    loofah (2.10.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -198,7 +198,7 @@ GEM
       minitest (> 1.2.0)
       rails (>= 2.3.3)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
@@ -213,7 +213,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.7)
-    nokogiri (1.11.4)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     oauth2 (1.4.4)
@@ -304,7 +304,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.3)
+    rake (13.0.6)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -437,7 +437,7 @@ DEPENDENCIES
   figaro
   geokit
   i18n-tasks (~> 0.9.29)
-  jquery-rails (~> 4.3.4)
+  jquery-rails (~> 4.4.0)
   jquery-ui-rails
   js-routes
   kaminari (~> 1.2)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Adds default reviewers to dependabot PRs
* Update jquery-rails so CI passes