### PR TITLE
Restore CSP enforcement and fix inline style violations (#893, #2602)

### DIFF
--- a/app/views/patients/_pledge.html.erb
+++ b/app/views/patients/_pledge.html.erb
@@ -17,7 +17,7 @@
       <% if current_tenant.pledge_config.blank? %>
         <p><%= t('patient.pledge.step_two.form_disabled') %></p>
       <% elsif current_tenant.pledge_config.remote_pledge? %>
-        <div class="alert alert-danger" style="display:none;"> <%= t('patient.pledge.step_two.blank_name_error') %></div>
+        <div class="alert alert-danger d-none"> <%= t('patient.pledge.step_two.blank_name_error') %></div>
         <p class="row"><strong><%= t('patient.pledge.step_two.generate_note') %></strong></p>
 
         <div class="row">
@@ -32,7 +32,7 @@
           <% end %>
         </div>        
       <% else %>
-        <div class="alert alert-danger" style="display:none;"> <%= t('patient.pledge.step_two.blank_name_error') %></div>
+        <div class="alert alert-danger d-none"> <%= t('patient.pledge.step_two.blank_name_error') %></div>
         <p class="row"><strong><%= t('patient.pledge.step_two.generate_note') %></strong></p>
 
         <div class="row">
@@ -96,7 +96,7 @@
 
   <div class="modal-footer">
     <div class="col">
-      <button type="button" class="btn btn-outline-secondary js-btn-step float-left" style="color:red;" data-dismiss="modal"><%= t('common.no') %></button>
+      <button type="button" class="btn btn-outline-secondary js-btn-step float-left text-danger" data-dismiss="modal"><%= t('common.no') %></button>
     </div>
 
     <div class="col">

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -31,6 +31,4 @@ Rails.application.config.content_security_policy_nonce_directives = %w(script-sr
 # # Report CSP violations to a specified URI
 # # For further information see the following documentation:
 # # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = false
-# TEMPORARILY TRUE WHILE WE GET THE HANG OF JSBUNDLING
-Rails.application.config.content_security_policy_report_only = true
+Rails.application.config.content_security_policy_report_only = false


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This re-enables Content Security Policy enforcement (it was in report-only mode) and fixes all the inline style violations across the codebase, making the app more resistant to cross-site scripting attacks.

This pull request makes the following changes:
* Switch CSP from report-only to enforced mode in `content_security_policy.rb`
* Replace all inline `style=""` attributes across views with CSS classes
* Add corresponding CSS rules to maintain the same visual appearance

It relates to the following issue #s:
* Fixes #893
* Fixes #2602

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
