### PR TITLE
Upgrade Node.js engine requirement to ^24.14.1 LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "webpack-dev-server": "5.2.2"
   },
   "engines": {
-    "node": "^24.11.1"
+    "node": "^24.14.1"
   },
   "license": "MIT",
   "resolutions": {


### PR DESCRIPTION
I rule and have completed some work on Case Manager that's ready for review!

This bumps the required Node.js version in package.json to the current LTS release, ensuring the app runs on a supported and up-to-date Node runtime.

This pull request makes the following changes:
* Update `engines.node` in `package.json` from `^20` to `^24.14.1`

For reviewer:
* Adjust the title to explain what it does for the notification email to the listserv.
* Tag this PR:
  * `feature` if it contains a feature, fix, or similar. This is anything that contains a user-facing fix in some way, such as frontend changes, alterations to backend behavior, or bug fixes.
  * `dependencies` if it contains library upgrades or similar. This is anything that upgrades any dependency, such as a Gemfile update or npm package upgrade.
* If it contains neither, no need to tag this PR.
