### PR TITLE
Configurable Urgent Reset Window Config

### DIFF
--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -31,7 +31,7 @@ module TooltipsHelper
   end
 
   def urgent_cases_help_text
-    t('tooltips.urgent_cases').strip
+    t('tooltips.urgent_cases', urgent_reset: Config.urgent_reset).strip
   end
 
   def status_help_text(patient)

--- a/app/models/concerns/urgency.rb
+++ b/app/models/concerns/urgency.rb
@@ -5,7 +5,7 @@ module Urgency
   def still_urgent?
     # Verify that a pregnancy has not been marked urgent in the past six days
     return false if resolved_without_fund
-    recent = versions.where('created_at > ?', 6.days.ago)
+    recent = versions.where('created_at > ?', Config.urgent_reset.days.ago)
     return true if recent.any?(&:marked_urgent?)
     false
   end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -33,7 +33,8 @@ class Config < ApplicationRecord
     budget_bar_max: 11,
     voicemail: 12,
     days_to_keep_fulfilled_patients: 13,
-    days_to_keep_all_patients: 14
+    days_to_keep_all_patients: 14,
+    urgent_reset: 15,
   }
 
   # which fields are URLs (run special validation only on those)
@@ -57,6 +58,7 @@ class Config < ApplicationRecord
 
     days_to_keep_fulfilled_patients: :validate_patient_archive,
     days_to_keep_all_patients: :validate_patient_archive,
+    urgent_reset: :validate_urgent_reset,
   }.freeze
 
   before_validation :clean_config_value
@@ -112,6 +114,13 @@ class Config < ApplicationRecord
     # default 1 year
     archive_days ||= 365
     archive_days.to_i
+  end
+
+  def self.urgent_reset
+    urgent_reset_days = Config.find_or_create_by(config_key: 'urgent_reset').options.try :last
+    # default 6 days
+    urgent_reset_days ||= 6
+    urgent_reset_days.to_i
   end
 
   private
@@ -206,5 +215,13 @@ class Config < ApplicationRecord
 
     def validate_patient_archive
       validate_number && options.last.to_i.between?(ARCHIVE_MIN_DAYS, ARCHIVE_MAX_DAYS)
+    end
+
+    ### urgent reset
+    URGENT_MIN_DAYS = 2   # 2 days
+    URGENT_MAX_DAYS = 28  # 4 weeks
+
+    def validate_urgent_reset
+      validate_number && options.last.to_i.between?(URGENT_MIN_DAYS, URGENT_MAX_DAYS)
     end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -15,7 +15,8 @@ class Config < ApplicationRecord
     budget_bar_max: "The maximum for the budget bar. Defaults to 1000 if not set. Enter as a number with no dollar sign or commas.",
     hide_practical_support: 'Enter "yes" to hide the Practical Support panel on patient pages. This will not remove any existing data.',
     days_to_keep_fulfilled_patients: "Number of days (after initial entry) to keep identifying information for a patient whose pledge has been fulfilled and marked audited. Defaults to 90 days (3 months).",
-    days_to_keep_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year)."
+    days_to_keep_all_patients: "Number of days (after initial entry) to keep identifying information for any patient, regardless of pledge fulfillment. Defaults to 365 days (1 year).",
+    urgent_reset: "Number of idle days until a patient is removed from the urgent list. Defaults to 6 days.",
   }.freeze
 
   enum config_key: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -535,7 +535,7 @@ en:
     referred_to_clinic: Check this box if you as a case manager referred the patient to a particular clinic.
     resolved_without_fund: This is used to indicate that a patient does not require or want our services any longer.
     status_definition: Status definition
-    urgent_cases: These are patients who require a little more attention. This list is shared across all case managers working on a single line. Patients are removed from this list automatically after they are marked as having a sent pledge, or marked as resolved without assistance.
+    urgent_cases: 'These are patients who require a little more attention. This list is shared across all case managers working on a single line. Patients are removed from this list automatically after they are marked as having a sent pledge, are marked as resolved without assistance, or after %{urgent_reset} days of inactivity.'
   user:
     common:
       last_login: Last Login

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -535,7 +535,7 @@ en:
     referred_to_clinic: Check this box if you as a case manager referred the patient to a particular clinic.
     resolved_without_fund: This is used to indicate that a patient does not require or want our services any longer.
     status_definition: Status definition
-    urgent_cases: 'These are patients who require a little more attention. This list is shared across all case managers working on a single line. Patients are removed from this list automatically after they are marked as having a sent pledge, are marked as resolved without assistance, or after %{urgent_reset} days of inactivity.'
+    urgent_cases: These are patients who require a little more attention. This list is shared across all case managers working on a single line. Patients are removed from this list automatically after they are marked as having a sent pledge, are marked as resolved without assistance, or after %{urgent_reset} days of inactivity.
   user:
     common:
       last_login: Last Login

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -535,7 +535,7 @@ en:
     referred_to_clinic: Check this box if you as a case manager referred the patient to a particular clinic.
     resolved_without_fund: This is used to indicate that a patient does not require or want our services any longer.
     status_definition: Status definition
-    urgent_cases: These are patients who require a little more attention. This list is shared across all case managers working on a single line. Patients are removed from this list automatically after they are marked as having a sent pledge, are marked as resolved without assistance, or after %{urgent_reset} days of inactivity.
+    urgent_cases: These are patients who require a little more attention. This list is shared across all case managers working on a single line. Patients are removed from this list automatically after they are marked as resolved without assistance, or after %{urgent_reset} days of inactivity.
   user:
     common:
       last_login: Last Login

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -535,7 +535,7 @@ es:
     referred_to_clinic: Marque esta casilla si usted, como administrador de casos, refirió al paciente a un clínica particular.
     resolved_without_fund: Esto se utiliza para indicar que un paciente ya no necesita o quiere nuestros servicios.
     status_definition: Definición de estado
-    urgent_cases: Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados con "promesa enviada", o marcado como "resuelto sin ayuda".
+    urgent_cases: 'Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados con "promesa enviada", o marcado como "resuelto sin ayuda", o después de %{urgent_reset} días de inactividad.'
   user:
     common:
       last_login: Último Acceso

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -535,7 +535,7 @@ es:
     referred_to_clinic: Marque esta casilla si usted, como administrador de casos, refirió al paciente a un clínica particular.
     resolved_without_fund: Esto se utiliza para indicar que un paciente ya no necesita o quiere nuestros servicios.
     status_definition: Definición de estado
-    urgent_cases: Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados con "promesa enviada", o marcado como "resuelto sin ayuda", o después de %{urgent_reset} días de inactividad.
+    urgent_cases: Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcado como "resuelto sin ayuda", o después de %{urgent_reset} días de inactividad.
   user:
     common:
       last_login: Último Acceso

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -535,7 +535,7 @@ es:
     referred_to_clinic: Marque esta casilla si usted, como administrador de casos, refirió al paciente a un clínica particular.
     resolved_without_fund: Esto se utiliza para indicar que un paciente ya no necesita o quiere nuestros servicios.
     status_definition: Definición de estado
-    urgent_cases: 'Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados con "promesa enviada", o marcado como "resuelto sin ayuda", o después de %{urgent_reset} días de inactividad.'
+    urgent_cases: Estos son pacientes que requieren un poco más de atención. Esta lista es compartido entre todos los administradores de casos que trabajan en una sola línea. Los pacientes son eliminados de esta lista automáticamente después de que estén marcados con "promesa enviada", o marcado como "resuelto sin ayuda", o después de %{urgent_reset} días de inactividad.
   user:
     common:
       last_login: Último Acceso

--- a/docs/user_guides/CASE_MANAGERS.md
+++ b/docs/user_guides/CASE_MANAGERS.md
@@ -43,7 +43,7 @@ There is a way to flag patients so that they are easier for others to find. This
 
 To mark a patient urgent, look in the `Patient Record page` under `Notes`.
 
-Patients automatically filter out of this section after a period of not being updated, or if they're marked resolved, or if a pledge is sent for them to a clinic.
+Patients automatically filter out of this section after a period of not being updated, or if they're marked resolved without assistance.
 
 The period of inactivity before a patient will be removed from the Urgent cases list is configurable per fund. See the Urgent tooltip for your fund's setting.
 

--- a/docs/user_guides/CASE_MANAGERS.md
+++ b/docs/user_guides/CASE_MANAGERS.md
@@ -43,7 +43,9 @@ There is a way to flag patients so that they are easier for others to find. This
 
 To mark a patient urgent, look in the `Patient Record page` under `Notes`.
 
-Patients automatically filter out of this section after a week of not being updated, or if they're marked resolved, or if a pledge is sent for them to a clinic.
+Patients automatically filter out of this section after a period of not being updated, or if they're marked resolved, or if a pledge is sent for them to a clinic.
+
+The period of inactivity before a patient will be removed from the Urgent cases list is configurable per fund. See the Urgent tooltip for your fund's setting.
 
 ### Line Activity Log
 

--- a/test/models/config_test.rb
+++ b/test/models/config_test.rb
@@ -190,5 +190,35 @@ class ConfigTest < ActiveSupport::TestCase
         assert_equal :tuesday, Config.start_day
       end
     end
+
+    describe 'urgent_reset' do
+      it 'should return proper default' do
+        assert_equal 6, Config.urgent_reset
+      end
+
+      it 'should validate bounds' do
+        c = Config.find_or_create_by(config_key: 'urgent_reset')
+
+        # low out of bounds
+        c.config_value = { options: ["1"] }
+        refute c.valid?
+
+        # low edge
+        c.config_value = { options: ["2"] }
+        assert c.valid?
+
+        # in bounds
+        c.config_value = { options: ["14"] }
+        assert c.valid?
+
+        # high edge
+        c.config_value = { options: ["28"] }
+        assert c.valid?
+
+        c.config_value = { options: ["29"] }
+        refute c.valid?
+      end
+    end
+
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -338,7 +338,7 @@ class PatientTest < ActiveSupport::TestCase
       end
 
       describe 'trim_urgent_patients method' do
-        it 'should trim pregnancies after they have been urgent for five days' do
+        it 'should trim patients from urgent after they have been inactive or resolved' do
           skip "test not implemented for patient#trim_urgent_patients"
         end
       end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -383,6 +383,28 @@ class PatientTest < ActiveSupport::TestCase
 
         assert_not @patient.still_urgent?
       end
+
+      describe 'respect custom urgent reset config' do
+        c = Config.find_or_create_by(config_key: 'urgent_reset')
+        c.config_value = { options: ["14"] }
+        c.save
+
+        it 'should return true if marked urgent in the last configured days' do
+          Timecop.freeze(Time.zone.now - 15.days) do
+            @patient.update urgent_flag: true
+          end
+
+          assert_not @patient.still_urgent?
+        end
+
+        it 'should return false if not updated in the last configured days' do
+          Timecop.freeze(Time.zone.now - 7.days) do
+            @patient.update urgent_flag: true
+          end
+
+          assert @patient.still_urgent?
+        end
+      end
     end
 
     describe 'destroy_associated_events method' do


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Adds the Urgent Reset config, default to 6
* Uses the config instead of hard-coded 6
* Adds tests
* docs
* config alt text
* Urgent `?` tool tip

It relates to the following issue #s: 
* Fixes #2338 
* Fixes #2322 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
