### PR TITLE
Adding "quick add" button for search when there are results.

### DIFF
--- a/app/views/dashboards/search.js.erb
+++ b/app/views/dashboards/search.js.erb
@@ -6,5 +6,6 @@ $('#search_results_shell').empty();
     $('[data-toggle="popover"]').popover()
   })
 <% else %>
-  $("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");
+  $("#search_results_shell").append("<h3 class='mt-5 mb-5'><small><%= t('dashboard.search.no_results') %></small></h3>");
 <% end %>
+$("#search_results_shell").append("<%= escape_javascript(render partial: 'patients/new_patient', locals: { patient: @patient, name: @name, phone: @phone, today: @today }) %>");

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,7 @@ en:
     search:
       header: Build your call list
       input_placeholder: Name (Susan Smith) or Phone (555-555-5555)
+      no_results: Your search produced no results
     table_content:
       clear_call_list: Clear your call list
       clear_call_list_confirm: Are you sure you want to clear your current call list? This will also clear completed calls.
@@ -435,7 +436,7 @@ en:
     new:
       add_button: Add new patient
       initial_call_date: Initial Call Date
-      title: 'Your search produced no results, so add a new patient:'
+      title: 'Add a new patient:'
     notes:
       placeholder: Enter notes here
       submit: Create Note

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -185,6 +185,7 @@ es:
     search:
       header: Construye tu lista de llamadas
       input_placeholder: Nombre (Susan Smith) o teléfono (555-555-5555)
+      no_results: Your search produced no results
     table_content:
       clear_call_list: Borrar su lista de llamadas
       clear_call_list_confirm: "¿Está seguro/a de que desea borrar su lista de llamadas actual? Esto también borrará las llamadas completadas."

--- a/test/system/record_lookup_test.rb
+++ b/test/system/record_lookup_test.rb
@@ -61,6 +61,7 @@ class RecordLookupTest < ApplicationSystemTestCase
 
       assert has_text? 'Search results'
       assert has_text? 'Susan Everyteen DC'
+      assert has_text? 'Add a new patient'
     end
 
     it 'should not pick up patients on other lines' do
@@ -69,7 +70,8 @@ class RecordLookupTest < ApplicationSystemTestCase
 
       refute has_text? 'Susan Everyteen MD'
       within :css, '#search_results_shell' do
-        assert has_text? 'Your search produced no results, so add a new patient'
+        assert has_text? 'Your search produced no results'
+        assert has_text? 'Add a new patient'
         assert has_no_text? 'Search results'
       end
     end
@@ -82,6 +84,10 @@ class RecordLookupTest < ApplicationSystemTestCase
       click_button 'Search'
 
       assert_equal 15, page.all('tbody#search_results_content tr').count
+
+      within :css, '#search_results_shell' do
+        assert has_text? 'Add a new patient'
+      end
     end
 
     # We haven't reached a UX agreement on this yet, but test is ready to go
@@ -101,7 +107,8 @@ class RecordLookupTest < ApplicationSystemTestCase
       click_button 'Search'
 
       within :css, '#search_results_shell' do
-        assert has_text? 'Your search produced no results, so add a new patient'
+        assert has_text? 'Your search produced no results'
+        assert has_text? 'Add a new patient'
         assert_equal 'Nobody Real Here', find_field('Name').value
         assert has_no_text? 'Search results'
       end
@@ -112,7 +119,8 @@ class RecordLookupTest < ApplicationSystemTestCase
       click_button 'Search'
 
       within :css, '#search_results_shell' do
-        assert has_text? 'Your search produced no results, so add a new patient'
+        assert has_text? 'Your search produced no results'
+        assert has_text? 'Add a new patient'
         assert_equal '111-111-1112', find_field('Phone').value
       end
     end


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This pull request makes the following changes:
* Adding "quick add" button for search when there are results.

(with results)
<img width="1262" alt="Screen Shot 2021-07-21 at 5 26 47 PM" src="https://user-images.githubusercontent.com/34173394/126575948-a6d9342b-8054-4df7-9d5b-cf1211f7aa5e.png">
(without results)
<img width="1198" alt="Screen Shot 2021-07-21 at 5 26 38 PM" src="https://user-images.githubusercontent.com/34173394/126575951-227728e4-dc59-4e74-840a-39b83bc198e2.png">


It relates to the following issue #s: 
* Bumps #2173 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
