### PR TITLE
re-upgrade mini-mime to 1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     mini_backtrace (0.1.3)
       minitest (> 1.2.0)
       rails (>= 2.3.3)
-    mini_mime (1.0.3)
+    mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.14.4)
     minitest-ci (3.4.0)


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

dependabot kicked this down for some reason; this kicks it back up.

This pull request makes the following changes:
* restore mini-mime to 1.1.0

no view changes
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
