### PR TITLE
Enforce config key uniqueness to avoid weird errors when changing fund configs in the Config panel

### DIFF
--- a/db/migrate/20210725025609_add_index_to_config_key.rb
+++ b/db/migrate/20210725025609_add_index_to_config_key.rb
@@ -1,0 +1,6 @@
+class AddIndexToConfigKey < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :configs, :config_key
+    add_index :configs, :config_key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_26_161444) do
+ActiveRecord::Schema.define(version: 2021_07_25_025609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 2021_06_26_161444) do
     t.jsonb "config_value", default: {"options"=>[]}, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["config_key"], name: "index_configs_on_config_key"
+    t.index ["config_key"], name: "index_configs_on_config_key", unique: true
   end
 
   create_table "events", force: :cascade do |t|

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -28,6 +28,13 @@ class ConfigTest < ActiveSupport::TestCase
       assert @dupe_config.errors.messages[:config_key].include? 'has already been taken'
     end
 
+    it 'should enforce config_key uniqueness at the DB level' do
+      @dupe_config = build :config
+      assert_raises ActiveRecord::RecordNotUnique do
+        @dupe_config.save!(validate: false)
+      end
+    end
+
     it 'should require a config_key' do
       @bad_config = build :config, config_key: nil
       refute @bad_config.valid?


### PR DESCRIPTION
This pull request makes the following changes:
1) Requires uniqueness of configkey at the db level
2) adds spec

It relates to the following issue #s:
#2227 