### PR TITLE
pin bootstrap gem to < 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 # Asset pipeline
 gem 'webpacker', '~> 5.4'
 gem 'sass-rails', '>= 6'
-gem 'bootstrap', '~> 4.5.0'
+gem 'bootstrap', '~> 4.5.0', '< 5' # we're on bs4 for now
 gem 'bootstrap_form', '~> 4.5.0'
 gem 'coffee-rails', '~> 5.0.0'
 gem 'jquery-rails', '~> 4.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-session_store
   bootsnap (>= 1.4.2)
-  bootstrap (~> 4.5.0)
+  bootstrap (~> 4.5.0, < 5)
   bootstrap_form (~> 4.5.0)
   bundler-audit
   byebug


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Dependabot tried to bump bootstrap; upgrading bootstrap is very very hard; we'll pin it for now to make it clear that we don't want to do this.

This pull request makes the following changes:
* pin bootstrap gem below 5

no views
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
