### PR TITLE
autoretry failures on the flaky create user test

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
+  extend Minitest::OptionalRetry
+
   before do
     @user = create :user, role: 'admin'
     @user_2 = create :user, role: 'cm', name: 'Billy Everyteen'


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This hack-fixes a problem ID'd by @xmunoz - the create user controller test occasionally fails for no real reason, about one out of every four times. This is cheating a little, but it's a pattern we've adopted in a few other spots - by having the test class extend MiniTest::OptionalRetry, we'll retry failed tests in that class again up to 3 times before calling it a wash officially. Since this is a problem that seems to be primarily limited to CI (and possibly test parallelization), and we've never once gotten a sentry error about it, I think the hacky/brute forcey method is probably fine here.

This pull request makes the following changes:
* drop in the auto-retry module to deal with this flaky test

no view changes

It relates to the following issue #s: 
* Fixes #2337 

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
