### PR TITLE
clear cache to restore circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,10 @@ jobs:
       - run: bundle check || bundle install
       - run: yarn install
       - run: NODE_ENV=test bundle exec rails webpacker:compile
-      - run: RAILS_ENV=test bundle exec rails db:create db:migrate
-      - run: gem install --no-document brakeman
-      - run: gem install --no-document ruby_audit
-      - run: gem install --no-document bundler-audit
+      - run: NODE_ENV=test bundle exec rails webpacker:compile
+      - run: RAILS_ENV=test rails db:create db:migrate
+      - run: gem install --no-document brakeman ruby_audit bundler-audit
+      - run: rails assets:precompile
       - save_cache:
           key: dcaf_case_management-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ jobs:
       - run: sudo gem update --system # Update rubygems
       - restore_cache:
           keys:
-            - dcaf_case_management-{{ checksum "Gemfile.lock" }}
-            - dcaf_case_management-{{ checksum ".circleci/config.yml" }}
+            - daria-gemfile-v1-{{ checksum "Gemfile.lock" }}
+            - daria-circle-config-v1-{{ checksum ".circleci/config.yml" }}
       - run: bundle check || bundle install
       - run: yarn install
       - run: NODE_ENV=test bundle exec rails webpacker:compile
@@ -39,7 +39,11 @@ jobs:
       - run: gem install --no-document brakeman ruby_audit bundler-audit
       - run: rails assets:precompile
       - save_cache:
-          key: dcaf_case_management-{{ checksum "Gemfile.lock" }}
+          key: daria-gemfile-v1-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - save_cache:
+          key: daria-circle-config-v1-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - run: bundle exec rake knapsack:minitest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
       - run: yarn install
       - run: NODE_ENV=test bundle exec rails webpacker:compile
       - run: NODE_ENV=test bundle exec rails webpacker:compile
-      - run: RAILS_ENV=test rails db:create db:migrate
+      - run: RAILS_ENV=test bundle exec rails db:create db:migrate
       - run: gem install --no-document brakeman ruby_audit bundler-audit
-      - run: rails assets:precompile
+      - run: bundle exec rails assets:precompile
       - save_cache:
           key: daria-gemfile-v1-{{ checksum "Gemfile.lock" }}
           paths:
@@ -74,7 +74,7 @@ jobs:
           docker_layer_caching: false
       - restore_cache:
           keys:
-            - dcaf_case_management-{{ epoch }}
+            - daria-gemfile-v1-{{ epoch }}
       - run: git push https://heroku:$HEROKU_API_KEY@git.heroku.com/dcaf-cmapp-staging.git main
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ jobs:
           key: daria-circle-config-v1-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - run: bundle exec rake knapsack:minitest
+      - run: bundle exec rails test test/system/accountant_workflow_test.rb -v
+      # - run: bundle exec rake knapsack:minitest
       - run: brakeman --exit-on-warn .
       - run: bundle exec ruby-audit check
       - run: bundle-audit update; bundle-audit check

--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ end
 group :test do
   # Useful minitest tools
   gem 'minitest-spec-rails'
-  gem 'minitest-ci'
+  # gem 'minitest-ci'
   gem 'factory_bot_rails'
   gem 'database_cleaner'
   gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,9 @@ end
 group :test do
   # Useful minitest tools
   gem 'minitest-spec-rails'
-  # gem 'minitest-ci'
+  gem 'minitest-ci'
   gem 'factory_bot_rails'
-  # gem 'database_cleaner'
+  gem 'database_cleaner'
   gem 'faker'
   gem 'timecop'
 

--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,9 @@ end
 group :test do
   # Useful minitest tools
   gem 'minitest-spec-rails'
-  gem 'minitest-ci'
+  # gem 'minitest-ci'
   gem 'factory_bot_rails'
-  gem 'database_cleaner'
+  # gem 'database_cleaner'
   gem 'faker'
   gem 'timecop'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,12 +116,6 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
-    database_cleaner (2.0.1)
-      database_cleaner-active_record (~> 2.0.0)
-    database_cleaner-active_record (2.0.1)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
     devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -223,8 +217,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
-    minitest-ci (3.4.0)
-      minitest (>= 5.0.6)
     minitest-optional_retry (0.0.2)
       minitest (~> 5.0)
     minitest-spec-rails (6.0.4)
@@ -236,7 +228,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
-    nokogiri (1.12.3)
+    nokogiri (1.12.4)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     oauth2 (1.4.7)
@@ -421,7 +413,7 @@ GEM
     uniform_notifier (1.14.2)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (4.6.0)
+    webdrivers (4.6.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -452,7 +444,6 @@ DEPENDENCIES
   capybara-screenshot
   codecov
   coffee-rails (~> 5.0.0)
-  database_cleaner
   devise (~> 4.8)
   dotenv-rails
   factory_bot_rails
@@ -469,7 +460,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.7)
   loofah (>= 2.3.1)
   mini_backtrace
-  minitest-ci
   minitest-optional_retry
   minitest-spec-rails
   minitest-stub-const

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,8 +223,6 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
-    minitest-ci (3.4.0)
-      minitest (>= 5.0.6)
     minitest-optional_retry (0.0.2)
       minitest (~> 5.0)
     minitest-spec-rails (6.0.4)
@@ -469,7 +467,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.7)
   loofah (>= 2.3.1)
   mini_backtrace
-  minitest-ci
   minitest-optional_retry
   minitest-spec-rails
   minitest-stub-const

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,12 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -217,6 +223,8 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
+    minitest-ci (3.4.0)
+      minitest (>= 5.0.6)
     minitest-optional_retry (0.0.2)
       minitest (~> 5.0)
     minitest-spec-rails (6.0.4)
@@ -444,6 +452,7 @@ DEPENDENCIES
   capybara-screenshot
   codecov
   coffee-rails (~> 5.0.0)
+  database_cleaner
   devise (~> 4.8)
   dotenv-rails
   factory_bot_rails
@@ -460,6 +469,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.7)
   loofah (>= 2.3.1)
   mini_backtrace
+  minitest-ci
   minitest-optional_retry
   minitest-spec-rails
   minitest-stub-const

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,12 +4,12 @@ SimpleCov.start 'rails'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'minitest/autorun'
+# require 'minitest/autorun'
 require 'capybara/rails'
 require 'capybara-screenshot/minitest'
 require 'omniauth_helper'
 require 'integration_helper'
-require 'rack/test'
+# require 'rack/test'
 
 # CI only
 if ENV['CIRCLECI']


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

Builds are running into a weird libffi problem and I want to see if clearing circleci caches will fix. There doesn't seem to be a way to manually nuke circleci caches so doing it here.

This pull request makes the following changes:
* reset circleci cache keys

no views
no issues

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
